### PR TITLE
Chore/address template todos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,4 @@
 ROLLBAR_ACCESS_TOKEN=ROLLBAR_ACCESS_TOKEN
 ROLLBAR_ENV=development
 
-# TODO: Replace `rails-template` with the name of the app.
-DATABASE_URL=postgres://postgres@localhost:5432/rails-template-development
+DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-development

--- a/.env.test
+++ b/.env.test
@@ -5,5 +5,4 @@
 #
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
-# TODO: Replace `rails-template` with the name of the app.
-DATABASE_URL=postgres://postgres@localhost:5432/rails-template-test
+DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,3 @@
-# TODO: Enable GitHub Actions on the repository to test all pull requests
-# https://github.com/<org>/<repo>/actions
 name: CI
 
 on: pull_request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- address rails-template TODO
+
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-# Using this template
-
-1. Search for `TODO` across the repository to customise the template to the new
-  project
-1. Be aware of [dxw RFCs](https://github.com/dxw/tech-team-rfcs), especially
-  those that have not resulted in a default code change in this repository:
-  - [rfc-013-use-docker-to-deploy-and-run-applications-in-containers](https://github.com/dxw/tech-team-rfcs/blob/master/rfc-013-use-docker-to-deploy-and-run-applications-in-containers.md)
-
-TODO: Remove this section from the README once complete
-
----
-
 # Buy for your school
 
 A service to help school buying professionals create tender documents that comply with the relevant government policy. These tender documents can then be used to start a procurement process saving schools time and money.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ TODO: Remove this section from the README once complete
 
 ---
 
-# Rails Template
+# Buy for your school
 
-TODO: replace README header with project name
-
-TODO: Add a summary of who the application is for and what it will do.
+A service to help school buying professionals create tender documents that comply with the relevant government policy. These tender documents can then be used to start a procurement process saving schools time and money.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,28 @@ A service to help school buying professionals create tender documents that compl
 
 ## Getting started
 
+1. `brew install postgres`
+1. `brew services start postgres`
+1. `createuser postgres --super`
 1. copy `/.env.example` into `/.env.development.local`.
 
   Our intention is that the example should include enough to get the application started quickly. If this is not the case, please ask another developer for a copy of their `/.env.development.local` file.
-
-TODO: Add getting started steps
+1. `rbenv install 2.6.3 && rbenv local 2.6.3`
+1. `gem install bundle`
+1. `bundle`
+1. `rake db:setup && RAILS_ENV=test rake db:setup`
+1. `rails server`
+1. Visit http://localhost:3000
 
 ## Running the tests
 
-TODO: Add testing instructions
+### The whole test suite
+
+`bundle exec rake`
+
+### RSpec only
+
+`bundle exec rspec`
 
 ## Running Brakeman
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-# TODO: Name the application
-module RailsTemplate
+module BuyForYourSchool
   class Application < Rails::Application
     config.generators do |g|
       g.test_framework :rspec,


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

After using the [dxw rails-template](https://github.com/dxw/rails-template) to start this repository the first step is to follow the instructions and address the TODO throughout the repo. This pull requests deals with all but one: where to find the live environment. This isn't included yet as we don't have any real environments!

The Scripts to Rule Them All pattern didn't have enough approvals by the time we wanted to make this repo so additional starter instruction was added. It seems that copying the branch from the template starts a decent sized conflict fight which feels best avoided https://github.com/DFE-Digital/buy-for-your-school/tree/chore/add-scripts-to-rule-them-all. We may wish to replace these with scripts on a second pass.