### PR TITLE
Run GitHub CI action on merges to main and develop

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
 
 jobs:
   test:


### PR DESCRIPTION
Heroku is waiting for a passing CI test before automatically deploying, but previously CI would only run on pull requests and not on the resulting merges to develop or main branches. This changes that behaviour, so tests run on any push to those branches as well as any PR.