### PR TITLE
[21] Users can answer a hardcoded Contentful question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog 1.0.0].
 - address rails-template TODO
 - any user can see a start page for the planning journey
 - use GOV.UK Frontend framework
+- users can see a basic form to start the planning journey sourced by a
+Contentful fixture
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ end
 group :test do
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
+  gem "shoulda-matchers"
   gem "simplecov"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    shoulda-matchers (4.4.1)
+      activesupport (>= 4.2.0)
     simplecov (0.19.1)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -311,6 +313,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 6.0)
   selenium-webdriver
+  shoulda-matchers
   simplecov
   spring
   spring-commands-rspec

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AnswersController < ApplicationController
+  def create
+    plan = Plan.find(plan_id)
+    question = Question.find(question_id)
+
+    Answer.create(response: params[:response], question: question)
+    redirect_to plan_path(plan)
+  end
+
+  private
+
+  def plan_id
+    params[:plan_id]
+  end
+
+  def question_id
+    params[:question_id]
+  end
+end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -5,7 +5,11 @@ class AnswersController < ApplicationController
     plan = Plan.find(plan_id)
     question = Question.find(question_id)
 
-    Answer.create(response: params[:response], question: question)
+    answer = Answer.new
+    answer.response = params[:response]
+    answer.question = question
+    answer.save
+
     redirect_to plan_path(plan)
   end
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PlansController < ApplicationController
+  def new
+    plan = Plan.create(category: "catering")
+    redirect_to new_plan_question_path(plan)
+  end
+
+  def show
+    @plan = Plan.find(plan_id)
+  end
+
+  private
+
+  def plan_id
+    params[:id]
+  end
+end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class QuestionsController < ApplicationController
+  def new
+    @plan = Plan.find(plan_id)
+    @question = CreateQuestion.new(plan: @plan).call
+
+    # TODO: Creating a question requires us to check externally if one exists
+    # based on the previous question. Instead of looping through at the start,
+    # we assume there is and try to create one. If not, we jump to the end.
+
+    redirect_to plan_path(@plan) if @question.nil?
+  end
+
+  private
+
+  def plan_id
+    params[:plan_id]
+  end
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,4 @@
+class Answer < ApplicationRecord
+  self.implicit_order_column = "created_at"
+  belongs_to :question
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,0 +1,3 @@
+class Plan < ApplicationRecord
+  self.implicit_order_column = "created_at"
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,3 +1,4 @@
 class Plan < ApplicationRecord
   self.implicit_order_column = "created_at"
+  has_many :questions
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,5 @@
 class Question < ApplicationRecord
   self.implicit_order_column = "created_at"
   belongs_to :plan
+  has_one :answer
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,4 @@
+class Question < ApplicationRecord
+  self.implicit_order_column = "created_at"
+  belongs_to :plan
+end

--- a/app/services/create_question.rb
+++ b/app/services/create_question.rb
@@ -1,0 +1,23 @@
+class CreateQuestion
+  attr_accessor :plan
+  def initialize(plan:)
+    self.plan = plan
+  end
+
+  def call
+    Question.create(
+      title: contentful_response.dig("fields", "title"),
+      help_text: contentful_response.dig("fields", "helpText"),
+      contentful_type: contentful_response.dig("fields", "type"),
+      options: contentful_response.dig("fields", "options"),
+      raw: contentful_response,
+      plan: plan
+    )
+  end
+
+  private
+
+  def contentful_response
+    @contentful_response ||= GetContentfulQuestion.new.call
+  end
+end

--- a/app/services/get_contentful_question.rb
+++ b/app/services/get_contentful_question.rb
@@ -1,0 +1,8 @@
+class GetContentfulQuestion
+  def call
+    # TODO: Spec fixture only used for the first slice, needs a real API call
+    JSON.parse(
+      File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
+    )
+  end
+end

--- a/app/views/pages/planning_start_page.html.erb
+++ b/app/views/pages/planning_start_page.html.erb
@@ -15,3 +15,4 @@
   <% end %>
 </ul>
 <p class="govuk-body"><%= I18n.t("planning.start_page.before_you_start_body") %></p>
+<%= link_to I18n.t("generic.button.start"), new_plan_path %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,0 +1,5 @@
+<%= @plan.category %>
+<% @plan.questions.each do |question| %>
+  <%= question.title %>
+  <%= question.answer.response %>
+<% end %>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :title, @question.title %>
+
+<h1><%= @question.title %></h1>
+<p><%= @question.help_text %></p>
+
+<%= form_with(url: plan_question_answers_path(@plan, @question), method: "post") do %>
+  <% @question.options.each do |option| %>
+    <%= radio_button_tag(:response, option.downcase) %>
+    <%= label_tag("response_#{option.downcase}", option) %>
+  <% end %>
+  <%= submit_tag I18n.t("generic.button.soft_finish") %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  generic:
+    button:
+      start: "Continue"
+      soft_finish: "Save and continue later"
   planning:
     start_page:
       page_title: "Identify the level of support you need for what you're buying"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,10 @@
 Rails.application.routes.draw do
   get "health_check" => "application#health_check"
   root to: "high_voltage/pages#show", id: "planning_start_page"
+
+  resources :plans, only: [:new, :show] do
+    resources :questions, only: [:new] do
+      resources :answers, only: [:create]
+    end
+  end
 end

--- a/db/migrate/20201026154740_enable_uuid.rb
+++ b/db/migrate/20201026154740_enable_uuid.rb
@@ -1,0 +1,5 @@
+class EnableUuid < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+  end
+end

--- a/db/migrate/20201027160912_create_plan_table.rb
+++ b/db/migrate/20201027160912_create_plan_table.rb
@@ -1,0 +1,8 @@
+class CreatePlanTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :plans, id: :uuid do |t|
+      t.string :category, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201027163306_create_question_table.rb
+++ b/db/migrate/20201027163306_create_question_table.rb
@@ -1,0 +1,13 @@
+class CreateQuestionTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :questions, id: :uuid do |t|
+      t.references :plan, type: :uuid
+      t.string :title, null: false
+      t.string :help_text
+      t.string :contentful_type, null: false
+      t.string :options, array: true
+      t.binary :raw, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201028103219_create_answer_table.rb
+++ b/db/migrate/20201028103219_create_answer_table.rb
@@ -1,0 +1,9 @@
+class CreateAnswerTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :answers, id: :uuid do |t|
+      t.references :question, type: :uuid
+      t.string :response, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,18 +2,24 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_10_27_160912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "category", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_27_160912) do
+ActiveRecord::Schema.define(version: 2020_10_27_163306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,6 +20,18 @@ ActiveRecord::Schema.define(version: 2020_10_27_160912) do
     t.string "category", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "plan_id"
+    t.string "title", null: false
+    t.string "help_text"
+    t.string "contentful_type", null: false
+    t.string "options", array: true
+    t.binary "raw", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["plan_id"], name: "index_questions_on_plan_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema.define(version: 0) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_27_163306) do
+ActiveRecord::Schema.define(version: 2020_10_28_103219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "question_id"
+    t.string "response", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["question_id"], name: "index_answers_on_question_id"
+  end
 
   create_table "plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "category", null: false

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :answer do
+    response { "Green" }
+  end
+end

--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :plan do
+    trait :catering do
+      category { "catering" }
+    end
+  end
+end

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :question do
+    title { "What is your favourite colour?" }
+    help_text { "Choose the primary colour closest to your choice" }
+    association :plan, factory: :plan
+
+    trait :radio do
+      options { ["Red", "Green", "Blue"] }
+      contentful_type { "radios" }
+    end
+  end
+end

--- a/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
@@ -1,0 +1,16 @@
+feature "Anyone can start the planning journey" do
+  scenario "Start page includs a call to action" do
+    visit root_path
+
+    click_on(I18n.t("generic.button.start"))
+
+    expect(page).to have_content("Which service do you need?")
+    expect(page).to have_content("Tell us which service you need.")
+    expect(page).to have_content("Catering")
+    expect(page).to have_content("Cleaning")
+
+    choose("Catering")
+
+    click_on(I18n.t("generic.button.soft_finish"))
+  end
+end

--- a/spec/fixtures/contentful/radio-question-example.json
+++ b/spec/fixtures/contentful/radio-question-example.json
@@ -1,0 +1,48 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "jspwts36h1os"
+            }
+        },
+        "id": "1UjQurSOi5MWkcRuGxdXZS",
+        "type": "Entry",
+        "createdAt": "2020-09-07T10:56:40.585Z",
+        "updatedAt": "2020-09-14T22:16:54.633Z",
+        "environment": {
+            "sys": {
+                "id": "master",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 7,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/which-service",
+        "title": "Which service do you need?",
+        "helpText": "Tell us which service you need.",
+        "type": "radios",
+        "options": [
+            "Catering",
+            "Cleaning"
+        ],
+        "next": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "47EI2X2T5EDTpJX9WjRR9p"
+            }
+        }
+    }
+}

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Answer, type: :model do
+  it { should belong_to(:question) }
+
+  it "captures the users response as a string" do
+    answer = build(:answer, response: "Yellow")
+    expect(answer.response).to eql("Yellow")
+  end
+end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Plan, type: :model do
+  it "captures the category" do
+    plan = build(:plan, :catering)
+    expect(plan.category).to eql("catering")
+  end
+end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Plan, type: :model do
+  it { should have_many(:questions) }
+
   it "captures the category" do
     plan = build(:plan, :catering)
     expect(plan.category).to eql("catering")

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Question, type: :model do
+  it { should belong_to(:plan) }
+  it "store the basic fields of a contentful response" do
+    question = build(:question,
+      :radio,
+      title: "foo",
+      help_text: "bar",
+      options: ["baz", "boo"])
+
+    expect(question.title).to eql("foo")
+    expect(question.help_text).to eql("bar")
+    expect(question.options).to eql(["baz", "boo"])
+  end
+
+  it "captures the raw contentful response" do
+    contentful_json_response = JSON("foo": {})
+    question = build(:question,
+      raw: contentful_json_response)
+
+    expect(question.raw).to eql("{\"foo\":{}}")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,11 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end

--- a/spec/services/create_question_spec.rb
+++ b/spec/services/create_question_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe CreateQuestion do
+  describe "#call" do
+    it "creates a local copy of the new question" do
+      plan = create(:plan, :catering)
+      raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
+      fake_contentful_question_response = JSON.parse(raw_response)
+      stub_contentful_question(response: fake_contentful_question_response)
+
+      result = described_class.new(plan: plan).call
+
+      expect(result.title).to eq("Which service do you need?")
+      expect(result.help_text).to eq("Tell us which service you need.")
+      expect(result.contentful_type).to eq("radios")
+      expect(result.options).to eq(["Catering", "Cleaning"])
+      expect(result.raw).to eq(fake_contentful_question_response.to_s)
+    end
+  end
+
+  def stub_contentful_question(response: {"fields" => {"title" => "Which service do you need?"}})
+    get_contentful_question_double = instance_double(GetContentfulQuestion)
+    allow(GetContentfulQuestion).to receive(:new).and_return(get_contentful_question_double)
+    allow(get_contentful_question_double).to receive(:call).and_return(response)
+  end
+end

--- a/spec/services/get_contentful_question_spec.rb
+++ b/spec/services/get_contentful_question_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe GetContentfulQuestion do
+  describe "#call" do
+    it "returns the contents of Contentful fixture (for now)" do
+      raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
+      fake_contentful_question_response = JSON.parse(raw_response)
+
+      result = described_class.new.call
+
+      expect(result).to eq(fake_contentful_question_response)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

This work concerns itself with proving that we can take a Contentful shaped question and present it to the user. The user is then able to answer the question, we persist it and then display it back to them on the most basic of show pages.

Prior to this work we decided that we would take the approach of persisting the state of Contentful at the time the user starts the journey for stability. Given that the Contentful documents can be changed upstream at any time we were at risk of becoming out of sync should this happen before a user had finished the journey. Until we know how often these documents change by the content team and how often users aren't able to complete them in one go, we skip a more complicated version management process for now in favour of a quick snapshot-in-time model. 

- fake a contentful response for a radio questionin order to keep this slice small. This question comes directly from the Alpha
- build a basic data structure of Plan > Question > Answer with the minimum viable fields
- ignore styling and validation for now since this pull request is likely big enough
- use UUID for the primary keys and add a default sort order by using created_at
- plans have their category of "catering" hard-coded for now as that's our choice for private beta. We will definitely need to come back to this model later to add more things to authorise which user can see which plans
- the end of the journey currently goes back to plan#show as it was quick to do. We may wish to change this later for a confirmation page with extra validation etc.

## Screenshots of UI changes

![Screenshot 2020-10-28 at 15 02 32](https://user-images.githubusercontent.com/912473/97456633-f5ece600-1930-11eb-9884-61fbb6349403.png)
![Screenshot 2020-10-28 at 15 03 56](https://user-images.githubusercontent.com/912473/97456657-f8e7d680-1930-11eb-91ac-b50f7e1f6ba7.png)
![Screenshot 2020-10-28 at 15 04 16](https://user-images.githubusercontent.com/912473/97456662-fa190380-1930-11eb-9c19-d5b307ef86f1.png)
