### PR TITLE
[21] Users can see a GOV.UK styled planning form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - use GOV.UK Frontend framework
 - users can see a basic form to start the planning journey sourced by a
 Contentful fixture
+- planning form is styled as a GOV.UK form
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.6.6"
 
 gem "bootsnap", ">= 1.1.0", require: false
 gem "coffee-rails", "~> 5.0"
+gem "govuk_design_system_formbuilder", "~> 2.1"
 gem "high_voltage"
 gem "jbuilder", "~> 2.5"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,10 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govuk_design_system_formbuilder (2.1.2)
+      actionview (>= 5.2)
+      activemodel (>= 5.2)
+      activesupport (>= 5.2)
     high_voltage (3.1.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -298,6 +302,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  govuk_design_system_formbuilder (~> 2.1)
   high_voltage
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -5,8 +5,7 @@ class AnswersController < ApplicationController
     plan = Plan.find(plan_id)
     question = Question.find(question_id)
 
-    answer = Answer.new
-    answer.response = params[:response]
+    answer = Answer.new(answer_params)
     answer.question = question
     answer.save
 
@@ -21,5 +20,9 @@ class AnswersController < ApplicationController
 
   def question_id
     params[:question_id]
+  end
+
+  def answer_params
+    params.require(:answer).permit(:response)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
-  
+
   def health_check
     render json: {rails: "OK"}, status: :ok
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+  
   def health_check
     render json: {rails: "OK"}, status: :ok
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,7 @@ class QuestionsController < ApplicationController
   def new
     @plan = Plan.find(plan_id)
     @question = CreateQuestion.new(plan: @plan).call
-
+    @answer = Answer.new
     # TODO: Creating a question requires us to check externally if one exists
     # based on the previous question. Instead of looping through at the start,
     # we assume there is and try to create one. If not, we jump to the end.

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,4 +2,8 @@ class Question < ApplicationRecord
   self.implicit_order_column = "created_at"
   belongs_to :plan
   has_one :answer
+
+  def radio_options
+    options.map { |option| OpenStruct.new(id: option.downcase, name: option.titleize) }
+  end
 end

--- a/app/views/pages/planning_start_page.html.erb
+++ b/app/views/pages/planning_start_page.html.erb
@@ -15,4 +15,4 @@
   <% end %>
 </ul>
 <p class="govuk-body"><%= I18n.t("planning.start_page.before_you_start_body") %></p>
-<%= link_to I18n.t("generic.button.start"), new_plan_path %>
+<%= link_to I18n.t("generic.button.start"), new_plan_path, class: "govuk-button" %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,5 +1,9 @@
-<%= @plan.category %>
-<% @plan.questions.each do |question| %>
-  <%= question.title %>
-  <%= question.answer.response %>
-<% end %>
+<%= content_for :title, @plan.category.capitalize %>
+
+<h1 class="govuk-heading-xl"><%= @plan.category.capitalize %></h1>
+<dl class="govuk-summary-list">
+  <% @plan.questions.each do |question| %>
+    <dt class="govuk-summary-list__key"><%= question.title %></dt>
+    <dd class="govuk-summary-list__value"><%= question.answer.response.capitalize %></dd>
+  <% end %>
+</dl>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,12 +1,14 @@
 <%= content_for :title, @question.title %>
 
-<h1><%= @question.title %></h1>
-<p><%= @question.help_text %></p>
-
-<%= form_with(url: plan_question_answers_path(@plan, @question), method: "post") do %>
-  <% @question.options.each do |option| %>
-    <%= radio_button_tag(:response, option.downcase) %>
-    <%= label_tag("response_#{option.downcase}", option) %>
-  <% end %>
-  <%= submit_tag I18n.t("generic.button.soft_finish") %>
+<%= form_for @answer, url: plan_question_answers_path(@plan, @question), method: "post" do |f| %>
+  <%= f.govuk_collection_radio_buttons :response,
+    @question.radio_options,
+    :id,
+    ->(option) { option.name },
+    :description,
+    legend: { text: @question.title, size: 'xl' },
+    hint: { text: @question.help_text },
+    inline: false
+  %>
+  <%= f.submit I18n.t("generic.button.soft_finish"), class: "govuk-button" %>
 <% end %>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

Parent pull request that should be reviewed first: https://github.com/DFE-Digital/buy-for-your-school/pull/12

## Changes in this PR

- install the DfE form builder gem
- iterate the basic planning form so that it's styled with GOV.UK for consistency
- iterate the form so that it uses an `answer` resource instead of generating a very basic post request 

## Screenshots of UI changes

### Before

![Screenshot 2020-10-28 at 15 03 56](https://user-images.githubusercontent.com/912473/97459901-284c1280-1934-11eb-897c-6754d0305a4a.png)
![Screenshot 2020-10-28 at 15 04 16](https://user-images.githubusercontent.com/912473/97459893-271ae580-1934-11eb-8257-6bc5977e6d54.png)

### After

![Screenshot 2020-10-28 at 15 41 48](https://user-images.githubusercontent.com/912473/97459870-21250480-1934-11eb-8ee8-438cff7484fb.png)
![Screenshot 2020-10-28 at 15 41 53](https://user-images.githubusercontent.com/912473/97459875-22563180-1934-11eb-864d-a69e8a6a56ec.png)
