### PR TITLE
Perform database migrations as part of Heroku release stages

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+release: rake db:migrate


### PR DESCRIPTION
Adds a release stage to the `Procfile` so that Heroku will run database migrations during release stages.