### PR TITLE
[21] Planning form has basic validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can see a basic form to start the planning journey sourced by a
 Contentful fixture
 - planning form is styled as a GOV.UK form
+- validate that an answer is provided to a question
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -2,14 +2,17 @@
 
 class AnswersController < ApplicationController
   def create
-    plan = Plan.find(plan_id)
-    question = Question.find(question_id)
+    @plan = Plan.find(plan_id)
+    @question = Question.find(question_id)
 
-    answer = Answer.new(answer_params)
-    answer.question = question
-    answer.save
-
-    redirect_to plan_path(plan)
+    @answer = Answer.new(answer_params)
+    @answer.question = @question
+    if @answer.valid?
+      @answer.save
+      redirect_to plan_path(@plan)
+    else
+      render "questions/new"
+    end
   end
 
   private

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,6 @@
 class Answer < ApplicationRecord
   self.implicit_order_column = "created_at"
   belongs_to :question
+
+  validates :response, presence: true
 end

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :title, @question.title %>
 
 <%= form_for @answer, url: plan_question_answers_path(@plan, @question), method: "post" do |f| %>
+  <%= f.hidden_field :response, value: nil %>
   <%= f.govuk_collection_radio_buttons :response,
     @question.radio_options,
     :id,

--- a/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
@@ -13,4 +13,16 @@ feature "Anyone can start the planning journey" do
 
     click_on(I18n.t("generic.button.soft_finish"))
   end
+
+  scenario "an answer must be provided" do
+    visit root_path
+
+    click_on(I18n.t("generic.button.start"))
+
+    # Omit a choice
+
+    click_on(I18n.t("generic.button.soft_finish"))
+
+    expect(page).to have_content("can't be blank")
+  end
 end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -7,4 +7,8 @@ RSpec.describe Answer, type: :model do
     answer = build(:answer, response: "Yellow")
     expect(answer.response).to eql("Yellow")
   end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:response) }
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

The last in a sequence of pull requests aimed at delivering story 21! 🎉 

- add basic presence validation for `Answer.response` 
- use default rails error messages for now, we can change these in Rails locales later if needed
- use default styling etc from the DfE form builder gem

## Screenshots of UI changes

![Screenshot 2020-10-29 at 12 01 28](https://user-images.githubusercontent.com/912473/97569093-12475c00-19df-11eb-8d43-8e5b8df2f608.png)
