### PR TITLE
Replace contentful fixture with real API request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ ROLLBAR_ACCESS_TOKEN=ROLLBAR_ACCESS_TOKEN
 ROLLBAR_ENV=development
 
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-development
+
+# Contentful
+CONTENTFUL_SPACE=
+CONTENTFUL_ACCESS_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,6 @@ DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-development
 
 # Contentful
 CONTENTFUL_SPACE=
+CONTENTFUL_ENVIRONMENT=master
 CONTENTFUL_ACCESS_TOKEN=
 CONTENTFUL_PLANNING_START_ENTRY_ID=

--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-development
 # Contentful
 CONTENTFUL_SPACE=
 CONTENTFUL_ACCESS_TOKEN=
+CONTENTFUL_PLANNING_START_ENTRY_ID=

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ ROLLBAR_ENV=development
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-development
 
 # Contentful
+CONTENTFUL_URL=cdn.contentful.com
 CONTENTFUL_SPACE=
 CONTENTFUL_ENVIRONMENT=master
 CONTENTFUL_ACCESS_TOKEN=

--- a/.env.test
+++ b/.env.test
@@ -8,6 +8,7 @@
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-test
 
 # Contentful
+CONTENTFUL_URL=cdn.contentful.com
 CONTENTFUL_SPACE=test
 CONTENTFUL_ENVIRONMENT=master
 CONTENTFUL_ACCESS_TOKEN=123

--- a/.env.test
+++ b/.env.test
@@ -9,5 +9,6 @@ DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-test
 
 # Contentful
 CONTENTFUL_SPACE=test
+CONTENTFUL_ENVIRONMENT=master
 CONTENTFUL_ACCESS_TOKEN=123
 CONTENTFUL_PLANNING_START_ENTRY_ID=1UjQurSOi5MWkcRuGxdXZS

--- a/.env.test
+++ b/.env.test
@@ -10,3 +10,4 @@ DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-test
 # Contentful
 CONTENTFUL_SPACE=test
 CONTENTFUL_ACCESS_TOKEN=123
+CONTENTFUL_PLANNING_START_ENTRY_ID=1UjQurSOi5MWkcRuGxdXZS

--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,7 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-test
+
+# Contentful
+CONTENTFUL_SPACE=test
+CONTENTFUL_ACCESS_TOKEN=123

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Contentful fixture
 - planning form is styled as a GOV.UK form
 - validate that an answer is provided to a question
 - the first planning question comes directly from Contentful
+- handle the exceptional case when a Contentful entry is missing
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 Contentful fixture
 - planning form is styled as a GOV.UK form
 - validate that an answer is provided to a question
+- the first planning question comes directly from Contentful
 
 [unreleased]: TODO
 [keep a changelog 1.0.0]: https://keepachangelog.com/en/1.0.0/

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.6.6"
 
 gem "bootsnap", ">= 1.1.0", require: false
 gem "coffee-rails", "~> 5.0"
+gem "contentful", "~> 2.15"
 gem "govuk_design_system_formbuilder", "~> 2.1"
 gem "high_voltage"
 gem "jbuilder", "~> 2.5"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "2.6.6"
 
 gem "bootsnap", ">= 1.1.0", require: false
+gem "climate_control"
 gem "coffee-rails", "~> 5.0"
 gem "contentful", "~> 2.15"
 gem "govuk_design_system_formbuilder", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,10 +90,15 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
+    contentful (2.15.4)
+      http (> 0.8, < 5.0)
+      multi_json (~> 1)
     crass (1.0.6)
     database_cleaner (1.8.5)
     diff-lcs (1.4.4)
     docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -108,6 +113,9 @@ GEM
     faker (2.14.0)
       i18n (>= 1.6, < 2)
     ffi (1.13.1)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk_design_system_formbuilder (2.1.2)
@@ -115,6 +123,16 @@ GEM
       activemodel (>= 5.2)
       activesupport (>= 5.2)
     high_voltage (3.1.2)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.1)
@@ -144,6 +162,7 @@ GEM
       libv8 (~> 8.4.255)
     minitest (5.14.2)
     msgpack (1.3.3)
+    multi_json (1.15.0)
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -273,6 +292,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
     uniform_notifier (1.13.0)
     web-console (4.0.4)
@@ -298,6 +320,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   coffee-rails (~> 5.0)
+  contentful (~> 2.15)
   database_cleaner
   dotenv-rails
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (0.2.0)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -319,6 +320,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 2.15)
+  climate_control
   coffee-rails (~> 5.0)
   contentful (~> 2.15)
   database_cleaner

--- a/app.json
+++ b/app.json
@@ -21,6 +21,9 @@
     "WEB_CONCURRENCY": {
       "value": 2
     },
+    "CONTENTFUL_URL": {
+      "value": "cdn.contentful.com"
+    },
     "CONTENTFUL_ENVIRONMENT": {
       "value": "master"
     }

--- a/app.json
+++ b/app.json
@@ -20,6 +20,9 @@
     },
     "WEB_CONCURRENCY": {
       "value": 2
+    },
+    "CONTENTFUL_ENVIRONMENT": {
+      "value": "master"
     }
   }
 }

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -3,7 +3,7 @@
 class QuestionsController < ApplicationController
   def new
     @plan = Plan.find(plan_id)
-    @question = CreateQuestion.new(plan: @plan).call
+    @question = CreatePlanningQuestion.new(plan: @plan).call
     @answer = Answer.new
     # TODO: Creating a question requires us to check externally if one exists
     # based on the previous question. Instead of looping through at the start,

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class QuestionsController < ApplicationController
+  rescue_from GetContentfulQuestion::EntryNotFound do |exception|
+    @exception = exception
+    render "errors/contentful_entry_not_found", status: 500
+  end
+
   def new
     @plan = Plan.find(plan_id)
     @question = CreatePlanningQuestion.new(plan: @plan).call

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class QuestionsController < ApplicationController
-  rescue_from GetContentfulQuestion::EntryNotFound do |exception|
+  rescue_from GetContentfulEntry::EntryNotFound do |exception|
     @exception = exception
     render "errors/contentful_entry_not_found", status: 500
   end

--- a/app/services/create_planning_question.rb
+++ b/app/services/create_planning_question.rb
@@ -1,4 +1,4 @@
-class CreateQuestion
+class CreatePlanningQuestion
   attr_accessor :plan
   def initialize(plan:)
     self.plan = plan

--- a/app/services/create_planning_question.rb
+++ b/app/services/create_planning_question.rb
@@ -18,7 +18,7 @@ class CreatePlanningQuestion
   private
 
   def contentful_response
-    @contentful_response ||= GetContentfulQuestion
+    @contentful_response ||= GetContentfulEntry
       .new
       .call(entry_id: ENV["CONTENTFUL_PLANNING_START_ENTRY_ID"])
   end

--- a/app/services/create_planning_question.rb
+++ b/app/services/create_planning_question.rb
@@ -18,6 +18,8 @@ class CreatePlanningQuestion
   private
 
   def contentful_response
-    @contentful_response ||= GetContentfulQuestion.new.call
+    @contentful_response ||= GetContentfulQuestion
+      .new
+      .call(entry_id: ENV["CONTENTFUL_PLANNING_START_ENTRY_ID"])
   end
 end

--- a/app/services/get_contentful_entry.rb
+++ b/app/services/get_contentful_entry.rb
@@ -1,6 +1,6 @@
 require "contentful"
 
-class GetContentfulQuestion
+class GetContentfulEntry
   class EntryNotFound < StandardError
     attr_accessor :message
     def initialize(message)

--- a/app/services/get_contentful_question.rb
+++ b/app/services/get_contentful_question.rb
@@ -1,8 +1,28 @@
 require "contentful"
 
 class GetContentfulQuestion
+  class EntryNotFound < StandardError
+    attr_accessor :message
+    def initialize(message)
+      @message = message
+    end
+  end
+
   def call(entry_id:)
-    contentful_client.entry(entry_id).raw
+    response = contentful_client.entry(entry_id)
+    if response.nil?
+      error_message = "The following Contentful entry identifier could not be found."
+      Rollbar.warning(
+        error_message,
+        contentful_url: ENV["CONTENTFUL_URL"],
+        contentful_space_id: ENV["CONTENTFUL_SPACE"],
+        contentful_environment: ENV["CONTENTFUL_ENVIRONMENT"],
+        contentful_entry_id: entry_id
+      )
+      raise EntryNotFound.new(error_message)
+    end
+
+    response.raw
   end
 
   private

--- a/app/services/get_contentful_question.rb
+++ b/app/services/get_contentful_question.rb
@@ -1,8 +1,8 @@
 require "contentful"
 
 class GetContentfulQuestion
-  def call
-    contentful_client.entry("1UjQurSOi5MWkcRuGxdXZS").raw
+  def call(entry_id:)
+    contentful_client.entry(entry_id).raw
   end
 
   private

--- a/app/services/get_contentful_question.rb
+++ b/app/services/get_contentful_question.rb
@@ -10,6 +10,7 @@ class GetContentfulQuestion
   def contentful_client
     @contentful_client ||= Contentful::Client.new(
       space: ENV["CONTENTFUL_SPACE"],
+      environment: ENV["CONTENTFUL_ENVIRONMENT"],
       access_token: ENV["CONTENTFUL_ACCESS_TOKEN"]
     )
   end

--- a/app/services/get_contentful_question.rb
+++ b/app/services/get_contentful_question.rb
@@ -1,8 +1,16 @@
+require "contentful"
+
 class GetContentfulQuestion
   def call
-    # TODO: Spec fixture only used for the first slice, needs a real API call
-    JSON.parse(
-      File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
+    contentful_client.entry("1UjQurSOi5MWkcRuGxdXZS").raw
+  end
+
+  private
+
+  def contentful_client
+    @contentful_client ||= Contentful::Client.new(
+      space: ENV["CONTENTFUL_SPACE"],
+      access_token: ENV["CONTENTFUL_ACCESS_TOKEN"]
     )
   end
 end

--- a/app/services/get_contentful_question.rb
+++ b/app/services/get_contentful_question.rb
@@ -9,6 +9,7 @@ class GetContentfulQuestion
 
   def contentful_client
     @contentful_client ||= Contentful::Client.new(
+      api_url: ENV["CONTENTFUL_URL"],
       space: ENV["CONTENTFUL_SPACE"],
       environment: ENV["CONTENTFUL_ENVIRONMENT"],
       access_token: ENV["CONTENTFUL_ACCESS_TOKEN"]

--- a/app/views/errors/contentful_entry_not_found.html.erb
+++ b/app/views/errors/contentful_entry_not_found.html.erb
@@ -1,0 +1,7 @@
+<%= content_for :title, I18n.t("errors.contentful_entry_not_found.page_title") %>
+
+<h1 class="govuk-heading-xl"><%= I18n.t("errors.contentful_entry_not_found.page_title") %></h1>
+<p class="govuk-body">
+  <%= I18n.t("errors.contentful_entry_not_found.page_body") %>
+</p>
+

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -3,6 +3,7 @@
 if defined?(Dotenv)
   Dotenv.require_keys(
     "CONTENTFUL_SPACE",
+    "CONTENTFUL_ENVIRONMENT",
     "CONTENTFUL_ACCESS_TOKEN",
     "CONTENTFUL_PLANNING_START_ENTRY_ID"
   )

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,5 +1,9 @@
 # Require environment variables on initialisation
 # https://github.com/bkeepers/dotenv#required-keys
 if defined?(Dotenv)
-  Dotenv.require_keys("CONTENTFUL_SPACE", "CONTENTFUL_ACCESS_TOKEN")
+  Dotenv.require_keys(
+    "CONTENTFUL_SPACE",
+    "CONTENTFUL_ACCESS_TOKEN",
+    "CONTENTFUL_PLANNING_START_ENTRY_ID"
+  )
 end

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,3 +1,5 @@
 # Require environment variables on initialisation
 # https://github.com/bkeepers/dotenv#required-keys
-Dotenv.require_keys if defined?(Dotenv)
+if defined?(Dotenv)
+  Dotenv.require_keys
+end

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -2,6 +2,7 @@
 # https://github.com/bkeepers/dotenv#required-keys
 if defined?(Dotenv)
   Dotenv.require_keys(
+    "CONTENTFUL_URL",
     "CONTENTFUL_SPACE",
     "CONTENTFUL_ENVIRONMENT",
     "CONTENTFUL_ACCESS_TOKEN",

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,5 +1,5 @@
 # Require environment variables on initialisation
 # https://github.com/bkeepers/dotenv#required-keys
 if defined?(Dotenv)
-  Dotenv.require_keys
+  Dotenv.require_keys("CONTENTFUL_SPACE", "CONTENTFUL_ACCESS_TOKEN")
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,3 +20,9 @@ en:
         - support you have access to in your school
         - information on the current contract
       before_you_start_body: "It will take around 3 minutes to complete the process"
+    errors:
+      contentful_entry_not_found: "An unexpected error occurred. The starting question has been revoked by the content team."
+  errors:
+    contentful_entry_not_found:
+      page_title: "An unexpected error occurred"
+      page_body: "The service has had a problem trying to retrieve the required question. The team have been notified of this problem and you should be able to retry shortly."

--- a/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
@@ -1,5 +1,7 @@
 feature "Anyone can start the planning journey" do
   scenario "Start page includs a call to action" do
+    stub_get_contentful_entry
+
     visit root_path
 
     click_on(I18n.t("generic.button.start"))
@@ -15,6 +17,8 @@ feature "Anyone can start the planning journey" do
   end
 
   scenario "an answer must be provided" do
+    stub_get_contentful_entry
+
     visit root_path
 
     click_on(I18n.t("generic.button.start"))

--- a/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
@@ -37,7 +37,7 @@ feature "Anyone can start the planning journey" do
 
     allow(contentful_client).to receive(:entry)
       .with(anything)
-      .and_raise(GetContentfulQuestion::EntryNotFound.new("The following Contentful error could not be found: sss "))
+      .and_raise(GetContentfulEntry::EntryNotFound.new("The following Contentful error could not be found: sss "))
 
     visit root_path
 

--- a/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_start_a_planning_journey_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 feature "Anyone can start the planning journey" do
   scenario "Start page includs a call to action" do
     stub_get_contentful_entry
@@ -28,5 +30,20 @@ feature "Anyone can start the planning journey" do
     click_on(I18n.t("generic.button.soft_finish"))
 
     expect(page).to have_content("can't be blank")
+  end
+
+  scenario "a Contentful entry_id does not exist" do
+    contentful_client = stub_contentful_client
+
+    allow(contentful_client).to receive(:entry)
+      .with(anything)
+      .and_raise(GetContentfulQuestion::EntryNotFound.new("The following Contentful error could not be found: sss "))
+
+    visit root_path
+
+    click_on(I18n.t("generic.button.start"))
+
+    expect(page).to have_content(I18n.t("errors.contentful_entry_not_found.page_title"))
+    expect(page).to have_content(I18n.t("errors.contentful_entry_not_found.page_body"))
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include ContentfulHelpers
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/services/create_planning_question_spec.rb
+++ b/spec/services/create_planning_question_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CreateQuestion do
+RSpec.describe CreatePlanningQuestion do
   describe "#call" do
     it "creates a local copy of the new question" do
       plan = create(:plan, :catering)

--- a/spec/services/create_planning_question_spec.rb
+++ b/spec/services/create_planning_question_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe CreatePlanningQuestion do
   end
 
   def stub_contentful_question(response: {"fields" => {"title" => "Which service do you need?"}})
-    get_contentful_question_double = instance_double(GetContentfulQuestion)
-    allow(GetContentfulQuestion).to receive(:new).and_return(get_contentful_question_double)
+    get_contentful_question_double = instance_double(GetContentfulEntry)
+    allow(GetContentfulEntry).to receive(:new).and_return(get_contentful_question_double)
     allow(get_contentful_question_double).to receive(:call).and_return(response)
   end
 end

--- a/spec/services/get_contentful_entry_spec.rb
+++ b/spec/services/get_contentful_entry_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe GetContentfulQuestion do
+RSpec.describe GetContentfulEntry do
   let(:contentful_url) { "preview.contentful" }
   let(:contentful_space) { "abc" }
   let(:contentful_environment) { "test" }

--- a/spec/services/get_contentful_question_spec.rb
+++ b/spec/services/get_contentful_question_spec.rb
@@ -1,13 +1,17 @@
 require "rails_helper"
 
 RSpec.describe GetContentfulQuestion do
+  let(:contentful_url) { "preview.contentful" }
   let(:contentful_space) { "abc" }
+  let(:contentful_environment) { "test" }
   let(:contentful_access_token) { "123" }
   let(:contentful_planning_start_entry_id) { "1a2b3c4d5" }
 
   around do |example|
     ClimateControl.modify(
+      CONTENTFUL_URL: contentful_url,
       CONTENTFUL_SPACE: contentful_space,
+      CONTENTFUL_ENVIRONMENT: contentful_environment,
       CONTENTFUL_ACCESS_TOKEN: contentful_access_token,
       CONTENTFUL_PLANNING_START_ENTRY_ID: contentful_planning_start_entry_id
     ) do
@@ -22,7 +26,10 @@ RSpec.describe GetContentfulQuestion do
 
       contentful_client = instance_double(Contentful::Client)
       expect(Contentful::Client).to receive(:new)
-        .with(space: contentful_space, access_token: contentful_access_token)
+        .with(api_url: contentful_url,
+              space: contentful_space,
+              environment: contentful_environment,
+              access_token: contentful_access_token)
         .and_return(contentful_client)
 
       contentful_response = double(Contentful::Entry, id: contentful_planning_start_entry_id)

--- a/spec/services/get_contentful_question_spec.rb
+++ b/spec/services/get_contentful_question_spec.rb
@@ -6,6 +6,19 @@ RSpec.describe GetContentfulQuestion do
       raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
       fake_contentful_question_response = JSON.parse(raw_response)
 
+      contentful_client = instance_double(Contentful::Client)
+      expect(Contentful::Client).to receive(:new)
+        .with(space: anything, access_token: anything)
+        .and_return(contentful_client)
+
+      contentful_response = double(Contentful::Entry, id: "1UjQurSOi5MWkcRuGxdXZS")
+      expect(contentful_client).to receive(:entry)
+        .with("1UjQurSOi5MWkcRuGxdXZS")
+        .and_return(contentful_response)
+
+      expect(contentful_response).to receive(:raw)
+        .and_return(fake_contentful_question_response)
+
       result = described_class.new.call
 
       expect(result).to eq(fake_contentful_question_response)

--- a/spec/services/get_contentful_question_spec.rb
+++ b/spec/services/get_contentful_question_spec.rb
@@ -1,6 +1,15 @@
 require "rails_helper"
 
 RSpec.describe GetContentfulQuestion do
+  let(:contentful_space) { "abc" }
+  let(:contentful_access_token) { "123" }
+
+  around do |example|
+    ClimateControl.modify CONTENTFUL_SPACE: contentful_space, CONTENTFUL_ACCESS_TOKEN: contentful_access_token do
+      example.run
+    end
+  end
+
   describe "#call" do
     it "returns the contents of Contentful fixture (for now)" do
       raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
@@ -8,7 +17,7 @@ RSpec.describe GetContentfulQuestion do
 
       contentful_client = instance_double(Contentful::Client)
       expect(Contentful::Client).to receive(:new)
-        .with(space: anything, access_token: anything)
+        .with(space: contentful_space, access_token: contentful_access_token)
         .and_return(contentful_client)
 
       contentful_response = double(Contentful::Entry, id: "1UjQurSOi5MWkcRuGxdXZS")

--- a/spec/services/get_contentful_question_spec.rb
+++ b/spec/services/get_contentful_question_spec.rb
@@ -3,9 +3,14 @@ require "rails_helper"
 RSpec.describe GetContentfulQuestion do
   let(:contentful_space) { "abc" }
   let(:contentful_access_token) { "123" }
+  let(:contentful_planning_start_entry_id) { "1a2b3c4d5" }
 
   around do |example|
-    ClimateControl.modify CONTENTFUL_SPACE: contentful_space, CONTENTFUL_ACCESS_TOKEN: contentful_access_token do
+    ClimateControl.modify(
+      CONTENTFUL_SPACE: contentful_space,
+      CONTENTFUL_ACCESS_TOKEN: contentful_access_token,
+      CONTENTFUL_PLANNING_START_ENTRY_ID: contentful_planning_start_entry_id
+    ) do
       example.run
     end
   end
@@ -20,15 +25,15 @@ RSpec.describe GetContentfulQuestion do
         .with(space: contentful_space, access_token: contentful_access_token)
         .and_return(contentful_client)
 
-      contentful_response = double(Contentful::Entry, id: "1UjQurSOi5MWkcRuGxdXZS")
+      contentful_response = double(Contentful::Entry, id: contentful_planning_start_entry_id)
       expect(contentful_client).to receive(:entry)
-        .with("1UjQurSOi5MWkcRuGxdXZS")
+        .with(contentful_planning_start_entry_id)
         .and_return(contentful_response)
 
       expect(contentful_response).to receive(:raw)
         .and_return(fake_contentful_question_response)
 
-      result = described_class.new.call
+      result = described_class.new.call(entry_id: contentful_planning_start_entry_id)
 
       expect(result).to eq(fake_contentful_question_response)
     end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -19,4 +19,12 @@ module ContentfulHelpers
     allow(contentful_response).to receive(:raw)
       .and_return(fake_contentful_question_response)
   end
+
+  def stub_contentful_client
+    contentful_client = instance_double(Contentful::Client)
+    expect(Contentful::Client).to receive(:new)
+      .with(space: anything, access_token: anything)
+      .and_return(contentful_client)
+    contentful_client
+  end
 end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -6,10 +6,7 @@ module ContentfulHelpers
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{fixture_filename}")
     fake_contentful_question_response = JSON.parse(raw_response)
 
-    contentful_client = instance_double(Contentful::Client)
-    allow(Contentful::Client).to receive(:new)
-      .with(space: anything, access_token: anything)
-      .and_return(contentful_client)
+    contentful_client = stub_contentful_client
 
     contentful_response = double(Contentful::Entry, id: entry_id)
     allow(contentful_client).to receive(:entry)
@@ -23,7 +20,7 @@ module ContentfulHelpers
   def stub_contentful_client
     contentful_client = instance_double(Contentful::Client)
     expect(Contentful::Client).to receive(:new)
-      .with(space: anything, access_token: anything)
+      .with(space: anything, environment: anything, access_token: anything)
       .and_return(contentful_client)
     contentful_client
   end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -1,0 +1,22 @@
+module ContentfulHelpers
+  def stub_get_contentful_entry(
+    entry_id: "1UjQurSOi5MWkcRuGxdXZS",
+    fixture_filename: "radio-question-example.json"
+  )
+    raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{fixture_filename}")
+    fake_contentful_question_response = JSON.parse(raw_response)
+
+    contentful_client = instance_double(Contentful::Client)
+    allow(Contentful::Client).to receive(:new)
+      .with(space: anything, access_token: anything)
+      .and_return(contentful_client)
+
+    contentful_response = double(Contentful::Entry, id: entry_id)
+    allow(contentful_client).to receive(:entry)
+      .with(entry_id)
+      .and_return(contentful_response)
+
+    allow(contentful_response).to receive(:raw)
+      .and_return(fake_contentful_question_response)
+  end
+end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -20,7 +20,7 @@ module ContentfulHelpers
   def stub_contentful_client
     contentful_client = instance_double(Contentful::Client)
     expect(Contentful::Client).to receive(:new)
-      .with(space: anything, environment: anything, access_token: anything)
+      .with(api_url: anything, space: anything, environment: anything, access_token: anything)
       .and_return(contentful_client)
     contentful_client
   end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- replace the first question in the planning journey with a real Contentful API request
- the Contentful client is configurable through environment variables in keeping with a 12 factor app
- the first question we ask for is also configurable through an environment variable as opposed to hardcoding it this allows us a little flexibility
- handle the exceptional case where we ask Contentful for an Entry and it wasn't found, fail quickly and loudly to the user and report to the team via Rollbar. The rollbar includes 2 pieces of technical information to help us debug Contenful: `entry_id` and `space_id`

It's worth noting the relevant risk error we've identified to the ability to delete Contentful entries https://trello.com/c/cSuRk7Kj. Given they _can_ be deleted by users we should (and now do) handle that situation. 

## Screenshots of UI changes

![Screenshot 2020-11-02 at 12 02 23](https://user-images.githubusercontent.com/912473/97868052-ebeb2e80-1d06-11eb-8fee-e1ff540ed9a3.png)
![Screenshot 2020-11-02 at 12 09 21](https://user-images.githubusercontent.com/912473/97868049-eaba0180-1d06-11eb-8b97-8aca714f789e.png)
