### PR TITLE
Refactor the getting of Contentful Entries to return an object instead

### DIFF
--- a/app/services/create_planning_question.rb
+++ b/app/services/create_planning_question.rb
@@ -15,15 +15,15 @@ class CreatePlanningQuestion
     end
 
     question = Question.create(
-      title: contentful_response.dig("fields", "title"),
-      help_text: contentful_response.dig("fields", "helpText"),
-      contentful_type: contentful_response.dig("fields", "type"),
-      options: contentful_response.dig("fields", "options"),
-      raw: contentful_response,
+      title: contentful_response.title,
+      help_text: contentful_response.help_text,
+      contentful_type: contentful_response.type,
+      options: contentful_response.options,
+      raw: contentful_response.raw,
       plan: plan
     )
 
-    plan.update(next_entry_id: contentful_response.dig("fields", "next", "sys", "id"))
+    plan.update(next_entry_id: contentful_response.next.id)
 
     question
   end
@@ -31,7 +31,7 @@ class CreatePlanningQuestion
   private
 
   def content_entry_id
-    contentful_response.dig("sys", "id")
+    contentful_response.id
   end
 
   def contentful_response
@@ -41,7 +41,7 @@ class CreatePlanningQuestion
   end
 
   def content_type
-    contentful_response.dig("sys", "contentType", "sys", "id")
+    contentful_response.content_type.id
   end
 
   def expected_question_type?

--- a/app/services/create_planning_question.rb
+++ b/app/services/create_planning_question.rb
@@ -15,15 +15,15 @@ class CreatePlanningQuestion
     end
 
     question = Question.create(
-      title: contentful_response.title,
-      help_text: contentful_response.help_text,
-      contentful_type: contentful_response.type,
-      options: contentful_response.options,
-      raw: contentful_response.raw,
+      title: contentful_entry.title,
+      help_text: contentful_entry.help_text,
+      contentful_type: contentful_entry.type,
+      options: contentful_entry.options,
+      raw: contentful_entry.raw,
       plan: plan
     )
 
-    plan.update(next_entry_id: contentful_response.next.id)
+    plan.update(next_entry_id: contentful_entry.next.id)
 
     question
   end
@@ -31,17 +31,17 @@ class CreatePlanningQuestion
   private
 
   def content_entry_id
-    contentful_response.id
+    contentful_entry.id
   end
 
-  def contentful_response
-    @contentful_response ||= GetContentfulEntry
+  def contentful_entry
+    @contentful_entry ||= GetContentfulEntry
       .new(entry_id: plan.next_entry_id)
       .call
   end
 
   def content_type
-    contentful_response.content_type.id
+    contentful_entry.content_type.id
   end
 
   def expected_question_type?

--- a/app/services/get_contentful_entry.rb
+++ b/app/services/get_contentful_entry.rb
@@ -17,7 +17,7 @@ class GetContentfulEntry
       raise EntryNotFound
     end
 
-    response.raw
+    response
   end
 
   private

--- a/spec/services/get_contentful_entry_spec.rb
+++ b/spec/services/get_contentful_entry_spec.rb
@@ -21,9 +21,6 @@ RSpec.describe GetContentfulEntry do
 
   describe "#call" do
     it "returns the contents of Contentful fixture (for now)" do
-      raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
-      fake_contentful_question_response = JSON.parse(raw_response)
-
       contentful_client = instance_double(Contentful::Client)
       expect(Contentful::Client).to receive(:new)
         .with(api_url: contentful_url,
@@ -37,12 +34,9 @@ RSpec.describe GetContentfulEntry do
         .with(contentful_planning_start_entry_id)
         .and_return(contentful_response)
 
-      expect(contentful_response).to receive(:raw)
-        .and_return(fake_contentful_question_response)
-
       result = described_class.new(entry_id: contentful_planning_start_entry_id).call
 
-      expect(result).to eq(fake_contentful_question_response)
+      expect(result).to eq(contentful_response)
     end
 
     context "when the Contentful entry cannot be found" do

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -4,17 +4,15 @@ module ContentfulHelpers
     fixture_filename: "radio-question-example.json"
   )
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{fixture_filename}")
-    fake_contentful_question_response = JSON.parse(raw_response)
 
     contentful_client = stub_contentful_client
-
-    contentful_response = double(Contentful::Entry, id: entry_id)
+    contentful_response = fake_contentful_radio_question_entry(contentful_fixture_filename: fixture_filename)
     allow(contentful_client).to receive(:entry)
       .with(entry_id)
       .and_return(contentful_response)
 
     allow(contentful_response).to receive(:raw)
-      .and_return(fake_contentful_question_response)
+      .and_return(raw_response)
   end
 
   def stub_contentful_client
@@ -23,5 +21,28 @@ module ContentfulHelpers
       .with(api_url: anything, space: anything, environment: anything, access_token: anything)
       .and_return(contentful_client)
     contentful_client
+  end
+
+  def stub_contentful_question(fake_entry: fake_contentful_radio_question_entry)
+    get_contentful_question_double = instance_double(GetContentfulEntry)
+    allow(GetContentfulEntry).to receive(:new).and_return(get_contentful_question_double)
+    allow(get_contentful_question_double).to receive(:call).and_return(fake_entry)
+  end
+
+  def fake_contentful_radio_question_entry(contentful_fixture_filename:)
+    raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{contentful_fixture_filename}")
+    hash_response = JSON.parse(raw_response)
+
+    double(
+      Contentful::Entry,
+      id: hash_response.dig("sys", "id"),
+      title: hash_response.dig("fields", "title"),
+      help_text: hash_response.dig("fields", "helpText"),
+      options: hash_response.dig("fields", "options"),
+      type: hash_response.dig("fields", "type"),
+      next: double(id: hash_response.dig("fields", "next", "sys", "id")),
+      raw: raw_response,
+      content_type: double(id: hash_response.dig("sys", "contentType", "sys", "id"))
+    )
   end
 end


### PR DESCRIPTION
This pull request has been extracted from the work being done to address https://trello.com/c/2r44iApA. In order to make this change I found some friction around reusing the `GetContentfulEntry` service. I think this refactoring offers improvement regardless of additional work.

Change the way we handle the Contentful API response so we pass down an object of the Contentful gem, rather than a blob of JSON (though we still do store the raw JSON).