### PR TITLE
Entry fixtures without next element are more realistic

### DIFF
--- a/spec/fixtures/contentful/no-next-question-example.json
+++ b/spec/fixtures/contentful/no-next-question-example.json
@@ -36,7 +36,6 @@
         "options": [
             "Stationary",
             "IT supplies"
-        ],
-        "next": {}
+        ]
     }
 }

--- a/spec/fixtures/contentful/radio-question-example.json
+++ b/spec/fixtures/contentful/radio-question-example.json
@@ -36,8 +36,6 @@
         "options": [
             "Catering",
             "Cleaning"
-        ],
-        "next": {
-        }
+        ]
     }
 }


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Tiny change to correct 2 fixtures that attempt to replicate a response for entries with no 'next' element.

You can verify this by making a Contentful API request manually for an entry that has no next element, no `next` key is returned.
