### PR TITLE
Fix RadioAnswer and ShortTextAnswer database migrations

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -8,7 +8,7 @@ class PlansController < ApplicationController
 
   def show
     @plan = Plan.includes(
-      questions: [:radio_answer, :short_text_answer]
+      questions: [:answer, :radio_answer, :short_text_answer]
     ).find(plan_id)
   end
 

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,6 @@
+class Answer < ApplicationRecord
+  self.implicit_order_column = "created_at"
+  belongs_to :question
+
+  validates :response, presence: true
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,7 +1,7 @@
 class Question < ApplicationRecord
   self.implicit_order_column = "created_at"
   belongs_to :plan
-
+  has_one :answer
   has_one :radio_answer
   has_one :short_text_answer
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -8,8 +8,4 @@ class Question < ApplicationRecord
   def radio_options
     options.map { |option| OpenStruct.new(id: option.downcase, name: option.titleize) }
   end
-
-  def answer
-    @answer ||= radio_answer || short_text_answer
-  end
 end

--- a/app/services/answer_factory.rb
+++ b/app/services/answer_factory.rb
@@ -9,6 +9,7 @@ class AnswerFactory
     case question.contentful_type
     when "radios" then RadioAnswer.new
     when "short_text" then ShortTextAnswer.new
+    else Answer.new
     end
   end
 end

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -3,6 +3,10 @@
 <h1 class="govuk-heading-xl"><%= @plan.category.capitalize %></h1>
 <dl class="govuk-summary-list">
   <% @plan.questions.each do |question| %>
-    <%= render "#{question.contentful_type}_answer", question: question, answer: question.answer %>
+    <% if question.radio_answer %>
+      <%= render "radios_answer", question: question, answer: question.radio_answer %>
+    <% elsif question.short_text_answer %>
+      <%= render "short_text_answer", question: question, answer: question.short_text_answer %>
+    <% end %>
   <% end %>
 </dl>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -7,6 +7,11 @@
       <%= render "radios_answer", question: question, answer: question.radio_answer %>
     <% elsif question.short_text_answer %>
       <%= render "short_text_answer", question: question, answer: question.short_text_answer %>
+    <% else %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key"><%= question.title %></dt>
+        <dd class="govuk-summary-list__value"><%= question.answer.response %></dd>
+      </div>
     <% end %>
   <% end %>
 </dl>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,6 +59,7 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.raise = true # raise an error if n+1 query occurs
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Question", association: :answer
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Question", association: :radio_answer
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Question", association: :short_text_answer
   end

--- a/db/migrate/20201112123028_remove_answer_table.rb
+++ b/db/migrate/20201112123028_remove_answer_table.rb
@@ -1,5 +1,0 @@
-class RemoveAnswerTable < ActiveRecord::Migration[6.0]
-  def change
-    drop_table :answers
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_123028) do
+ActiveRecord::Schema.define(version: 2020_11_11_155941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "question_id"
+    t.string "response", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["question_id"], name: "index_answers_on_question_id"
+  end
 
   create_table "plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "category", null: false

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -1,4 +1,10 @@
 FactoryBot.define do
+  factory :answer do
+    association :question, factory: :question, contentful_type: "radios"
+
+    response { "Green" }
+  end
+
   factory :radio_answer do
     association :question, factory: :question, contentful_type: "radios"
 

--- a/spec/factories/question.rb
+++ b/spec/factories/question.rb
@@ -9,13 +9,11 @@ FactoryBot.define do
     trait :radio do
       options { ["Red", "Green", "Blue"] }
       contentful_type { "radios" }
-      association :radio_answer
     end
 
     trait :short_text do
       options { nil }
       contentful_type { "short_text" }
-      association :short_text_answer
     end
   end
 end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Answer, type: :model do
+  it { should belong_to(:question) }
+
+  it "captures the users response as a string" do
+    answer = build(:answer, response: "Yellow")
+    expect(answer.response).to eql("Yellow")
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:response) }
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -24,22 +24,4 @@ RSpec.describe Question, type: :model do
 
     expect(question.raw).to eql("{\"foo\":{}}")
   end
-
-  describe "#answer" do
-    context "when a RadioAnswer is associated to the question" do
-      it "returns the RadioAnswer object" do
-        radio_answer = create(:radio_answer)
-        question = create(:question, :radio, radio_answer: radio_answer)
-        expect(question.answer).to eq(radio_answer)
-      end
-    end
-
-    context "when a ShortTextAnswer is associated to the question" do
-      it "returns the ShortTextAnswer object" do
-        short_text_answer = create(:short_text_answer)
-        question = create(:question, :short_text, short_text_answer: short_text_answer)
-        expect(question.answer).to eq(short_text_answer)
-      end
-    end
-  end
 end

--- a/spec/services/answer_factory_spec.rb
+++ b/spec/services/answer_factory_spec.rb
@@ -2,6 +2,14 @@ require "rails_helper"
 
 RSpec.describe AnswerFactory do
   describe "#call" do
+    context "when the question is for an unexpected type" do
+      it "returns a plain Answer object" do
+        question = create(:question, contentful_type: "foo")
+        result = described_class.new(question: question).call
+        expect(result).to be_kind_of(Answer)
+      end
+    end
+
     context "when the question is for radios" do
       it "returns a new RadioAnswer object" do
         question = create(:question, :radio)


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

This deployment of https://github.com/DFE-Digital/buy-for-your-school/pull/33 is currently failing on line https://github.com/DFE-Digital/buy-for-your-school/blob/develop/db/migrate/20201111144757_create_radio_answer_table.rb#L12 and requires a fix.

I believe [the new #answer method](https://github.com/DFE-Digital/buy-for-your-school/blob/develop/app/models/question.rb#L13) was conflicting with the migrations that were intending to ask for `answer` through an ActiveRecord association, however our method of the same name was unintentionally found and used instead.

The presence of that method hid the fact that `Answer` had been removed from the code base at the time of the migration and that `question.answer` was no longer viable to handle the radio and short text migrations in all cases. The new answer method did enable the migrations to work locally although not intentionally! It allowed the migrations to process all questions that **had** answers. For those questions that didn't have answers (staging has loads) then it goes bang, this is why it wasn't noticed in dev. 

This change reverts the 2 final commits made to https://github.com/DFE-Digital/buy-for-your-school/pull/33 which should then enable these migrations to complete. Once all environments are migrated these changes can be added back in. I'll set up a draft pull request so we don't forget (https://github.com/DFE-Digital/buy-for-your-school/pull/37).

