### PR TITLE
Add foreign key contraints to the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- add database foreign key constraints for better data integrity
+
 ## [release-002] - 2020-11-16
 
 - migrate answer database table into Radio and ShortText

--- a/db/migrate/20201116142721_add_foreign_key_constraint.rb
+++ b/db/migrate/20201116142721_add_foreign_key_constraint.rb
@@ -1,0 +1,9 @@
+class AddForeignKeyConstraint < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key :questions, :plans, on_delete: :cascade
+
+    add_foreign_key :radio_answers, :questions, on_delete: :cascade
+    add_foreign_key :short_text_answers, :questions, on_delete: :cascade
+    add_foreign_key :long_text_answers, :questions, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_152711) do
+ActiveRecord::Schema.define(version: 2020_11_16_142721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -59,4 +59,8 @@ ActiveRecord::Schema.define(version: 2020_11_12_152711) do
     t.index ["question_id"], name: "index_short_text_answers_on_question_id"
   end
 
+  add_foreign_key "long_text_answers", "questions", on_delete: :cascade
+  add_foreign_key "questions", "plans", on_delete: :cascade
+  add_foreign_key "radio_answers", "questions", on_delete: :cascade
+  add_foreign_key "short_text_answers", "questions", on_delete: :cascade
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

This proposal attempts to ensure we have better data integrity between our associations. 

I found when debugging locally and on staging that the database was starting to get into unexpected states. For example we could have an `answer` without a `question`, or the potential for a `question` to not have a `plan`. Adding cascade constraints will help us delete records in a reliable manner. Deleting a plan will delete all associated questions, and all questions will delete associated answers. The result of deleting a plan will now leave no orphan records that have no way of ever being referenced.

We may wish to use `:restrict` in future if we want to guard against accidental deletions.

[As pointed out in the Rails documentation we can do this in the model or at the database level for a better guarantee](https://guides.rubyonrails.org/active_record_migrations.html#active-record-and-referential-integrity).