### PR TITLE
(53) Docker Compose used on CI and usable in dev

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,22 +10,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      RAILS_ENV: test
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Set up Docker
-        run: docker network create test
-      - name: Set up Postgres
-        run: docker run -d --name pg --network test -e POSTGRES_USER=test -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres:11
-      - name: Build a new Docker image
-        run: docker build . --build-arg RAILS_ENV=test -t app:test
-      - name: Run the tests
-        run: |
-          docker run --name test-container \
-            --network test \
-            -e RAILS_ENV=test \
-            -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
-            -e DATABASE_URL=postgres://test@pg:5432/app_test \
-            app:test bundle exec rake
+      - name: Build
+        run: docker-compose -f docker-compose.ci.yml build
+      - name: Test
+        run: docker-compose -f docker-compose.ci.yml run --rm test bundle exec rake

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,11 @@ RUN npm install
 COPY Gemfile* ./
 RUN gem install bundler:2.1.4 --no-document
 
-# bundle ruby gems based on the current environment, default to production
-RUN echo $RAILS_ENV
-RUN if [ "$RAILS_ENV" = "production" ]; then \
-      bundle install --without development test --retry 10; \
-    else \
-      bundle install --retry 10; \
-    fi
+ARG BUNDLE_EXTRA_GEM_GROUPS
+ENV BUNDLE_GEM_GROUPS=${BUNDLE_EXTRA_GEM_GROUPS:-"production"}
+RUN bundle config set no-cache "true"
+RUN bundle config set with $BUNDLE_GEM_GROUPS
+RUN bundle install --no-binstubs --retry=3 --jobs=4
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
-FROM ruby:2.6.6 as release
+# BUILD STAGE #
+FROM ruby:2.6.6 AS build
 MAINTAINER dxw <rails@dxw.com>
+
+ENV INSTALL_PATH /srv/app
+ARG RAILS_ENV
+ENV RAILS_ENV=${RAILS_ENV:-production}
+ENV RACK_ENV=${RAILS_ENV:-production}
+
+WORKDIR $INSTALL_PATH
+
 RUN apt-get update && apt-get install -qq -y \
   build-essential \
   libpq-dev \
@@ -7,26 +16,13 @@ RUN apt-get update && apt-get install -qq -y \
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
         && apt-get install -y nodejs
 
-ENV INSTALL_PATH /srv/app
-RUN mkdir -p $INSTALL_PATH
-
-WORKDIR $INSTALL_PATH
-
-# set rails environment
-ARG RAILS_ENV
-ENV RAILS_ENV=${RAILS_ENV:-production}
-ENV RACK_ENV=${RAILS_ENV:-production}
-
-COPY package.json $INSTALL_PATH/package.json
-COPY package-lock.json $INSTALL_PATH/package-lock.json
+COPY package.json ./package.json
+COPY package-lock.json ./package-lock.json
 
 RUN npm install
 
-COPY Gemfile $INSTALL_PATH/Gemfile
-COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
-
-RUN gem update --system
-RUN gem install bundler
+COPY Gemfile* ./
+RUN gem install bundler:2.1.4 --no-document
 
 # bundle ruby gems based on the current environment, default to production
 RUN echo $RAILS_ENV
@@ -36,19 +32,32 @@ RUN if [ "$RAILS_ENV" = "production" ]; then \
       bundle install --retry 10; \
     fi
 
-COPY . $INSTALL_PATH
+COPY . .
+
+# RELEASE STAGE #
+FROM ruby:2.6.6 AS release
+
+ENV INSTALL_PATH /srv/app
+ARG RAILS_ENV
+ENV RAILS_ENV=${RAILS_ENV:-production}
+ENV RACK_ENV=${RAILS_ENV:-production}
+
+WORKDIR $INSTALL_PATH
+
+RUN gem install bundler:2.1.4 --no-document
+
+COPY --from=build /usr/local/bundle/ /usr/local/bundle/
+COPY --from=build $INSTALL_PATH $INSTALL_PATH
 
 # Compiling assets requires a key to exist: https://github.com/rails/rails/issues/32947
 RUN if [ "$RAILS_ENV" = "production" ]; then \
       RAILS_ENV=production SECRET_KEY_BASE="key" bundle exec rake assets:precompile; \
     fi
 
-
-# db setup
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 3000
 
-CMD ["rails", "server"]
+CMD ["bundle", "exec", "rails", "server"]

--- a/README.md
+++ b/README.md
@@ -4,17 +4,12 @@ A service to help school buying professionals create tender documents that compl
 
 ## Getting started
 
-1. `brew install postgres`
-1. `brew services start postgres`
-1. `createuser postgres --super`
+1. [Install Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
 1. copy `/.env.example` into `/.env.development.local`.
 
   Our intention is that the example should include enough to get the application started quickly. If this is not the case, please ask another developer for a copy of their `/.env.development.local` file.
-1. `rbenv install 2.6.6 && rbenv local 2.6.6`
-1. `gem install bundle`
-1. `bundle`
-1. `rake db:setup && RAILS_ENV=test rake db:setup`
-1. `rails server`
+  
+1. `script/server`
 1. Visit http://localhost:3000
 
 ## Running the tests

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A service to help school buying professionals create tender documents that compl
 1. copy `/.env.example` into `/.env.development.local`.
 
   Our intention is that the example should include enough to get the application started quickly. If this is not the case, please ask another developer for a copy of their `/.env.development.local` file.
-  
+
 1. `script/server`
 1. Visit http://localhost:3000
 
@@ -16,11 +16,30 @@ A service to help school buying professionals create tender documents that compl
 
 ### The whole test suite
 
-`bundle exec rake`
+* Using Docker has high parity, you don't have to install any dependencies but it takes longer to run (~20 seconds):
+
+    ```bash
+    docker-compose -f docker-compose.test.yml run --rm web bundle exec rake
+    ```
+* Without Docker is faster (~5 seconds) but has lower parity and you will need to install local dependencies on your machine first:
+
+    ```bash
+    brew install postgres
+    brew services start postgres
+    createuser postgres --super
+    rbenv install 2.6.6 && rbenv local 2.6.6
+    gem install bundle && bundle
+    RAILS_ENV=test rake db:setup
+    ```
+    ```ruby
+    script/test
+    ```
 
 ### RSpec only
 
-`bundle exec rspec`
+```
+bundle exec rspec spec/*
+```
 
 ## Running Brakeman
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,14 +23,14 @@ environment ENV.fetch("RAILS_ENV", "development")
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 
-workers ENV.fetch("WEB_CONCURRENCY", 2)
+# workers ENV.fetch("WEB_CONCURRENCY", 2)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 
-preload_app!
+# preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+services:
+  test:
+    build:
+      context: .
+      args:
+        RAILS_ENV: "test"
+        BUNDLE_EXTRA_GEM_GROUPS: "test"
+    command: bundle exec rake
+    ports:
+      - "3000:3000"
+    depends_on:
+      - test-db
+    env_file:
+       - .env.test
+    environment:
+      DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+    networks:
+      - test
+
+  test-db:
+    image: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_HOST_AUTH_METHOD: trust
+    networks:
+      - test
+
+networks:
+  test:
+volumes:
+  db-data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         RAILS_ENV: "test"
+        BUNDLE_EXTRA_GEM_GROUPS: "test"
     command: bundle exec rake
     ports:
       - "3000:3000"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,36 +1,39 @@
 version: "3.8"
 services:
-  web:
+  test:
     build:
       context: .
       args:
-        RAILS_ENV: "development"
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+        RAILS_ENV: "test"
+    command: bundle exec rake
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      - test-db
     env_file:
-       - .env.development.local
+       - .env.test
     environment:
-      DATABASE_URL: postgres://postgres:password@db:5432/buy-for-your-school-development
+      DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
     volumes:
       - .:/srv/app
     tty: true
     stdin_open: true
     networks:
-      - dev
+      - test
 
-  db:
+  test-db:
     image: postgres
     volumes:
       - db-data:/var/lib/postgresql/data
     environment:
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
+      POSTGRES_HOST_AUTH_METHOD: trust
     networks:
-      - dev
+      - test
 
 networks:
-  dev:
+  test:
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.7"
+services:
+  web:
+    build:
+      context: .
+      args:
+        RAILS_ENV: "development"
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    ports:
+      - "3000:3000"
+    links:
+      - db
+    env_file:
+       - .env.development.local
+    environment:
+      DATABASE_URL: postgres://postgres:password@db:5432/buy-for-your-school-development
+    volumes:
+      - .:/srv/app
+    tty: true
+    stdin_open: true
+    networks:
+      - dev
+
+  db:
+    image: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+    networks:
+      - dev
+
+networks:
+  dev:
+volumes:
+  db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       args:
         RAILS_ENV: "development"
+        BUNDLE_EXTRA_GEM_GROUPS: "development test"
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     ports:
       - "3000:3000"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,7 +11,7 @@ setup_database()
   echo "ENTRYPOINT: Finished database setup."
 }
 
-if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi
+if [ -z ${DATABASE_URL+x} ]; then echo "ENTRYPOINT: Skipping database setup"; else setup_database; fi
 
 echo "ENTRYPOINT: Finished docker entrypoint."
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,11 @@ setup_database()
   echo "ENTRYPOINT: Finished database setup."
 }
 
+# Bundle any Gemfile changes in development without requiring a long image rebuild
+if [ ! "$RAILS_ENV" == "production" ]; then
+  if bundle check; then echo "ENTRYPOINT: Skipping bundle for development"; else bundle; fi
+fi
+
 if [ -z ${DATABASE_URL+x} ]; then echo "ENTRYPOINT: Skipping database setup"; else setup_database; fi
 
 echo "ENTRYPOINT: Finished docker entrypoint."

--- a/script/server
+++ b/script/server
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# script/server: Launch the application and any extra required processes
+#                locally.
+
+set -e
+
+docker-compose up --detach
+docker attach buy-for-your-school_web_1

--- a/script/test
+++ b/script/test
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# script/server: Launch the application and any extra required processes
+#                locally.
+
+set -e
+
+bundle exec rake


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- Puma workers reduced from 2 to single process. If we want to scale the app with more resources we can go horizontally with more containers, rather than horizontally.
- Docker Compose can be used to run local dev servers using Docker, included `script/server`
- Docker Compose can be used to run local test servers using Docker, included in the readme. Both Docker and Non-Docker options are referenced in the Readme as there are trade-offs to using each
- Refactor the Dockerfile into build layers to help debug a problem with the assets being unavailable only on CI