### PR TITLE
(53) Deploy to heroku with containers

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,13 +1,6 @@
 {
   "repository": "https://github.com/DFE-Digital/buy-for-your-school",
-  "buildpacks": [
-    {
-      "url": "heroku/nodejs"
-    },
-    {
-      "url": "heroku/ruby"
-    }
-  ],
+  "stack": "container",
   "addons": [
     "heroku-postgresql"
   ],

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,9 @@
+build:
+  docker:
+    web: Dockerfile
+release:
+  image: web
+  command:
+    - rake db:migrate
+run:
+  web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

Based ontop of https://github.com/DFE-Digital/buy-for-your-school/pull/40 which should be merged first.

I've spun up a [new Heroku app](https://dashboard.heroku.com/apps/dfe-bfys-docker-test) to test this, it can be looked at here https://dfe-bfys-docker-test.herokuapp.com/. The preview app works but should be deploying using the old buildpack strategy. 

Heroku will intercept the current git push and continue taking control of the deployment as it does now. This means GitHub Actions and Heroku will do duplicate Docker builds on the same Git SHA. There was potential for more work here to get GitHub Actions to build and push to a container registry and then instruct Heroku to pull and deploy the same artifact, reducing build times and deploying the exact artifact that was tested would be ideal. Given the move away from Heroku through Terraform to PaaS I thought it might be a bridge too far to invest any more time now in optimising the perfect deployment pipeline. One step at a time feels good.

## Changes in this PR

- remove Heroku buildpacks and replace it with the container stack
- existing environments appear to need require `heroku set:stack container` to be run before they will change over

## Next steps

- update all environments with the new stack command, remove old buildpacks to be double sure
- verify each deployment uses containers
- tear down the heroku environment used for docker testing