### PR TITLE
Refactor Contentful interactions into dedicated interface class

### DIFF
--- a/app/services/contentful_connector.rb
+++ b/app/services/contentful_connector.rb
@@ -1,0 +1,16 @@
+require "contentful"
+
+class ContentfulConnector
+  def initialize
+    @contentful_client ||= Contentful::Client.new(
+      api_url: ENV["CONTENTFUL_URL"],
+      space: ENV["CONTENTFUL_SPACE"],
+      environment: ENV["CONTENTFUL_ENVIRONMENT"],
+      access_token: ENV["CONTENTFUL_ACCESS_TOKEN"]
+    )
+  end
+
+  def get_entry_by_id(entry_id)
+    @contentful_client.entry(entry_id)
+  end
+end

--- a/spec/services/contentful_connector_spec.rb
+++ b/spec/services/contentful_connector_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe ContentfulConnector do
+  let(:contentful_url) { "preview.contentful" }
+  let(:contentful_space) { "abc" }
+  let(:contentful_environment) { "test" }
+  let(:contentful_access_token) { "123" }
+
+  around do |example|
+    ClimateControl.modify(
+      CONTENTFUL_URL: contentful_url,
+      CONTENTFUL_SPACE: contentful_space,
+      CONTENTFUL_ENVIRONMENT: contentful_environment,
+      CONTENTFUL_ACCESS_TOKEN: contentful_access_token
+    ) do
+      example.run
+    end
+  end
+
+  describe "#get_entry_by_id" do
+    it "returns a Contentful entry by making a call to Contentful" do
+      contentful_client = instance_double(Contentful::Client)
+      expect(Contentful::Client).to receive(:new)
+        .with(api_url: contentful_url,
+              space: contentful_space,
+              environment: contentful_environment,
+              access_token: contentful_access_token)
+        .and_return(contentful_client)
+
+      contentful_response = double(Contentful::Entry, id: "123")
+      expect(contentful_client).to receive(:entry)
+        .with("123")
+        .and_return(contentful_response)
+
+      result = described_class.new.get_entry_by_id("123")
+
+      expect(result).to eq(contentful_response)
+    end
+  end
+end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -5,14 +5,21 @@ module ContentfulHelpers
   )
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{fixture_filename}")
 
-    contentful_client = stub_contentful_client
+    contentful_connector = stub_contentful_connector
     contentful_response = fake_contentful_question_entry(contentful_fixture_filename: fixture_filename)
-    allow(contentful_client).to receive(:entry)
+    allow(contentful_connector).to receive(:get_entry_by_id)
       .with(entry_id)
       .and_return(contentful_response)
 
     allow(contentful_response).to receive(:raw)
       .and_return(raw_response)
+  end
+
+  def stub_contentful_connector
+    contentful_connector = instance_double(ContentfulConnector)
+    expect(ContentfulConnector).to receive(:new)
+      .and_return(contentful_connector)
+    contentful_connector
   end
 
   def stub_contentful_client


### PR DESCRIPTION
## Changes in this PR

Contentful interactions are now handled by the `ContentfulConnector` class, to better separate concerns and reduce duplication when different kinds of Contentful API calls are made in future.
