### PR TITLE
(112) Fix reading from the Redis cache

### DIFF
--- a/spec/requests/contentful_caching_spec.rb
+++ b/spec/requests/contentful_caching_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe "Contentful Caching", type: :request do
     plan = create(:plan, next_entry_id: "1UjQurSOi5MWkcRuGxdXZS")
 
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
-
-    RedisCache.redis.set("contentful:entry:1UjQurSOi5MWkcRuGxdXZS", raw_response)
+    RedisCache.redis.set("contentful:entry:1UjQurSOi5MWkcRuGxdXZS", JSON.dump(raw_response))
 
     expect_any_instance_of(Contentful::Client).not_to receive(:entry)
 
@@ -36,7 +35,7 @@ RSpec.describe "Contentful Caching", type: :request do
     get new_plan_question_path(plan)
 
     expect(RedisCache.redis.get("contentful:entry:1UjQurSOi5MWkcRuGxdXZS"))
-      .to eq(raw_response)
+      .to eq(JSON.dump(raw_response.to_json))
 
     RedisCache.redis.del("contentful:entry:1UjQurSOi5MWkcRuGxdXZS")
   end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Addresses https://rollbar.com/dxw/dfe-buy-for-your-school/items/31/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification

A string was being passed into the Redis cache that could not be parsed back out by `JSON.parse`. I should have run it locally one last time before creating the PR.

Instead of blindly storing the `entry.raw` JSON blob, we now serialise and deserialise it with `JSON.dump` and `JSON.restore`. 

Here's an illustration for how the data should change along the way before and after:

Before: 
```
Set -> 
  "{\"sys\"=>{\"space\"…
Get -> 
  JSON.parse('{"sys"=>{"space"…) -> 💥 JSON::ParseError
```

After: 
```
Set -> 
  "{"sys"=> {"space"=>".to_json -> "{\"sys\":{\"space\"
  JSON.dump("{\"sys\":{\"space\":) -> "\"{\\\"sys\\\":{\\\"space\\\": # This is what goes into Redis
Get -> 
  JSON.restore("\"{\\\"sys\\\":{\\\"space\\\":) -> "{\"sys\":{\"space\":
  JSON.parse("{\"sys\":{\"space\":) -> {"sys"=> {"space"=> # This is what's passed into Contentful::ResourceBuilder
```

There is a warning on the use of the `JSON.load` method [1] (aliased as `restore`) however since we are only using it to store trusted content from Contentful which only the team can edit, this is a "client under our control".

## Next steps

- [ ] Mark the rollbar event as resolved