### PR TITLE
(171) Automatically warm Contentful cache every night

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ ROLLBAR_ENV=development
 
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-development
 REDIS_CACHE_URL=redis://localhost:6379/1
+REDIS_SIDEKIQ_URL=redis://localhost:6379/2
 
 # Contentful
 CONTENTFUL_URL=cdn.contentful.com

--- a/.env.test
+++ b/.env.test
@@ -6,7 +6,8 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-test
-REDIS_CACHE_URL=redis://localhost:6379/2
+REDIS_CACHE_URL=redis://localhost:6379/11
+REDIS_SIDEKIQ_URL=redis://localhost:6379/12
 
 # Contentful
 CONTENTFUL_URL=cdn.contentful.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- fix primary key type on long_text_answers table to UUID
+- nightly task to warm the Contentful cache for all entries
+
 ## [release-003] - 2020-12-07
 
 - add database foreign key constraints for better data integrity
@@ -15,7 +18,6 @@ The format is based on [Keep a Changelog 1.0.0].
 - refactor name of "Question" to "Step"
 - refactor redis caching into reusable class
 - users can be shown a step in the journey that is only static content
-- fix primary key type on long_text_answers table to UUID
 
 ## [release-002] - 2020-11-16
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "rollbar"
 gem "rails", "~> 6.0.0"
 gem "sass-rails", "~> 6.0"
 gem "sidekiq", "~> 6.1"
+gem "sidekiq-cron", "~> 1.2"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uglifier", ">= 1.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "redis-namespace"
 gem "rollbar"
 gem "rails", "~> 6.0.0"
 gem "sass-rails", "~> 6.0"
+gem "sidekiq", "~> 6.1"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uglifier", ">= 1.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,8 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    et-orbi (1.2.4)
+      tzinfo
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -118,6 +120,9 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    fugit (1.4.1)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk_design_system_formbuilder (2.1.5)
@@ -179,6 +184,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.1.0)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -272,6 +278,9 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sidekiq-cron (1.2.0)
+      fugit (~> 1.1)
+      sidekiq (>= 4.2.1)
     simplecov (0.20.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -359,6 +368,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   sidekiq (~> 6.1)
+  sidekiq-cron (~> 1.2)
   simplecov
   spring
   spring-commands-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
+    connection_pool (2.2.3)
     contentful (2.15.4)
       http (> 0.8, < 5.0)
       multi_json (~> 1)
@@ -267,6 +268,10 @@ GEM
       rubyzip (>= 1.2.2)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     simplecov (0.20.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -353,6 +358,7 @@ DEPENDENCIES
   sass-rails (~> 6.0)
   selenium-webdriver
   shoulda-matchers
+  sidekiq (~> 6.1)
   simplecov
   spring
   spring-commands-rspec

--- a/app/jobs/warm_entry_cache_job.rb
+++ b/app/jobs/warm_entry_cache_job.rb
@@ -1,0 +1,22 @@
+class WarmEntryCacheJob < ApplicationJob
+  include CacheableEntry
+
+  queue_as :caching
+  sidekiq_options retry: 5
+
+  def perform
+    entries = GetAllContentfulEntries.new.call
+    entries.each do |entry|
+      store_in_cache(cache: cache, key: "contentful:entry:#{entry.id}", entry: entry)
+    end
+  end
+
+  private
+
+  def cache
+    @cache ||= Cache.new(
+      enabled: ENV.fetch("CONTENTFUL_ENTRY_CACHING"),
+      ttl: ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 60 * 60 * 48)
+    )
+  end
+end

--- a/app/jobs/warm_entry_cache_job.rb
+++ b/app/jobs/warm_entry_cache_job.rb
@@ -16,7 +16,7 @@ class WarmEntryCacheJob < ApplicationJob
   def cache
     @cache ||= Cache.new(
       enabled: ENV.fetch("CONTENTFUL_ENTRY_CACHING"),
-      ttl: ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 60 * 60 * 48)
+      ttl: ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 60 * 60 * 72)
     )
   end
 end

--- a/app/services/cache.rb
+++ b/app/services/cache.rb
@@ -1,8 +1,7 @@
 class Cache
   attr_accessor :enabled, :key, :ttl
-  def initialize(enabled:, key:, ttl:)
+  def initialize(enabled:, ttl:)
     self.enabled = enabled
-    self.key = key
     self.ttl = ttl
   end
 
@@ -10,7 +9,7 @@ class Cache
     @redis_cache ||= RedisCache.redis
   end
 
-  def hit?
+  def hit?(key:)
     if enabled == "true"
       redis_cache.exists?(key)
     else
@@ -18,11 +17,11 @@ class Cache
     end
   end
 
-  def get
+  def get(key:)
     redis_cache.get(key)
   end
 
-  def set(value:)
+  def set(key:, value:)
     return unless enabled == "true"
     redis_cache.set(key, value)
     redis_cache.expire(key, ttl)

--- a/app/services/concerns/cacheable_entry.rb
+++ b/app/services/concerns/cacheable_entry.rb
@@ -1,23 +1,23 @@
 module CacheableEntry
   extend ActiveSupport::Concern
 
-  def find_and_build_entry_from_cache(cache:)
+  def find_and_build_entry_from_cache(cache:, key:)
     Contentful::ResourceBuilder.new(
-      load_from_cache(cache: cache)
+      load_from_cache(cache: cache, key: key)
     ).run
   end
 
-  def store_in_cache(cache:, entry:)
+  def store_in_cache(cache:, key:, entry:)
     return unless entry.present? && entry.respond_to?(:raw)
 
-    cache.set(value: JSON.dump(entry.raw.to_json))
+    cache.set(key: key, value: JSON.dump(entry.raw.to_json))
   end
 
   private
 
-  def load_from_cache(cache:)
+  def load_from_cache(cache:, key:)
     # rubocop:disable Security/JSONLoad
-    serialised_json_string = cache.get
+    serialised_json_string = cache.get(key: key)
     unserialised_json_string = JSON.restore(serialised_json_string)
     JSON.parse(unserialised_json_string)
     # rubocop:enable Security/JSONLoad

--- a/app/services/concerns/cacheable_entry.rb
+++ b/app/services/concerns/cacheable_entry.rb
@@ -9,7 +9,6 @@ module CacheableEntry
 
   def store_in_cache(cache:, key:, entry:)
     return unless entry.present? && entry.respond_to?(:raw)
-
     cache.set(key: key, value: JSON.dump(entry.raw.to_json))
   end
 

--- a/app/services/get_contentful_entry.rb
+++ b/app/services/get_contentful_entry.rb
@@ -9,7 +9,7 @@ class GetContentfulEntry
     @contentful_connector = contentful_connector
     self.cache = Cache.new(
       enabled: ENV.fetch("CONTENTFUL_ENTRY_CACHING"),
-      ttl: ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 172_800) # 48 hours
+      ttl: ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 60 * 60 * 48)
     )
   end
 

--- a/app/services/get_contentful_entry.rb
+++ b/app/services/get_contentful_entry.rb
@@ -9,7 +9,7 @@ class GetContentfulEntry
     @contentful_connector = contentful_connector
     self.cache = Cache.new(
       enabled: ENV.fetch("CONTENTFUL_ENTRY_CACHING"),
-      ttl: ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 60 * 60 * 48)
+      ttl: ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 60 * 60 * 72)
     )
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,7 @@ module BuyForYourSchool
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
     end
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = {url: ENV["REDIS_SIDEKIQ_URL"]}
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {url: ENV["REDIS_SIDEKIQ_URL"]}
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,11 @@
 Sidekiq.configure_server do |config|
   config.redis = {url: ENV["REDIS_SIDEKIQ_URL"]}
+
+  # Sidekiq Cron
+  schedule_file = "config/schedule.yml"
+  if File.exist?(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+  end
 end
 
 Sidekiq.configure_client do |config|

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,8 @@
+warm_contentful_entry_cache:
+  cron: "0 3 * * *"
+  class: "WarmEntryCacheJob"
+  description: This is a content driven service and the content is sourced by
+    the Contentful API. As a single point of failure we have a Redis cache to
+    provide some resilience to downtime or minor connection issues. As this
+    service is used infrequently by real users, we automatically update the
+    cache.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,6 @@
+---
+:concurrency: 5
+:queues:
+  - default
+  - [high_priority, 2]
+  - [caching, 1]

--- a/doc/architecture/decisions/0008-use-sidekiq-for-asynchronous-tasks.md
+++ b/doc/architecture/decisions/0008-use-sidekiq-for-asynchronous-tasks.md
@@ -1,0 +1,28 @@
+# 8. use sidekiq for asynchronous tasks
+
+Date: 2020-11-30
+
+## Status
+
+Accepted
+
+## Context
+
+We need a way for the service to automatically and regularly run a task.
+
+We already have Redis available as our caching layer and Sidekiq works great with it.
+
+An alternative could be to use Cron for scheduled tasks and a postgres backed asynchronous jobs, perhaps even run inline. We know how to get Sidekiq running with Docker and reusing Redis (rather than Postgres) for job data that is ephemeral feels a better fit given we already have Redis.
+
+## Decision
+
+Use Sidekiq for processing asynchronous tasks.
+
+## Consequences
+
+- We add another process/box of complexity to the system architecture though we would need to do this with Cron too
+- It should take less time to add another asynchronous task in future
+- It should take less time to add another scheduled task
+- A clear separation of concerns between persistent data being in Postgres and ephemeral data in Redis
+- Sidekiq can manage the scheduled task queue on initialiser which automatically takes care of provisioning jobs on all environments
+- Adding Sidekiq takes more time now and will require another widget to Terraform when moving to GPaaS. We have done this before.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     ports:
       - "3000:3000"
+    image: "buy_for_your_school:dev"
     depends_on:
       - db
       - redis
@@ -17,6 +18,7 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:password@db:5432/buy-for-your-school-development
       REDIS_CACHE_URL: redis://redis:6379/1
+      REDIS_SIDEKIQ_URL: redis://redis:6379/2
     volumes:
       - .:/srv/app
     tty: true
@@ -37,6 +39,17 @@ services:
     image: redis
     volumes:
       - redis-data:/data
+    networks:
+      - dev
+
+  sidekiq:
+    image: buy_for_your_school:dev
+    command: bundle exec sidekiq -C config/sidekiq.yml
+    depends_on:
+      - db
+      - redis
+    volumes:
+      - .:/srv/app
     networks:
       - dev
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -7,3 +7,7 @@ release:
     - rake db:migrate
 run:
   web: bundle exec puma -C config/puma.rb
+  worker:
+    command:
+      - bundle exec sidekiq -C config/sidekiq.yml
+    image: web

--- a/spec/fixtures/contentful/multiple-entries-example.json
+++ b/spec/fixtures/contentful/multiple-entries-example.json
@@ -1,0 +1,102 @@
+{
+    "sys": {
+        "type": "Array"
+    },
+    "total": 5,
+    "skip": 0,
+    "limit": 100,
+    "items": [
+        {
+            "sys": {
+                "space": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Space",
+                        "id": "rwl7tyzv9sys"
+                    }
+                },
+                "id": "5kZ9hIFDvNCEhjWs72SFwj",
+                "type": "Entry",
+                "createdAt": "2020-12-02T10:48:35.748Z",
+                "updatedAt": "2020-12-02T10:48:35.748Z",
+                "environment": {
+                    "sys": {
+                        "id": "develop",
+                        "type": "Link",
+                        "linkType": "Environment"
+                    }
+                },
+                "revision": 1,
+                "contentType": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "ContentType",
+                        "id": "staticContent"
+                    }
+                },
+                "locale": "en-US"
+            },
+            "fields": {
+                "slug": "/timelines",
+                "title": "When you should start",
+                "body": "Procuring a new catering contract can take up to 6 months to consult, create, review and award. \n\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.",
+                "type": "paragraphs",
+                "next": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Entry",
+                        "id": "hfjJgWRg4xiiiImwVRDtZ"
+                    }
+                }
+            }
+        },
+        {
+            "sys": {
+                "space": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Space",
+                        "id": "rwl7tyzv9sys"
+                    }
+                },
+                "id": "52Ni9UFvZj8BYXSbhs373C",
+                "type": "Entry",
+                "createdAt": "2020-11-04T12:28:30.442Z",
+                "updatedAt": "2020-11-26T16:39:54.188Z",
+                "environment": {
+                    "sys": {
+                        "id": "develop",
+                        "type": "Link",
+                        "linkType": "Environment"
+                    }
+                },
+                "revision": 6,
+                "contentType": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "ContentType",
+                        "id": "question"
+                    }
+                },
+                "locale": "en-US"
+            },
+            "fields": {
+                "slug": "/dev-start-which-service",
+                "title": "Which service do you need?",
+                "helpText": "Tell us which service you need.",
+                "type": "radios",
+                "options": [
+                    "Catering",
+                    "Cleaning"
+                ],
+                "next": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Entry",
+                        "id": "hfjJgWRg4xiiiImwVRDtZ"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/spec/jobs/warm_entry_cache_job_spec.rb
+++ b/spec/jobs/warm_entry_cache_job_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe WarmEntryCacheJob, type: :job do
+  include ActiveJob::TestHelper
+
+  before(:each) { ActiveJob::Base.queue_adapter = :test }
+
+  around do |example|
+    ClimateControl.modify(
+      CONTENTFUL_ENTRY_CACHING: "true"
+    ) do
+      example.run
+    end
+  end
+
+  describe ".perform_later" do
+    it "enqueues a job asynchronously on the caching queue" do
+      expect {
+        described_class.perform_later
+      }.to have_enqueued_job.on_queue("caching")
+    end
+
+    it "asks GetAllContentfulEntries for the Contentful entries" do
+      raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/multiple-entries-example.json")
+      response_hash = JSON.parse(raw_response)
+      fake_contentful_entry_array = Contentful::ResourceBuilder.new(response_hash).run
+
+      get_all_contentful_entries_double = instance_double(GetAllContentfulEntries)
+      allow(GetAllContentfulEntries).to receive(:new).and_return(get_all_contentful_entries_double)
+      allow(get_all_contentful_entries_double).to receive(:call).and_return(fake_contentful_entry_array)
+
+      perform_enqueued_jobs do
+        described_class.perform_later
+      end
+
+      expect(RedisCache.redis.get("contentful:entry:5kZ9hIFDvNCEhjWs72SFwj"))
+        .to eql(
+          "\"{\\\"sys\\\":{\\\"space\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Space\\\",\\\"id\\\":\\\"rwl7tyzv9sys\\\"}},\\\"id\\\":\\\"5kZ9hIFDvNCEhjWs72SFwj\\\",\\\"type\\\":\\\"Entry\\\",\\\"createdAt\\\":\\\"2020-12-02T10:48:35.748Z\\\",\\\"updatedAt\\\":\\\"2020-12-02T10:48:35.748Z\\\",\\\"environment\\\":{\\\"sys\\\":{\\\"id\\\":\\\"develop\\\",\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Environment\\\"}},\\\"revision\\\":1,\\\"contentType\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"ContentType\\\",\\\"id\\\":\\\"staticContent\\\"}},\\\"locale\\\":\\\"en-US\\\"},\\\"fields\\\":{\\\"slug\\\":\\\"/timelines\\\",\\\"title\\\":\\\"When you should start\\\",\\\"body\\\":\\\"Procuring a new catering contract can take up to 6 months to consult, create, review and award. \\\\n\\\\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.\\\",\\\"type\\\":\\\"paragraphs\\\",\\\"next\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Entry\\\",\\\"id\\\":\\\"hfjJgWRg4xiiiImwVRDtZ\\\"}}}}\""
+        )
+      expect(RedisCache.redis.get("contentful:entry:52Ni9UFvZj8BYXSbhs373C"))
+        .to eql(
+          "\"{\\\"sys\\\":{\\\"space\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Space\\\",\\\"id\\\":\\\"rwl7tyzv9sys\\\"}},\\\"id\\\":\\\"52Ni9UFvZj8BYXSbhs373C\\\",\\\"type\\\":\\\"Entry\\\",\\\"createdAt\\\":\\\"2020-11-04T12:28:30.442Z\\\",\\\"updatedAt\\\":\\\"2020-11-26T16:39:54.188Z\\\",\\\"environment\\\":{\\\"sys\\\":{\\\"id\\\":\\\"develop\\\",\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Environment\\\"}},\\\"revision\\\":6,\\\"contentType\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"ContentType\\\",\\\"id\\\":\\\"question\\\"}},\\\"locale\\\":\\\"en-US\\\"},\\\"fields\\\":{\\\"slug\\\":\\\"/dev-start-which-service\\\",\\\"title\\\":\\\"Which service do you need?\\\",\\\"helpText\\\":\\\"Tell us which service you need.\\\",\\\"type\\\":\\\"radios\\\",\\\"options\\\":[\\\"Catering\\\",\\\"Cleaning\\\"],\\\"next\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Entry\\\",\\\"id\\\":\\\"hfjJgWRg4xiiiImwVRDtZ\\\"}}}}\""
+        )
+    end
+  end
+end

--- a/spec/requests/contentful_caching_spec.rb
+++ b/spec/requests/contentful_caching_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Contentful Caching", type: :request do
     RedisCache.redis.del("contentful:entry:1UjQurSOi5MWkcRuGxdXZS")
   end
 
-  it "sets a TTL to 48 hours by default" do
+  it "sets a TTL to 72 hours by default" do
     journey = create(:journey, next_entry_id: "1UjQurSOi5MWkcRuGxdXZS")
     stub_get_contentful_entry(
       entry_id: "1UjQurSOi5MWkcRuGxdXZS",
@@ -51,7 +51,7 @@ RSpec.describe "Contentful Caching", type: :request do
       get new_journey_step_path(journey)
 
       expect(RedisCache.redis.ttl("contentful:entry:1UjQurSOi5MWkcRuGxdXZS"))
-        .to eq(172_800)
+        .to eq(60 * 60 * 72)
     end
 
     RedisCache.redis.del("contentful:entry:1UjQurSOi5MWkcRuGxdXZS")

--- a/spec/services/cache_spec.rb
+++ b/spec/services/cache_spec.rb
@@ -2,15 +2,14 @@ require "rails_helper"
 
 RSpec.describe Cache do
   it "requires a key, enabled flag and ttl" do
-    result = described_class.new(key: "redis-key", enabled: "true", ttl: 123)
-    expect(result.key).to eql("redis-key")
+    result = described_class.new(enabled: "true", ttl: 123)
     expect(result.enabled).to eql("true")
     expect(result.ttl).to eql(123)
   end
 
   describe "#redis_cache" do
     it "returns an object that quacks like a redis instance (since MockRedis is used in Test)" do
-      result = described_class.new(key: anything, enabled: anything, ttl: anything)
+      result = described_class.new(enabled: anything, ttl: anything)
         .redis_cache
 
       expect(result.respond_to?(:get)).to eq(true)
@@ -23,23 +22,23 @@ RSpec.describe Cache do
   describe "#hit?" do
     context "when enabled" do
       it "asks redis if that key exists" do
-        cache = described_class.new(key: "key-to-find", enabled: "true", ttl: anything)
+        cache = described_class.new(enabled: "true", ttl: anything)
         redis = cache.redis_cache
 
         expect(redis).to receive(:exists?).with("key-to-find")
 
-        cache.hit?
+        cache.hit?(key: "key-to-find")
       end
     end
 
     context "when disabled" do
       it "returns false" do
-        cache = described_class.new(key: "key-to-find", enabled: "false", ttl: anything)
+        cache = described_class.new(enabled: "false", ttl: anything)
         redis = cache.redis_cache
 
         expect(redis).not_to receive(:exists?).with("key-to-find")
 
-        result = cache.hit?
+        result = cache.hit?(key: "key-to-find")
         expect(result).to eq(false)
       end
     end
@@ -47,37 +46,37 @@ RSpec.describe Cache do
 
   describe "#get" do
     it "asks redis to get that key" do
-      cache = described_class.new(key: "key-to-find", enabled: "false", ttl: anything)
+      cache = described_class.new(enabled: "false", ttl: anything)
       redis = cache.redis_cache
 
       expect(redis).to receive(:get).with("key-to-find")
 
-      cache.get
+      cache.get(key: "key-to-find")
     end
   end
 
   describe "#set" do
     context "when enabled" do
       it "asks redis to set that key with the ttl" do
-        cache = described_class.new(key: "key-to-set", enabled: "true", ttl: 123)
+        cache = described_class.new(enabled: "true", ttl: 123)
         redis = cache.redis_cache
 
         expect(redis).to receive(:set).with("key-to-set", "value-to-set")
         expect(redis).to receive(:expire).with("key-to-set", 123)
 
-        cache.set(value: "value-to-set")
+        cache.set(key: "key-to-set", value: "value-to-set")
       end
     end
 
     context "when disabled" do
       it "does not ask redis to set that key" do
-        cache = described_class.new(key: "key-to-set", enabled: "false", ttl: 123)
+        cache = described_class.new(enabled: "false", ttl: 123)
         redis = cache.redis_cache
 
         expect(redis).not_to receive(:set).with("key-to-set", "value-to-set")
         expect(redis).not_to receive(:expire).with("key-to-set", 123)
 
-        cache.set(value: "value-to-set")
+        cache.set(key: "key-to-set", value: "value-to-set")
       end
     end
   end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- install Sidekiq to enable asynchronous tasks
- install Sidekiq Cron to enable schedule asynchronous tasks. When Sidekiq is initialised the contents of the schedule.yml is automatically seeded into Redis
- refactor the way we send cache key information to the Cache class to make it reusable for this work
- get all Contentful entries and update their cached values **every night at 3am**

Remember if you'd like to test this locally to turn caching on with the `CONTENTFUL_ENTRY_CACHING` environment variable.

## Screenshots
![Screenshot 2020-12-03 at 15 33 31](https://user-images.githubusercontent.com/912473/101051013-eb9bb880-357c-11eb-8ddf-1156999fcfb8.png)

## Next steps

- [x] set new environment variables on all Heroku environments for `REDIS_SIDEKIQ_URL`. Copy the same value from`REDIS_URL` and add a new database onto the end name eg. `/1`, so long as it's different from the `REDIS_CACHE_URL`.