### PR TITLE
(171) Refactor contentful caching for reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - service name included in the header
 - refactor name of "Plan" to "Journey"
 - refactor name of "Question" to "Step"
+- refactor redis caching into reusable class
 
 ## [release-002] - 2020-11-16
 

--- a/app/services/cache.rb
+++ b/app/services/cache.rb
@@ -1,0 +1,30 @@
+class Cache
+  attr_accessor :enabled, :key, :ttl
+  def initialize(enabled:, key:, ttl:)
+    self.enabled = enabled
+    self.key = key
+    self.ttl = ttl
+  end
+
+  def redis_cache
+    @redis_cache ||= RedisCache.redis
+  end
+
+  def hit?
+    if enabled == "true"
+      redis_cache.exists?(key)
+    else
+      false
+    end
+  end
+
+  def get
+    redis_cache.get(key)
+  end
+
+  def set(value:)
+    return unless enabled == "true"
+    redis_cache.set(key, value)
+    redis_cache.expire(key, ttl)
+  end
+end

--- a/app/services/concerns/cacheable_entry.rb
+++ b/app/services/concerns/cacheable_entry.rb
@@ -1,0 +1,25 @@
+module CacheableEntry
+  extend ActiveSupport::Concern
+
+  def find_and_build_entry_from_cache(cache:)
+    Contentful::ResourceBuilder.new(
+      load_from_cache(cache: cache)
+    ).run
+  end
+
+  def store_in_cache(cache:, entry:)
+    return unless entry.present? && entry.respond_to?(:raw)
+
+    cache.set(value: JSON.dump(entry.raw.to_json))
+  end
+
+  private
+
+  def load_from_cache(cache:)
+    # rubocop:disable Security/JSONLoad
+    serialised_json_string = cache.get
+    unserialised_json_string = JSON.restore(serialised_json_string)
+    JSON.parse(unserialised_json_string)
+    # rubocop:enable Security/JSONLoad
+  end
+end

--- a/app/services/get_contentful_entry.rb
+++ b/app/services/get_contentful_entry.rb
@@ -1,15 +1,20 @@
 class GetContentfulEntry
   class EntryNotFound < StandardError; end
 
-  attr_accessor :entry_id
+  attr_accessor :entry_id, :cache
 
   def initialize(entry_id:, contentful_connector: ContentfulConnector.new)
     self.entry_id = entry_id
     @contentful_connector = contentful_connector
+    self.cache = Cache.new(
+      enabled: ENV.fetch("CONTENTFUL_ENTRY_CACHING"),
+      key: "contentful:entry:#{entry_id}",
+      ttl: ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 172_800) # 48 hours
+    )
   end
 
   def call
-    if cache_hit?
+    if cache.hit?
       entry = find_and_build_from_cache
     else
       entry = @contentful_connector.get_entry_by_id(entry_id)
@@ -36,43 +41,21 @@ class GetContentfulEntry
     )
   end
 
-  def cache_key
-    @cache_key ||= "contentful:entry:#{entry_id}"
+  def store_in_cache(entry:)
+    return unless entry.present? && entry.respond_to?(:raw)
+
+    cache.set(value: JSON.dump(entry.raw.to_json))
   end
 
-  def cache_hit?
-    if ENV["CONTENTFUL_ENTRY_CACHING"] == "true"
-      redis_cache.exists?(cache_key)
-    else
-      false
-    end
-  end
-
-  def cache_ttl
-    ENV.fetch("CONTENTFUL_ENTRY_CACHING_TTL", 172_800) # 48 hours
-  end
-
-  def find_in_cache
+  def load_from_cache
     # rubocop:disable Security/JSONLoad
-    serialised_json_string = redis_cache.get(cache_key)
+    serialised_json_string = cache.get
     unserialised_json_string = JSON.restore(serialised_json_string)
     JSON.parse(unserialised_json_string)
     # rubocop:enable Security/JSONLoad
   end
 
-  def store_in_cache(entry:)
-    return unless ENV["CONTENTFUL_ENTRY_CACHING"] == "true"
-    return unless entry.present? && entry.respond_to?(:raw)
-
-    redis_cache.set(cache_key, JSON.dump(entry.raw.to_json))
-    redis_cache.expire(cache_key, cache_ttl)
-  end
-
   def find_and_build_from_cache
-    Contentful::ResourceBuilder.new(find_in_cache).run
-  end
-
-  def redis_cache
-    RedisCache.redis
+    Contentful::ResourceBuilder.new(load_from_cache).run
   end
 end

--- a/app/services/get_contentful_entry.rb
+++ b/app/services/get_contentful_entry.rb
@@ -1,5 +1,6 @@
 class GetContentfulEntry
   class EntryNotFound < StandardError; end
+  include CacheableEntry
 
   attr_accessor :entry_id, :cache
 
@@ -15,10 +16,10 @@ class GetContentfulEntry
 
   def call
     if cache.hit?
-      entry = find_and_build_from_cache
+      entry = find_and_build_entry_from_cache(cache: cache)
     else
       entry = @contentful_connector.get_entry_by_id(entry_id)
-      store_in_cache(entry: entry)
+      store_in_cache(cache: cache, entry: entry)
     end
 
     if entry.nil?
@@ -39,23 +40,5 @@ class GetContentfulEntry
       contentful_environment: ENV["CONTENTFUL_ENVIRONMENT"],
       contentful_entry_id: entry_id
     )
-  end
-
-  def store_in_cache(entry:)
-    return unless entry.present? && entry.respond_to?(:raw)
-
-    cache.set(value: JSON.dump(entry.raw.to_json))
-  end
-
-  def load_from_cache
-    # rubocop:disable Security/JSONLoad
-    serialised_json_string = cache.get
-    unserialised_json_string = JSON.restore(serialised_json_string)
-    JSON.parse(unserialised_json_string)
-    # rubocop:enable Security/JSONLoad
-  end
-
-  def find_and_build_from_cache
-    Contentful::ResourceBuilder.new(load_from_cache).run
   end
 end

--- a/spec/services/cache_spec.rb
+++ b/spec/services/cache_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe Cache do
+  it "requires a key, enabled flag and ttl" do
+    result = described_class.new(key: "redis-key", enabled: "true", ttl: 123)
+    expect(result.key).to eql("redis-key")
+    expect(result.enabled).to eql("true")
+    expect(result.ttl).to eql(123)
+  end
+
+  describe "#redis_cache" do
+    it "returns an object that quacks like a redis instance (since MockRedis is used in Test)" do
+      result = described_class.new(key: anything, enabled: anything, ttl: anything)
+        .redis_cache
+
+      expect(result.respond_to?(:get)).to eq(true)
+      expect(result.respond_to?(:set)).to eq(true)
+      expect(result.respond_to?(:exists?)).to eq(true)
+      expect(result.respond_to?(:expire)).to eq(true)
+    end
+  end
+
+  describe "#hit?" do
+    context "when enabled" do
+      it "asks redis if that key exists" do
+        cache = described_class.new(key: "key-to-find", enabled: "true", ttl: anything)
+        redis = cache.redis_cache
+
+        expect(redis).to receive(:exists?).with("key-to-find")
+
+        cache.hit?
+      end
+    end
+
+    context "when disabled" do
+      it "returns false" do
+        cache = described_class.new(key: "key-to-find", enabled: "false", ttl: anything)
+        redis = cache.redis_cache
+
+        expect(redis).not_to receive(:exists?).with("key-to-find")
+
+        result = cache.hit?
+        expect(result).to eq(false)
+      end
+    end
+  end
+
+  describe "#get" do
+    it "asks redis to get that key" do
+      cache = described_class.new(key: "key-to-find", enabled: "false", ttl: anything)
+      redis = cache.redis_cache
+
+      expect(redis).to receive(:get).with("key-to-find")
+
+      cache.get
+    end
+  end
+
+  describe "#set" do
+    context "when enabled" do
+      it "asks redis to set that key with the ttl" do
+        cache = described_class.new(key: "key-to-set", enabled: "true", ttl: 123)
+        redis = cache.redis_cache
+
+        expect(redis).to receive(:set).with("key-to-set", "value-to-set")
+        expect(redis).to receive(:expire).with("key-to-set", 123)
+
+        cache.set(value: "value-to-set")
+      end
+    end
+
+    context "when disabled" do
+      it "does not ask redis to set that key" do
+        cache = described_class.new(key: "key-to-set", enabled: "false", ttl: 123)
+        redis = cache.redis_cache
+
+        expect(redis).not_to receive(:set).with("key-to-set", "value-to-set")
+        expect(redis).not_to receive(:expire).with("key-to-set", 123)
+
+        cache.set(value: "value-to-set")
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- generic Redis caching methods extracted into reusable caching object which introduces the opportunity for more unit test coverage, which I take
- specific Contentful Entry caching logic extracted into a reusable mixin. A new class didn't feel appropriate given the specificity of the contents

These changes should make it easier to add cache behaviour in the automated nightly task that is going to warm up the cache. Instead of getting an individual Entry and caching, it will get all Entries and cache every result. 