### PR TITLE
Fix form flow failures

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -19,9 +19,17 @@ class StepsController < ApplicationController
     return redirect_to journey_path(@journey) unless @journey.next_entry_id.present?
 
     contentful_entry = GetContentfulEntry.new(entry_id: @journey.next_entry_id).call
-    @step, @answer = CreateJourneyStep.new(
+    @step = CreateJourneyStep.new(
       journey: @journey, contentful_entry: contentful_entry
     ).call
+
+    redirect_to journey_step_path(@journey, @step)
+  end
+
+  def show
+    @journey = Journey.find(journey_id)
+    @step = Step.find(params[:id])
+    @answer = AnswerFactory.new(step: @step).call
 
     render "new.#{@step.contentful_type}"
   end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -16,7 +16,7 @@ class StepsController < ApplicationController
   def new
     @journey = Journey.find(journey_id)
 
-    redirect_to journey_path(@journey) unless @journey.next_entry_id.present?
+    return redirect_to journey_path(@journey) unless @journey.next_entry_id.present?
 
     contentful_entry = GetContentfulEntry.new(entry_id: @journey.next_entry_id).call
     @step, @answer = CreateJourneyStep.new(

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -34,7 +34,7 @@ class CreateJourneyStep
 
     journey.update(next_entry_id: next_entry_id)
 
-    [step, AnswerFactory.new(step: step).call]
+    step
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   root to: "high_voltage/pages#show", id: "planning_start_page"
 
   resources :journeys, only: [:new, :show] do
-    resources :steps, only: [:new] do
+    resources :steps, only: [:new, :show] do
       resources :answers, only: [:create]
     end
   end

--- a/spec/requests/contentful_caching_spec.rb
+++ b/spec/requests/contentful_caching_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Contentful Caching", type: :request do
 
     get new_journey_step_path(journey)
 
-    expect(response).to have_http_status(:success)
+    expect(response).to have_http_status(:found)
 
     RedisCache.redis.del("contentful:entry:1UjQurSOi5MWkcRuGxdXZS")
   end

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CreateJourneyStep do
           contentful_fixture_filename: "radio-question-example.json"
         )
 
-        step, _answer = described_class.new(journey: journey, contentful_entry: fake_entry).call
+        step = described_class.new(journey: journey, contentful_entry: fake_entry).call
 
         expect(step.title).to eq("Which service do you need?")
         expect(step.help_text).to eq("Tell us which service you need.")
@@ -24,46 +24,20 @@ RSpec.describe CreateJourneyStep do
           contentful_fixture_filename: "has-next-question-example.json"
         )
 
-        _step, _answer = described_class.new(journey: journey, contentful_entry: fake_entry).call
+        _step = described_class.new(journey: journey, contentful_entry: fake_entry).call
 
         expect(journey.next_entry_id).to eql("5lYcZs1ootDrOnk09LDLZg")
       end
     end
 
-    context "when the step is of type 'radios'" do
-      it "returns a fresh RadioAnswer object" do
-        journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
-          contentful_fixture_filename: "radio-question-example.json"
-        )
-
-        _step, answer = described_class.new(journey: journey, contentful_entry: fake_entry).call
-
-        expect(answer).to be_kind_of(RadioAnswer)
-        expect(answer.response).to eql(nil)
-      end
-    end
-
     context "when the question is of type 'short_text'" do
-      it "returns a fresh ShortTextAnswer object" do
-        journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
-          contentful_fixture_filename: "short-text-question-example.json"
-        )
-
-        _step, answer = described_class.new(journey: journey, contentful_entry: fake_entry).call
-
-        expect(answer).to be_kind_of(ShortTextAnswer)
-        expect(answer.response).to eql(nil)
-      end
-
       it "sets help_text and options to nil" do
         journey = create(:journey, :catering)
         fake_entry = fake_contentful_step_entry(
           contentful_fixture_filename: "short-text-question-example.json"
         )
 
-        step, _answer = described_class.new(journey: journey, contentful_entry: fake_entry).call
+        step = described_class.new(journey: journey, contentful_entry: fake_entry).call
 
         expect(step.options).to eq(nil)
       end
@@ -74,7 +48,7 @@ RSpec.describe CreateJourneyStep do
           contentful_fixture_filename: "short-text-question-example.json"
         )
 
-        step, _answer = described_class.new(journey: journey, contentful_entry: fake_entry).call
+        step = described_class.new(journey: journey, contentful_entry: fake_entry).call
 
         expect(step.contentful_type).to eq("short_text")
       end
@@ -87,7 +61,7 @@ RSpec.describe CreateJourneyStep do
           contentful_fixture_filename: "radio-question-example.json"
         )
 
-        _step, _answer = described_class.new(journey: journey, contentful_entry: fake_entry).call
+        _step = described_class.new(journey: journey, contentful_entry: fake_entry).call
 
         expect(journey.next_entry_id).to eql(nil)
       end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- [fix DoubleRenderError](https://rollbar.com/dxw/dfe-buy-for-your-school/items/34/)
- fix bug which allowed a user to easily refresh a question page to get to the next question. You can test this by going to https://dfe-buy-for-your-school-beta-s.herokuapp.com/plans/b313b903-319f-45fb-9bb5-f0cc1a2608ca/questions/new and refreshing your browser. After this change it is still technically possible for this to happen *if* a user manually edits/hacks the URL back to `question/new`. The chances of this are small, the impact is the plan#show blows up. We may wish to add additonal guard logic to question#new to protect against this if it becomes a problem. I'm concious not all steps will require answers so it might be better to wait.
