### PR TITLE
(179) Show static content from Contentful as a journey step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - refactor name of "Plan" to "Journey"
 - refactor name of "Question" to "Step"
 - refactor redis caching into reusable class
+- users can be shown a step in the journey that is only static content
 
 ## [release-002] - 2020-11-16
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -13,4 +13,8 @@ class Step < ApplicationRecord
   def answer
     @answer ||= radio_answer || short_text_answer || long_text_answer
   end
+
+  def question?
+    contentful_model == "question"
+  end
 end

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -3,8 +3,8 @@ class CreateJourneyStep
 
   class UnexpectedContentfulStepType < StandardError; end
 
-  ALLOWED_CONTENTFUL_MODELS = %w[question].freeze
-  ALLOWED_CONTENTFUL_QUESTION_TYPES = %w[radios short_text long_text].freeze
+  ALLOWED_CONTENTFUL_MODELS = %w[question staticContent].freeze
+  ALLOWED_CONTENTFUL_QUESTION_TYPES = %w[radios short_text long_text paragraphs].freeze
 
   attr_accessor :journey, :contentful_entry
   def initialize(journey:, contentful_entry:)
@@ -26,6 +26,7 @@ class CreateJourneyStep
     step = Step.create(
       title: title,
       help_text: help_text,
+      body: body,
       contentful_model: content_model,
       contentful_type: step_type,
       options: options,
@@ -71,6 +72,11 @@ class CreateJourneyStep
   def help_text
     return nil unless contentful_entry.respond_to?(:help_text)
     contentful_entry.help_text
+  end
+
+  def body
+    return nil unless contentful_entry.respond_to?(:body)
+    contentful_entry.body
   end
 
   def options

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -26,6 +26,7 @@ class CreateJourneyStep
     step = Step.create(
       title: title,
       help_text: help_text,
+      contentful_model: content_model,
       contentful_type: step_type,
       options: options,
       raw: raw,

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -4,7 +4,7 @@ class CreateJourneyStep
   class UnexpectedContentfulStepType < StandardError; end
 
   ALLOWED_CONTENTFUL_MODELS = %w[question staticContent].freeze
-  ALLOWED_CONTENTFUL_QUESTION_TYPES = %w[radios short_text long_text paragraphs].freeze
+  ALLOWED_CONTENTFUL_ENTRY_TYPES = %w[radios short_text long_text paragraphs].freeze
 
   attr_accessor :journey, :contentful_entry
   def initialize(journey:, contentful_entry:)
@@ -58,7 +58,7 @@ class CreateJourneyStep
   end
 
   def expected_contentful_step_type?
-    ALLOWED_CONTENTFUL_QUESTION_TYPES.include?(step_type)
+    ALLOWED_CONTENTFUL_ENTRY_TYPES.include?(step_type)
   end
 
   def unexpected_contentful_step_type?
@@ -107,7 +107,7 @@ class CreateJourneyStep
       content_model: content_model,
       step_type: step_type,
       allowed_content_models: ALLOWED_CONTENTFUL_MODELS.join(", "),
-      allowed_step_types: ALLOWED_CONTENTFUL_QUESTION_TYPES.join(", ")
+      allowed_step_types: ALLOWED_CONTENTFUL_ENTRY_TYPES.join(", ")
     )
   end
 end

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -4,7 +4,7 @@ class CreateJourneyStep
   class UnexpectedContentfulStepType < StandardError; end
 
   ALLOWED_CONTENTFUL_MODELS = %w[question].freeze
-  ALLOWED_CONTENTFUL_QUESTION_TYPES = ["radios", "short_text", "long_text"].freeze
+  ALLOWED_CONTENTFUL_QUESTION_TYPES = %w[radios short_text long_text].freeze
 
   attr_accessor :journey, :contentful_entry
   def initialize(journey:, contentful_entry:)

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -3,6 +3,8 @@
 <h1 class="govuk-heading-xl"><%= @journey.category.capitalize %></h1>
 <dl class="govuk-summary-list">
   <% @journey.steps.each do |step| %>
-    <%= render "#{step.contentful_type}_answer", step: step, answer: step.answer %>
+    <% if step.question? %>
+      <%= render "#{step.contentful_type}_answer", step: step, answer: step.answer %>
+    <% end %>
   <% end %>
 </dl>

--- a/app/views/steps/new.paragraphs.html.erb
+++ b/app/views/steps/new.paragraphs.html.erb
@@ -1,0 +1,7 @@
+<%= content_for :title, @step.title %>
+
+<h1 class="govuk-heading-xl"><%= @step.title %></h1>
+<div class="static-content">
+  <%= simple_format(@step.body, wrapper_tag: "p", class: "govuk-body") %>
+</div>
+<%= link_to I18n.t("generic.button.next"), new_journey_step_path, class: "govuk-button" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
   generic:
     button:
       start: "Continue"
+      next: "Continue"
       soft_finish: "Save and continue later"
   banner:
     beta:

--- a/db/migrate/20201202105320_add_body_to_steps.rb
+++ b/db/migrate/20201202105320_add_body_to_steps.rb
@@ -1,0 +1,5 @@
+class AddBodyToSteps < ActiveRecord::Migration[6.0]
+  def change
+    add_column :steps, :body, :text
+  end
+end

--- a/db/migrate/20201202150359_add_contentful_model_to_step.rb
+++ b/db/migrate/20201202150359_add_contentful_model_to_step.rb
@@ -1,0 +1,10 @@
+class AddContentfulModelToStep < ActiveRecord::Migration[6.0]
+  def up
+    add_column :steps, :contentful_model, :string
+    Step.update_all(contentful_model: "question")
+  end
+
+  def down
+    remove_column :steps, :contentful_model
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_105320) do
+ActiveRecord::Schema.define(version: 2020_12_02_150359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2020_12_02_105320) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
+    t.string "contentful_model"
     t.index ["journey_id"], name: "index_steps_on_journey_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_155247) do
+ActiveRecord::Schema.define(version: 2020_12_02_105320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_155247) do
     t.binary "raw", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "body"
     t.index ["journey_id"], name: "index_steps_on_journey_id"
   end
 

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -8,18 +8,21 @@ FactoryBot.define do
 
     trait :radio do
       options { ["Red", "Green", "Blue"] }
+      contentful_model { "question" }
       contentful_type { "radios" }
       association :radio_answer
     end
 
     trait :short_text do
       options { nil }
+      contentful_model { "question" }
       contentful_type { "short_text" }
       association :short_text_answer
     end
 
     trait :long_text do
       options { nil }
+      contentful_model { "question" }
       contentful_type { "long_text" }
       association :long_text_answer
     end

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -26,5 +26,12 @@ FactoryBot.define do
       contentful_type { "long_text" }
       association :long_text_answer
     end
+
+    trait :static_content do
+      options { nil }
+      contentful_model { "staticContent" }
+      contentful_type { "paragraphs" }
+      association :paragraph_content
+    end
   end
 end

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -135,7 +135,39 @@ feature "Anyone can start a journey" do
     end
   end
 
-  context "when Contentful entry model wasn't a type of step" do
+  context "when Contentful entry is of type static_content" do
+    around do |example|
+      ClimateControl.modify(
+        CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+      ) do
+        example.run
+      end
+    end
+
+    scenario "user can read static content and proceed without answering" do
+      stub_get_contentful_entry(
+        entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+        fixture_filename: "static-content-example.json"
+      )
+
+      visit root_path
+      click_on(I18n.t("generic.button.start"))
+
+      expect(page).to have_content("When you should start")
+
+      within(".static-content") do
+        paragraphs_elements = find_all("p")
+        expect(paragraphs_elements.first.text).to have_content("Procuring a new catering contract can take up to 6 months to consult, create, review and award.")
+        expect(paragraphs_elements.last.text).to have_content("Usually existing contracts start and end in the month of September. We recommend starting this process around March.")
+      end
+
+      click_on(I18n.t("generic.button.next"))
+
+      expect(page).to have_content("Catering")
+    end
+  end
+
+  context "when Contentful entry model wasn't a type of question" do
     around do |example|
       ClimateControl.modify(
         CONTENTFUL_PLANNING_START_ENTRY_ID: "6EKsv389ETYcQql3htK3Z2"

--- a/spec/fixtures/contentful/static-content-example.json
+++ b/spec/fixtures/contentful/static-content-example.json
@@ -1,0 +1,37 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "rwl7tyzv9sys"
+      }
+    },
+    "id": "5kZ9hIFDvNCEhjWs72SFwj",
+    "type": "Entry",
+    "createdAt": "2020-12-02T10:48:35.748Z",
+    "updatedAt": "2020-12-02T10:48:35.748Z",
+    "environment": {
+      "sys": {
+        "id": "develop",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "staticContent"
+      }
+    },
+    "locale": "en-US"
+  },
+  "fields": {
+    "slug": "/timelines",
+    "title": "When you should start",
+    "body": "Procuring a new catering contract can take up to 6 months to consult, create, review and award. \n\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.",
+    "type": "paragraphs"
+  }
+}

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -42,4 +42,20 @@ RSpec.describe Step, type: :model do
       end
     end
   end
+
+  describe "#question?" do
+    context "when the contentful model is 'question'" do
+      it "returns true" do
+        step = build(:step, :radio, contentful_model: "question")
+        expect(step.question?).to eq(true)
+      end
+    end
+
+    context "when the contentful model is NOT 'question'" do
+      it "returns false" do
+        step = build(:step, contentful_model: "staticContent")
+        expect(step.question?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CreateJourneyStep do
 
         expect(step.title).to eq("Which service do you need?")
         expect(step.help_text).to eq("Tell us which service you need.")
+        expect(step.contentful_model).to eq("question")
         expect(step.contentful_type).to eq("radios")
         expect(step.options).to eq(["Catering", "Cleaning"])
         expect(step.raw).to eq(fake_entry.raw)

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -113,7 +113,7 @@ process around March.")
             content_model: "unmanagedPage",
             step_type: "radios",
             allowed_content_models: CreateJourneyStep::ALLOWED_CONTENTFUL_MODELS.join(", "),
-            allowed_step_types: CreateJourneyStep::ALLOWED_CONTENTFUL_QUESTION_TYPES.join(", "))
+            allowed_step_types: CreateJourneyStep::ALLOWED_CONTENTFUL_ENTRY_TYPES.join(", "))
           .and_call_original
         expect { described_class.new(journey: journey, contentful_entry: fake_entry).call }
           .to raise_error(CreateJourneyStep::UnexpectedContentfulModel)
@@ -147,7 +147,7 @@ process around March.")
             content_model: "question",
             step_type: "telepathy",
             allowed_content_models: CreateJourneyStep::ALLOWED_CONTENTFUL_MODELS.join(", "),
-            allowed_step_types: CreateJourneyStep::ALLOWED_CONTENTFUL_QUESTION_TYPES.join(", "))
+            allowed_step_types: CreateJourneyStep::ALLOWED_CONTENTFUL_ENTRY_TYPES.join(", "))
           .and_call_original
         expect { described_class.new(journey: journey, contentful_entry: fake_entry).call }
           .to raise_error(CreateJourneyStep::UnexpectedContentfulStepType)

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -68,6 +68,24 @@ RSpec.describe CreateJourneyStep do
       end
     end
 
+    context "when the new entry has a body field" do
+      it "updates the step with the body" do
+        journey = create(:journey, :catering)
+        fake_entry = fake_contentful_step_entry(
+          contentful_fixture_filename: "static-content-example.json"
+        )
+
+        step, _answer = described_class.new(
+          journey: journey, contentful_entry: fake_entry
+        ).call
+
+        expect(step.body).to eq("Procuring a new catering contract can \
+take up to 6 months to consult, create, review and award. \n\nUsually existing \
+contracts start and end in the month of September. We recommend starting this \
+process around March.")
+      end
+    end
+
     context "when the new entry has an unexpected content model" do
       it "raises an error" do
         journey = create(:journey, :catering)

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -45,6 +45,7 @@ module ContentfulHelpers
       id: hash_response.dig("sys", "id"),
       title: hash_response.dig("fields", "title"),
       help_text: hash_response.dig("fields", "helpText"),
+      body: hash_response.dig("fields", "body"),
       options: hash_response.dig("fields", "options"),
       type: hash_response.dig("fields", "type"),
       next: double(id: hash_response.dig("fields", "next", "sys", "id")),


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

This work is based on top of the fixes here https://github.com/DFE-Digital/buy-for-your-school/pull/61 without them the test suite fails.

## Changes in this PR

- accept a new Contentful model of `StaticContent` that has the type `paragraphs`
- content steps don't require an answer, the journey show page doesn't add a line summary for steps that don't have answers
- we store the `ContentfulModel` on the step so we can start to ask questions of Steps to help with presentation. Instead of showing steps if they have or don't have associated answers, we can make the assumption that if the step is of type "staticContent" then they'll never have an answer, but questions always should!

## Screenshots of UI changes
![Screenshot 2020-12-02 at 11 12 17](https://user-images.githubusercontent.com/912473/100867474-2bd23c80-3492-11eb-97f8-29b9f3879563.png)
