### PR TITLE
LongTextAnswer table also has UUID as the type of primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - refactor name of "Question" to "Step"
 - refactor redis caching into reusable class
 - users can be shown a step in the journey that is only static content
+- fix primary key type on long_text_answers table to UUID
 
 ## [release-002] - 2020-11-16
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,11 @@ module BuyForYourSchool
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # Automatically add UUID as the type of primary key on new tables, if you
+    # use the Rails migration generator with 'create'
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
+    end
   end
 end

--- a/db/migrate/20201203103421_change_long_text_answer_to_uuid.rb
+++ b/db/migrate/20201203103421_change_long_text_answer_to_uuid.rb
@@ -1,0 +1,17 @@
+class ChangeLongTextAnswerToUuid < ActiveRecord::Migration[6.0]
+  def up
+    enable_extension "uuid-ossp" unless extension_enabled?("uuid-ossp")
+
+    add_column :long_text_answers, :uuid, :uuid, default: "gen_random_uuid()", null: false
+
+    change_table :long_text_answers do |t|
+      t.remove :id
+      t.rename :uuid, :id
+    end
+    execute "ALTER TABLE long_text_answers ADD PRIMARY KEY (id);"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_150359) do
+ActiveRecord::Schema.define(version: 2020_12_03_103421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "journeys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "category", null: false
@@ -23,7 +24,7 @@ ActiveRecord::Schema.define(version: 2020_12_02_150359) do
     t.string "next_entry_id"
   end
 
-  create_table "long_text_answers", force: :cascade do |t|
+  create_table "long_text_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "step_id"
     t.text "response", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

Noticed this problem when pairing yesterday

## Changes in this PR

- migrate `LongTextAnswer` from using sequential ID to UUID
- add a little config to decrease the chances of future us forgetting/missing this again 

Having a non reversible migration usually feels icky. Given we have no real production data or users that could see past answers, an alternative could be to blow away the table and add it back in over 2 migrations?