### PR TITLE
Add class to retrieve all entries from Contentful

### DIFF
--- a/app/services/contentful_connector.rb
+++ b/app/services/contentful_connector.rb
@@ -13,4 +13,8 @@ class ContentfulConnector
   def get_entry_by_id(entry_id)
     @contentful_client.entry(entry_id)
   end
+
+  def get_all_entries
+    @contentful_client.entries
+  end
 end

--- a/app/services/get_all_contentful_entries.rb
+++ b/app/services/get_all_contentful_entries.rb
@@ -1,0 +1,31 @@
+require "contentful"
+
+class GetAllContentfulEntries
+  class NoEntriesFound < StandardError; end
+
+  def initialize(contentful_connector: ContentfulConnector.new)
+    @contentful_connector = contentful_connector
+  end
+
+  def call
+    response = @contentful_connector.get_all_entries
+
+    if response.nil?
+      send_rollbar_error
+      raise NoEntriesFound
+    end
+
+    response
+  end
+
+  private
+
+  def send_rollbar_error
+    Rollbar.warning(
+      "Could not retrieve all entries from the following contentful environment.",
+      contentful_url: ENV["CONTENTFUL_URL"],
+      contentful_space_id: ENV["CONTENTFUL_SPACE"],
+      contentful_environment: ENV["CONTENTFUL_ENVIRONMENT"]
+    )
+  end
+end

--- a/spec/services/contentful_connector_spec.rb
+++ b/spec/services/contentful_connector_spec.rb
@@ -37,4 +37,24 @@ RSpec.describe ContentfulConnector do
       expect(result).to eq(contentful_response)
     end
   end
+
+  describe "#get_all_entries" do
+    it "returns all Contentful entries by making a call to Contentful" do
+      contentful_client = instance_double(Contentful::Client)
+      expect(Contentful::Client).to receive(:new)
+        .with(api_url: contentful_url,
+              space: contentful_space,
+              environment: contentful_environment,
+              access_token: contentful_access_token)
+        .and_return(contentful_client)
+
+      contentful_response = double(Contentful::Array)
+      expect(contentful_client).to receive(:entries)
+        .and_return(contentful_response)
+
+      result = described_class.new.get_all_entries
+
+      expect(result).to eq(contentful_response)
+    end
+  end
 end

--- a/spec/services/get_all_contentful_entries_spec.rb
+++ b/spec/services/get_all_contentful_entries_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe GetAllContentfulEntries do
+  describe "#call" do
+    it "requests and returns all entries from Contentful" do
+      contentful_connector = instance_double(ContentfulConnector)
+      expect(ContentfulConnector).to receive(:new)
+        .and_return(contentful_connector)
+
+      contentful_response = double(Contentful::Array)
+
+      expect(contentful_connector).to receive(:get_all_entries)
+        .and_return(contentful_response)
+
+      result = described_class.new.call
+
+      expect(result).to eq(contentful_response)
+    end
+
+    context "when the Contentful entries are not returned" do
+      it "returns an error message" do
+        contentful_connector = stub_contentful_connector
+
+        allow(contentful_connector).to receive(:get_all_entries)
+          .and_return(nil)
+
+        expect { described_class.new.call }
+          .to raise_error(GetAllContentfulEntries::NoEntriesFound)
+      end
+
+      it "raises a rollbar event" do
+        contentful_client = stub_contentful_connector
+
+        allow(contentful_client).to receive(:get_all_entries)
+          .and_return(nil)
+
+        expect(Rollbar).to receive(:warning)
+          .with("Could not retrieve all entries from the following contentful environment.",
+            contentful_url: ENV["CONTENTFUL_URL"],
+            contentful_space_id: ENV["CONTENTFUL_SPACE"],
+            contentful_environment: ENV["CONTENTFUL_ENVIRONMENT"])
+          .and_call_original
+        expect { described_class.new.call }
+          .to raise_error(GetAllContentfulEntries::NoEntriesFound)
+      end
+    end
+  end
+end

--- a/spec/services/get_contentful_entry_spec.rb
+++ b/spec/services/get_contentful_entry_spec.rb
@@ -1,28 +1,28 @@
 require "rails_helper"
 
 RSpec.describe GetContentfulEntry do
-  let(:contentful_journeyning_start_entry_id) { "1a2b3c4d5" }
+  let(:contentful_journey_start_entry_id) { "1a2b3c4d5" }
 
   around do |example|
     ClimateControl.modify(
-      CONTENTFUL_PLANNING_START_ENTRY_ID: contentful_journeyning_start_entry_id
+      CONTENTFUL_PLANNING_START_ENTRY_ID: contentful_journey_start_entry_id
     ) do
       example.run
     end
   end
 
   describe "#call" do
-    it "returns the contents of Contentful fixture (for now)" do
+    it "requests and returns the required entry from Contentful" do
       contentful_connector = instance_double(ContentfulConnector)
       expect(ContentfulConnector).to receive(:new)
         .and_return(contentful_connector)
 
-      contentful_response = double(Contentful::Entry, id: contentful_journeyning_start_entry_id)
+      contentful_response = double(Contentful::Entry, id: contentful_journey_start_entry_id)
       expect(contentful_connector).to receive(:get_entry_by_id)
-        .with(contentful_journeyning_start_entry_id)
+        .with(contentful_journey_start_entry_id)
         .and_return(contentful_response)
 
-      result = described_class.new(entry_id: contentful_journeyning_start_entry_id).call
+      result = described_class.new(entry_id: contentful_journey_start_entry_id).call
 
       expect(result).to eq(contentful_response)
     end


### PR DESCRIPTION
## Changes in this PR

Adds a new `GetAllContentfulEntries` class which retrieves all entries from a Contentful instance.

## Next steps

This class will be used by subsequent work on mapping and cache-warming.
