### PR TITLE
(187) Form button text is configurable through Contentful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - fix primary key type on long_text_answers table to UUID
 - nightly task to warm the Contentful cache for all entries
+- form button content is configurable through Contentful
 
 ## [release-003] - 2020-12-07
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -17,4 +17,9 @@ class Step < ApplicationRecord
   def question?
     contentful_model == "question"
   end
+
+  def primary_call_to_action_text
+    return I18n.t("generic.button.next") unless super.present?
+    super
+  end
 end

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -30,6 +30,7 @@ class CreateJourneyStep
       contentful_model: content_model,
       contentful_type: step_type,
       options: options,
+      primary_call_to_action_text: primary_call_to_action_text,
       raw: raw,
       journey: journey
     )
@@ -86,6 +87,11 @@ class CreateJourneyStep
 
   def step_type
     contentful_entry.type.tr(" ", "_")
+  end
+
+  def primary_call_to_action_text
+    return nil unless contentful_entry.respond_to?(:primary_call_to_action)
+    contentful_entry.primary_call_to_action
   end
 
   def raw

--- a/app/views/steps/new.long_text.html.erb
+++ b/app/views/steps/new.long_text.html.erb
@@ -7,5 +7,5 @@
     width: "one-third",
     rows: 9
   %>
-  <%= f.submit I18n.t("generic.button.soft_finish"), class: "govuk-button" %>
+  <%= f.submit @step.primary_call_to_action_text, class: "govuk-button" %>
 <% end %>

--- a/app/views/steps/new.paragraphs.html.erb
+++ b/app/views/steps/new.paragraphs.html.erb
@@ -4,4 +4,4 @@
 <div class="static-content">
   <%= simple_format(@step.body, wrapper_tag: "p", class: "govuk-body") %>
 </div>
-<%= link_to I18n.t("generic.button.next"), new_journey_step_path, class: "govuk-button" %>
+<%= link_to @step.primary_call_to_action_text, new_journey_step_path, class: "govuk-button" %>

--- a/app/views/steps/new.radios.html.erb
+++ b/app/views/steps/new.radios.html.erb
@@ -11,5 +11,5 @@
     hint: { text: @step.help_text },
     inline: false
   %>
-  <%= f.submit I18n.t("generic.button.soft_finish"), class: "govuk-button" %>
+  <%= f.submit @step.primary_call_to_action_text, class: "govuk-button" %>
 <% end %>

--- a/app/views/steps/new.short_text.html.erb
+++ b/app/views/steps/new.short_text.html.erb
@@ -6,5 +6,5 @@
     hint: { text: @step.help_text },
     width: "one-third"
   %>
-  <%= f.submit I18n.t("generic.button.soft_finish"), class: "govuk-button" %>
+  <%= f.submit @step.primary_call_to_action_text, class: "govuk-button" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,6 @@ en:
     button:
       start: "Continue"
       next: "Continue"
-      soft_finish: "Save and continue later"
   banner:
     beta:
       tag: "beta"

--- a/db/migrate/20201207171647_add_primary_call_to_action_text_to_step.rb
+++ b/db/migrate/20201207171647_add_primary_call_to_action_text_to_step.rb
@@ -1,0 +1,5 @@
+class AddPrimaryCallToActionTextToStep < ActiveRecord::Migration[6.0]
+  def change
+    add_column :steps, :primary_call_to_action_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_03_103421) do
+ActiveRecord::Schema.define(version: 2020_12_07_171647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2020_12_03_103421) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
     t.string "contentful_model"
+    t.string "primary_call_to_action_text"
     t.index ["journey_id"], name: "index_steps_on_journey_id"
   end
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -15,7 +15,7 @@ feature "Anyone can start a journey" do
 
     choose("Catering")
 
-    click_on(I18n.t("generic.button.soft_finish"))
+    click_on(I18n.t("generic.button.next"))
   end
 
   scenario "an answer must be provided" do
@@ -27,7 +27,7 @@ feature "Anyone can start a journey" do
 
     # Omit a choice
 
-    click_on(I18n.t("generic.button.soft_finish"))
+    click_on(I18n.t("generic.button.next"))
 
     expect(page).to have_content("can't be blank")
   end
@@ -56,10 +56,11 @@ feature "Anyone can start a journey" do
         entry_id: "5lYcZs1ootDrOnk09LDLZg",
         fixture_filename: "no-next-question-example.json"
       )
-      click_on(I18n.t("generic.button.soft_finish"))
+
+      click_on(I18n.t("generic.button.next"))
 
       choose("Stationary")
-      click_on(I18n.t("generic.button.soft_finish"))
+      click_on(I18n.t("generic.button.next"))
 
       expect(page).to have_content("Catering")
       expect(page).to have_content("Stationary")
@@ -100,7 +101,7 @@ feature "Anyone can start a journey" do
       click_on(I18n.t("generic.button.start"))
 
       fill_in "answer[response]", with: "email@example.com"
-      click_on(I18n.t("generic.button.soft_finish"))
+      click_on(I18n.t("generic.button.next"))
 
       expect(page).to have_content("email@example")
     end
@@ -125,7 +126,7 @@ feature "Anyone can start a journey" do
       click_on(I18n.t("generic.button.start"))
 
       fill_in "answer[response]", with: "We would like a supplier to provide catering from September 2020.\r\nThey must be able to supply us for 3 years minumum."
-      click_on(I18n.t("generic.button.soft_finish"))
+      click_on(I18n.t("generic.button.next"))
 
       within(".govuk-summary-list") do
         paragraphs_elements = find_all("p")
@@ -162,6 +163,39 @@ feature "Anyone can start a journey" do
       end
 
       click_on(I18n.t("generic.button.next"))
+
+      expect(page).to have_content("Catering")
+    end
+  end
+
+  context "when the Contentful Entry has a 'primaryCallToAction' field" do
+    around do |example|
+      ClimateControl.modify(
+        CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+      ) do
+        example.run
+      end
+    end
+
+    scenario "user can read static content and proceed without answering" do
+      stub_get_contentful_entry(
+        entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+        fixture_filename: "primary-button-example.json"
+      )
+
+      visit root_path
+      click_on(I18n.t("generic.button.start"))
+
+      expect(page).to have_content("When you should start")
+
+      within(".static-content") do
+        paragraphs_elements = find_all("p")
+        expect(paragraphs_elements.first.text).to have_content("Procuring a new catering contract can take up to 6 months to consult, create, review and award.")
+        expect(paragraphs_elements.last.text).to have_content("Usually existing contracts start and end in the month of September. We recommend starting this process around March.")
+      end
+
+      expect(page).not_to have_content(I18n.t("generic.button.next"))
+      click_on("Go onwards!") # Language from fixture
 
       expect(page).to have_content("Catering")
     end

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -81,7 +81,7 @@ feature "Anyone can start a journey" do
     expect(page).to have_content(I18n.t("errors.contentful_entry_not_found.page_body"))
   end
 
-  context "when Contentful entry is of type short_text" do
+  context "when the Contentful Entry is of type short_text" do
     around do |example|
       ClimateControl.modify(
         CONTENTFUL_PLANNING_START_ENTRY_ID: "hfjJgWRg4xiiiImwVRDtZ"
@@ -106,7 +106,7 @@ feature "Anyone can start a journey" do
     end
   end
 
-  context "when Contentful entry is of type long_text" do
+  context "when the Contentful Entry is of type long_text" do
     around do |example|
       ClimateControl.modify(
         CONTENTFUL_PLANNING_START_ENTRY_ID: "2jWIO1MrVIya9NZrFWT4e"
@@ -135,7 +135,7 @@ feature "Anyone can start a journey" do
     end
   end
 
-  context "when Contentful entry is of type static_content" do
+  context "when the Contentful Entry is of type static_content" do
     around do |example|
       ClimateControl.modify(
         CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
@@ -167,7 +167,7 @@ feature "Anyone can start a journey" do
     end
   end
 
-  context "when Contentful entry model wasn't a type of question" do
+  context "when the Contentful Entry model wasn't of type 'question'" do
     around do |example|
       ClimateControl.modify(
         CONTENTFUL_PLANNING_START_ENTRY_ID: "6EKsv389ETYcQql3htK3Z2"
@@ -191,7 +191,7 @@ feature "Anyone can start a journey" do
     end
   end
 
-  context "when Contentful step entry wasn't an expected type" do
+  context "when the Contentful Entry wasn't an expected step type" do
     around do |example|
       ClimateControl.modify(
         CONTENTFUL_PLANNING_START_ENTRY_ID: "8as7df68uhasdnuasdf"

--- a/spec/fixtures/contentful/no-primary-button-example.json
+++ b/spec/fixtures/contentful/no-primary-button-example.json
@@ -1,0 +1,37 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "5kZ9hIFDvNCEhjWs72SFwj",
+        "type": "Entry",
+        "createdAt": "2020-12-02T10:48:35.748Z",
+        "updatedAt": "2020-12-07T17:04:21.854Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "staticContent"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/timelines",
+        "title": "When you should start",
+        "body": "Procuring a new catering contract can take up to 6 months to consult, create, review and award. \n\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.",
+        "type": "paragraphs"
+    }
+}

--- a/spec/fixtures/contentful/primary-button-example.json
+++ b/spec/fixtures/contentful/primary-button-example.json
@@ -1,0 +1,38 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "5kZ9hIFDvNCEhjWs72SFwj",
+        "type": "Entry",
+        "createdAt": "2020-12-02T10:48:35.748Z",
+        "updatedAt": "2020-12-07T17:04:21.854Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "staticContent"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/timelines",
+        "title": "When you should start",
+        "body": "Procuring a new catering contract can take up to 6 months to consult, create, review and award. \n\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.",
+        "type": "paragraphs",
+        "primaryCallToAction": "Go onwards!"
+    }
+}

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -86,6 +86,36 @@ process around March.")
       end
     end
 
+    context "when the new entry has a 'primaryCallToAction' field" do
+      it "updates the step with the body" do
+        journey = create(:journey, :catering)
+        fake_entry = fake_contentful_step_entry(
+          contentful_fixture_filename: "primary-button-example.json"
+        )
+
+        step, _answer = described_class.new(
+          journey: journey, contentful_entry: fake_entry
+        ).call
+
+        expect(step.primary_call_to_action_text).to eq("Go onwards!")
+      end
+    end
+
+    context "when no 'primaryCallToAction' is provided" do
+      it "default copy is used for the button" do
+        journey = create(:journey, :catering)
+        fake_entry = fake_contentful_step_entry(
+          contentful_fixture_filename: "no-primary-button-example.json"
+        )
+
+        step, _answer = described_class.new(
+          journey: journey, contentful_entry: fake_entry
+        ).call
+
+        expect(step.primary_call_to_action_text).to eq(I18n.t("generic.button.next"))
+      end
+    end
+
     context "when the new entry has an unexpected content model" do
       it "raises an error" do
         journey = create(:journey, :catering)

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -49,6 +49,7 @@ module ContentfulHelpers
       options: hash_response.dig("fields", "options"),
       type: hash_response.dig("fields", "type"),
       next: double(id: hash_response.dig("fields", "next", "sys", "id")),
+      primary_call_to_action: hash_response.dig("fields", "primaryCallToAction"),
       raw: raw_response,
       content_type: double(id: hash_response.dig("sys", "contentType", "sys", "id"))
     )


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- primary form button text is configurable through a new optional Contentful model field called `primaryCallToAction`.

## Screenshots of UI changes

### Contentful model
![Screenshot 2020-12-07 at 17 50 58](https://user-images.githubusercontent.com/912473/101386302-e5774600-38b4-11eb-996e-2e04a97bbf3f.png)

### Contentful entry
![Screenshot 2020-12-07 at 17 50 44](https://user-images.githubusercontent.com/912473/101386294-e4461900-38b4-11eb-88e2-73d47c80360a.png)

### Within the service
![Screenshot 2020-12-07 at 17 50 37](https://user-images.githubusercontent.com/912473/101386289-e314ec00-38b4-11eb-9705-d927096aeb5c.png)
