### PR TITLE
(221) Users can be asked a single date question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix primary key type on long_text_answers table to UUID
 - nightly task to warm the Contentful cache for all entries
 - form button content is configurable through Contentful
+- users can be asked to provide a single date answer
 
 ## [release-003] - 2020-12-07
 

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -8,7 +8,7 @@ class JourneysController < ApplicationController
 
   def show
     @journey = Journey.includes(
-      steps: [:radio_answer, :short_text_answer]
+      steps: [:radio_answer, :short_text_answer, :long_text_answer]
     ).find(journey_id)
   end
 

--- a/app/models/single_date_answer.rb
+++ b/app/models/single_date_answer.rb
@@ -1,0 +1,6 @@
+class SingleDateAnswer < ActiveRecord::Base
+  self.implicit_order_column = "created_at"
+  belongs_to :step
+
+  validates :response, presence: true
+end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -5,13 +5,18 @@ class Step < ApplicationRecord
   has_one :radio_answer
   has_one :short_text_answer
   has_one :long_text_answer
+  has_one :single_date_answer
 
   def radio_options
     options.map { |option| OpenStruct.new(id: option.downcase, name: option.titleize) }
   end
 
   def answer
-    @answer ||= radio_answer || short_text_answer || long_text_answer
+    @answer ||=
+      radio_answer ||
+      short_text_answer ||
+      long_text_answer ||
+      single_date_answer
   end
 
   def question?

--- a/app/services/answer_factory.rb
+++ b/app/services/answer_factory.rb
@@ -10,6 +10,7 @@ class AnswerFactory
     when "radios" then RadioAnswer.new
     when "short_text" then ShortTextAnswer.new
     when "long_text" then LongTextAnswer.new
+    when "single_date" then SingleDateAnswer.new
     end
   end
 end

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -4,7 +4,7 @@ class CreateJourneyStep
   class UnexpectedContentfulStepType < StandardError; end
 
   ALLOWED_CONTENTFUL_MODELS = %w[question staticContent].freeze
-  ALLOWED_CONTENTFUL_ENTRY_TYPES = %w[radios short_text long_text paragraphs].freeze
+  ALLOWED_CONTENTFUL_ENTRY_TYPES = %w[radios short_text long_text paragraphs single_date].freeze
 
   attr_accessor :journey, :contentful_entry
   def initialize(journey:, contentful_entry:)

--- a/app/views/journeys/_single_date_answer.html.erb
+++ b/app/views/journeys/_single_date_answer.html.erb
@@ -1,0 +1,4 @@
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key"><%= step.title %></dt>
+  <dd class="govuk-summary-list__value"><%= I18n.l(answer.response) %></dd>
+</div>

--- a/app/views/steps/new.single_date.html.erb
+++ b/app/views/steps/new.single_date.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :title, @step.title %>
+
+<%= form_for @answer, as: :answer, url: journey_step_answers_path(@journey, @step), method: "post" do |f| %>
+  <%= f.govuk_date_field :response,
+    legend: { text: @step.title, size: "xl" },
+    hint: { text: @step.help_text }
+  %>
+  <%= f.submit @step.primary_call_to_action_text, class: "govuk-button" %>
+<% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,5 +61,6 @@ Rails.application.configure do
     Bullet.raise = true # raise an error if n+1 query occurs
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :radio_answer
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :short_text_answer
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :long_text_answer
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,5 +62,6 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :radio_answer
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :short_text_answer
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :long_text_answer
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :single_date_answer
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,9 @@
 en:
   app:
     name: Buy for your school
+  date:
+    formats:
+      default: "%-d %b %Y"
   generic:
     button:
       start: "Continue"

--- a/db/migrate/20201208110342_create_single_date_answer.rb
+++ b/db/migrate/20201208110342_create_single_date_answer.rb
@@ -1,0 +1,9 @@
+class CreateSingleDateAnswer < ActiveRecord::Migration[6.0]
+  def change
+    create_table :single_date_answers, id: :uuid do |t|
+      t.references :step, type: :uuid
+      t.date :response, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_07_171647) do
+ActiveRecord::Schema.define(version: 2020_12_08_110342) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,6 +46,14 @@ ActiveRecord::Schema.define(version: 2020_12_07_171647) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["step_id"], name: "index_short_text_answers_on_step_id"
+  end
+
+  create_table "single_date_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "step_id"
+    t.date "response", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["step_id"], name: "index_single_date_answers_on_step_id"
   end
 
   create_table "steps", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -16,4 +16,10 @@ FactoryBot.define do
 
     response { "Lots of green" }
   end
+
+  factory :single_date_answer do
+    association :step, factory: :step, contentful_type: "single_date"
+
+    response { 1.year.from_now }
+  end
 end

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -27,6 +27,13 @@ FactoryBot.define do
       association :long_text_answer
     end
 
+    trait :single_date do
+      options { nil }
+      contentful_model { "question" }
+      contentful_type { "single_date" }
+      association :single_date_answer
+    end
+
     trait :static_content do
       options { nil }
       contentful_model { "staticContent" }

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -121,6 +121,34 @@ feature "Anyone can start a journey" do
         end
       end
     end
+
+    context "when Contentful entry is of type single_date" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "55G5kpCLLL3h5yBQLiVlYy"
+        ) do
+          example.run
+        end
+      end
+
+      scenario "user can answer using a date input" do
+        stub_get_contentful_entry(
+          entry_id: "55G5kpCLLL3h5yBQLiVlYy",
+          fixture_filename: "single-date-example.json"
+        )
+
+        visit root_path
+        click_on(I18n.t("generic.button.start"))
+
+        fill_in "answer[response(3i)]", with: "12"
+        fill_in "answer[response(2i)]", with: "8"
+        fill_in "answer[response(1i)]", with: "2020"
+
+        click_on(I18n.t("generic.button.next"))
+
+        expect(page).to have_content("12 Aug 2020")
+      end
+    end
   end
 
   context "when the Contentful model is of type staticContent" do

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -67,141 +67,97 @@ feature "Anyone can start a journey" do
     end
   end
 
-  scenario "a Contentful entry_id does not exist" do
-    contentful_client = stub_contentful_client
+  context "when the Contentful model is of type question" do
+    context "when Contentful entry is of type short_text" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "hfjJgWRg4xiiiImwVRDtZ"
+        ) do
+          example.run
+        end
+      end
 
-    allow(contentful_client).to receive(:entry)
-      .with(anything)
-      .and_raise(GetContentfulEntry::EntryNotFound.new("The following Contentful error could not be found: sss "))
+      scenario "user can answer using free text" do
+        stub_get_contentful_entry(
+          entry_id: "hfjJgWRg4xiiiImwVRDtZ",
+          fixture_filename: "short-text-question-example.json"
+        )
 
-    visit root_path
+        visit root_path
+        click_on(I18n.t("generic.button.start"))
 
-    click_on(I18n.t("generic.button.start"))
+        fill_in "answer[response]", with: "email@example.com"
+        click_on(I18n.t("generic.button.next"))
 
-    expect(page).to have_content(I18n.t("errors.contentful_entry_not_found.page_title"))
-    expect(page).to have_content(I18n.t("errors.contentful_entry_not_found.page_body"))
-  end
-
-  context "when the Contentful Entry is of type short_text" do
-    around do |example|
-      ClimateControl.modify(
-        CONTENTFUL_PLANNING_START_ENTRY_ID: "hfjJgWRg4xiiiImwVRDtZ"
-      ) do
-        example.run
+        expect(page).to have_content("email@example")
       end
     end
 
-    scenario "user can answer using free text" do
-      stub_get_contentful_entry(
-        entry_id: "hfjJgWRg4xiiiImwVRDtZ",
-        fixture_filename: "short-text-question-example.json"
-      )
-
-      visit root_path
-      click_on(I18n.t("generic.button.start"))
-
-      fill_in "answer[response]", with: "email@example.com"
-      click_on(I18n.t("generic.button.next"))
-
-      expect(page).to have_content("email@example")
-    end
-  end
-
-  context "when the Contentful Entry is of type long_text" do
-    around do |example|
-      ClimateControl.modify(
-        CONTENTFUL_PLANNING_START_ENTRY_ID: "2jWIO1MrVIya9NZrFWT4e"
-      ) do
-        example.run
+    context "when Contentful entry is of type long_text" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "2jWIO1MrVIya9NZrFWT4e"
+        ) do
+          example.run
+        end
       end
-    end
 
-    scenario "user can answer using free text with multiple lines" do
-      stub_get_contentful_entry(
-        entry_id: "2jWIO1MrVIya9NZrFWT4e",
-        fixture_filename: "long-text-question-example.json"
-      )
+      scenario "user can answer using free text with multiple lines" do
+        stub_get_contentful_entry(
+          entry_id: "2jWIO1MrVIya9NZrFWT4e",
+          fixture_filename: "long-text-question-example.json"
+        )
 
-      visit root_path
-      click_on(I18n.t("generic.button.start"))
+        visit root_path
+        click_on(I18n.t("generic.button.start"))
 
-      fill_in "answer[response]", with: "We would like a supplier to provide catering from September 2020.\r\nThey must be able to supply us for 3 years minumum."
-      click_on(I18n.t("generic.button.next"))
+        fill_in "answer[response]", with: "We would like a supplier to provide catering from September 2020.\r\nThey must be able to supply us for 3 years minumum."
+        click_on(I18n.t("generic.button.next"))
 
-      within(".govuk-summary-list") do
-        paragraphs_elements = find_all("p")
-        expect(paragraphs_elements.first.text).to have_content("We would like a supplier to provide catering from September 2020.")
-        expect(paragraphs_elements.last.text).to have_content("They must be able to supply us for 3 years minumum.")
+        within(".govuk-summary-list") do
+          paragraphs_elements = find_all("p")
+          expect(paragraphs_elements.first.text).to have_content("We would like a supplier to provide catering from September 2020.")
+          expect(paragraphs_elements.last.text).to have_content("They must be able to supply us for 3 years minumum.")
+        end
       end
     end
   end
 
-  context "when the Contentful Entry is of type static_content" do
-    around do |example|
-      ClimateControl.modify(
-        CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
-      ) do
-        example.run
-      end
-    end
-
-    scenario "user can read static content and proceed without answering" do
-      stub_get_contentful_entry(
-        entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
-        fixture_filename: "static-content-example.json"
-      )
-
-      visit root_path
-      click_on(I18n.t("generic.button.start"))
-
-      expect(page).to have_content("When you should start")
-
-      within(".static-content") do
-        paragraphs_elements = find_all("p")
-        expect(paragraphs_elements.first.text).to have_content("Procuring a new catering contract can take up to 6 months to consult, create, review and award.")
-        expect(paragraphs_elements.last.text).to have_content("Usually existing contracts start and end in the month of September. We recommend starting this process around March.")
+  context "when the Contentful model is of type staticContent" do
+    context "when Contentful entry is of type paragraphs" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+        ) do
+          example.run
+        end
       end
 
-      click_on(I18n.t("generic.button.next"))
+      scenario "user can read static content and proceed without answering" do
+        stub_get_contentful_entry(
+          entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+          fixture_filename: "static-content-example.json"
+        )
 
-      expect(page).to have_content("Catering")
+        visit root_path
+        click_on(I18n.t("generic.button.start"))
+
+        expect(page).to have_content("When you should start")
+
+        within(".static-content") do
+          paragraphs_elements = find_all("p")
+          expect(paragraphs_elements.first.text).to have_content("Procuring a new catering contract can take up to 6 months to consult, create, review and award.")
+          expect(paragraphs_elements.last.text).to have_content("Usually existing contracts start and end in the month of September. We recommend starting this process around March.")
+        end
+
+        click_on(I18n.t("generic.button.next"))
+
+        expect(page).to have_content("Catering")
+      end
     end
   end
 
-  context "when the Contentful Entry has a 'primaryCallToAction' field" do
-    around do |example|
-      ClimateControl.modify(
-        CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
-      ) do
-        example.run
-      end
-    end
-
-    scenario "user can read static content and proceed without answering" do
-      stub_get_contentful_entry(
-        entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
-        fixture_filename: "primary-button-example.json"
-      )
-
-      visit root_path
-      click_on(I18n.t("generic.button.start"))
-
-      expect(page).to have_content("When you should start")
-
-      within(".static-content") do
-        paragraphs_elements = find_all("p")
-        expect(paragraphs_elements.first.text).to have_content("Procuring a new catering contract can take up to 6 months to consult, create, review and award.")
-        expect(paragraphs_elements.last.text).to have_content("Usually existing contracts start and end in the month of September. We recommend starting this process around March.")
-      end
-
-      expect(page).not_to have_content(I18n.t("generic.button.next"))
-      click_on("Go onwards!") # Language from fixture
-
-      expect(page).to have_content("Catering")
-    end
-  end
-
-  context "when the Contentful Entry model wasn't of type 'question'" do
+  context "when Contentful entry model wasn't an expected type" do
     around do |example|
       ClimateControl.modify(
         CONTENTFUL_PLANNING_START_ENTRY_ID: "6EKsv389ETYcQql3htK3Z2"
@@ -247,5 +203,20 @@ feature "Anyone can start a journey" do
       expect(page).to have_content(I18n.t("errors.unexpected_contentful_step_type.page_title"))
       expect(page).to have_content(I18n.t("errors.unexpected_contentful_step_type.page_body"))
     end
+  end
+
+  scenario "a Contentful entry_id does not exist" do
+    contentful_client = stub_contentful_client
+
+    allow(contentful_client).to receive(:entry)
+      .with(anything)
+      .and_raise(GetContentfulEntry::EntryNotFound.new("The following Contentful error could not be found: sss "))
+
+    visit root_path
+
+    click_on(I18n.t("generic.button.start"))
+
+    expect(page).to have_content(I18n.t("errors.contentful_entry_not_found.page_title"))
+    expect(page).to have_content(I18n.t("errors.contentful_entry_not_found.page_body"))
   end
 end

--- a/spec/fixtures/contentful/single-date-example.json
+++ b/spec/fixtures/contentful/single-date-example.json
@@ -1,0 +1,36 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "55G5kpCLLL3h5yBQLiVlYy",
+        "type": "Entry",
+        "createdAt": "2020-12-08T10:43:19.102Z",
+        "updatedAt": "2020-12-08T10:43:19.102Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/starting-date",
+        "type": "single date",
+        "title": "When will this start?"
+    }
+}

--- a/spec/models/long_text_answer_spec.rb
+++ b/spec/models/long_text_answer_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe LongTextAnswer, type: :model do
+  it { should belong_to(:step) }
+
+  it "captures the users response as a string" do
+    answer = build(:long_text_answer, response: "Yellow")
+    expect(answer.response).to eql("Yellow")
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:response) }
+  end
+end

--- a/spec/models/single_date_answer_spec.rb
+++ b/spec/models/single_date_answer_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe SingleDateAnswer, type: :model do
+  it { should belong_to(:step) }
+
+  describe "#response" do
+    it "returns a date" do
+      answer = build(:single_date_answer, response: Date.new(2020, 10, 1))
+      expect(answer.response).to eq(Date.new(2020, 10, 1))
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:response) }
+  end
+end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Step, type: :model do
   it { should belong_to(:journey) }
   it { should have_one(:radio_answer) }
   it { should have_one(:short_text_answer) }
+  it { should have_one(:long_text_answer) }
 
   it "store the basic fields of a contentful response" do
     step = build(:step,
@@ -39,6 +40,14 @@ RSpec.describe Step, type: :model do
         short_text_answer = create(:short_text_answer)
         step = create(:step, :short_text, short_text_answer: short_text_answer)
         expect(step.answer).to eq(short_text_answer)
+      end
+    end
+
+    context "when a LongTextAnswer is associated to the step" do
+      it "returns the LongTextAnswer object" do
+        long_text_answer = create(:long_text_answer)
+        step = create(:step, :long_text, long_text_answer: long_text_answer)
+        expect(step.answer).to eq(long_text_answer)
       end
     end
   end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Step, type: :model do
   it { should have_one(:radio_answer) }
   it { should have_one(:short_text_answer) }
   it { should have_one(:long_text_answer) }
+  it { should have_one(:single_date_answer) }
 
   it "store the basic fields of a contentful response" do
     step = build(:step,
@@ -48,6 +49,14 @@ RSpec.describe Step, type: :model do
         long_text_answer = create(:long_text_answer)
         step = create(:step, :long_text, long_text_answer: long_text_answer)
         expect(step.answer).to eq(long_text_answer)
+      end
+    end
+
+    context "when a SingleDateAnswer is associated to the step" do
+      it "returns the SingleDateAnswer object" do
+        single_date_answer = create(:single_date_answer)
+        step = create(:step, :single_date, single_date_answer: single_date_answer)
+        expect(step.answer).to eq(single_date_answer)
       end
     end
   end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- add missing test coverage for LongTextAnswer that was noticed during this
- Single date questions can be asked

The language "Single" was picked because I expect we'll have to add support for another type of question where we need to ask for 2 dates to form a "Range".

## Screenshots of UI changes

![Screenshot 2020-12-08 at 11 41 19](https://user-images.githubusercontent.com/912473/101482469-af86a000-394e-11eb-987b-3d6faa80d03b.png)
![Screenshot 2020-12-08 at 11 41 15](https://user-images.githubusercontent.com/912473/101482462-ae557300-394e-11eb-922f-c1e362c6a50b.png)