### PR TITLE
(222) Users can be asked a question with multiple checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can be asked to provide a single date answer
 - add Webmock to prevent real http requests in the test suite
 - content users can see a journey map of all the Contentful steps
+- users can be asked to provide multiple answers via a checkbox question
 
 ## [release-003] - 2020-12-07
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -6,8 +6,14 @@ class AnswersController < ApplicationController
     @step = Step.find(step_id)
 
     @answer = AnswerFactory.new(step: @step).call
-    @answer.assign_attributes(answer_params)
     @answer.step = @step
+
+    case @step.contentful_type
+    when "checkboxes"
+      @answer.assign_attributes(checkbox_params)
+    else
+      @answer.assign_attributes(answer_params)
+    end
 
     if @answer.valid?
       @answer.save
@@ -33,5 +39,9 @@ class AnswersController < ApplicationController
 
   def answer_params
     params.require(:answer).permit(:response)
+  end
+
+  def checkbox_params
+    params.require(:answer).permit(response: [])
   end
 end

--- a/app/helpers/step_helper.rb
+++ b/app/helpers/step_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module StepHelper
+  def radio_options(array_of_options:)
+    array_of_options.map { |option|
+      OpenStruct.new(id: option.downcase, name: option.titleize)
+    }
+  end
+end

--- a/app/helpers/step_helper.rb
+++ b/app/helpers/step_helper.rb
@@ -6,4 +6,10 @@ module StepHelper
       OpenStruct.new(id: option.downcase, name: option.titleize)
     }
   end
+
+  def checkbox_options(array_of_options:)
+    array_of_options.map { |option|
+      OpenStruct.new(id: option.downcase, name: option.titleize)
+    }
+  end
 end

--- a/app/models/checkbox_answers.rb
+++ b/app/models/checkbox_answers.rb
@@ -3,4 +3,11 @@ class CheckboxAnswers < ActiveRecord::Base
   belongs_to :step
 
   validates :response, presence: true
+
+  def response=(args)
+    return if args.blank?
+    args.reject!(&:blank?) if args.is_a?(Array)
+
+    super(args)
+  end
 end

--- a/app/models/checkbox_answers.rb
+++ b/app/models/checkbox_answers.rb
@@ -1,0 +1,6 @@
+class CheckboxAnswers < ActiveRecord::Base
+  self.implicit_order_column = "created_at"
+  belongs_to :step
+
+  validates :response, presence: true
+end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -13,7 +13,8 @@ class Step < ApplicationRecord
       radio_answer ||
       short_text_answer ||
       long_text_answer ||
-      single_date_answer
+      single_date_answer ||
+      checkbox_answers
   end
 
   def primary_call_to_action_text

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -6,6 +6,7 @@ class Step < ApplicationRecord
   has_one :short_text_answer
   has_one :long_text_answer
   has_one :single_date_answer
+  has_one :checkbox_answers
 
   def answer
     @answer ||=

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -7,10 +7,6 @@ class Step < ApplicationRecord
   has_one :long_text_answer
   has_one :single_date_answer
 
-  def radio_options
-    options.map { |option| OpenStruct.new(id: option.downcase, name: option.titleize) }
-  end
-
   def answer
     @answer ||=
       radio_answer ||

--- a/app/services/answer_factory.rb
+++ b/app/services/answer_factory.rb
@@ -11,6 +11,7 @@ class AnswerFactory
     when "short_text" then ShortTextAnswer.new
     when "long_text" then LongTextAnswer.new
     when "single_date" then SingleDateAnswer.new
+    when "checkboxes" then CheckboxAnswers.new
     end
   end
 end

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -4,7 +4,14 @@ class CreateJourneyStep
   class UnexpectedContentfulStepType < StandardError; end
 
   ALLOWED_CONTENTFUL_MODELS = %w[question staticContent].freeze
-  ALLOWED_CONTENTFUL_ENTRY_TYPES = %w[radios short_text long_text paragraphs single_date].freeze
+  ALLOWED_CONTENTFUL_ENTRY_TYPES = %w[
+    radios
+    short_text
+    long_text
+    paragraphs
+    single_date
+    checkboxes
+  ].freeze
 
   attr_accessor :journey, :contentful_entry
   def initialize(journey:, contentful_entry:)

--- a/app/views/journeys/_checkboxes_answer.html.erb
+++ b/app/views/journeys/_checkboxes_answer.html.erb
@@ -1,0 +1,4 @@
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key"><%= step.title %></dt>
+  <dd class="govuk-summary-list__value"><%= answer.response.reject(&:blank?).map(&:capitalize).join(", ") %></dd>
+</div>

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -1,0 +1,8 @@
+<%= render layout: layout do |f| %>
+  <%= f.govuk_collection_check_boxes :response,
+    checkbox_options(array_of_options: @step.options),
+    :id,
+    :name,
+    legend: { text: @step.title, size: "xl" }
+  %>
+<% end %>

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: layout do |f| %>
   <%= f.hidden_field :response, value: nil %>
   <%= f.govuk_collection_radio_buttons :response,
-    @step.radio_options,
+    radio_options(array_of_options: @step.options),
     :id,
     ->(option) { option.name },
     :description,

--- a/db/migrate/20201209122555_create_checkbox_answers.rb
+++ b/db/migrate/20201209122555_create_checkbox_answers.rb
@@ -1,0 +1,9 @@
+class CreateCheckboxAnswers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :checkbox_answers, id: :uuid do |t|
+      t.references :step, type: :uuid
+      t.string :response, array: true, default: []
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_08_110342) do
+ActiveRecord::Schema.define(version: 2020_12_09_122555) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "checkbox_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "step_id"
+    t.string "response", default: [], array: true
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["step_id"], name: "index_checkbox_answers_on_step_id"
+  end
 
   create_table "journeys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "category", null: false

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -22,4 +22,10 @@ FactoryBot.define do
 
     response { 1.year.from_now }
   end
+
+  factory :checkbox_answers do
+    association :step, factory: :step, contentful_type: "checkboxes"
+
+    response { ["breakfast", "lunch", ""] }
+  end
 end

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -34,6 +34,13 @@ FactoryBot.define do
       association :single_date_answer
     end
 
+    trait :checkbox_answers do
+      options { ["Brown", "Gold"] }
+      contentful_model { "question" }
+      contentful_type { "checkboxes" }
+      association :checkbox_answers
+    end
+
     trait :static_content do
       options { nil }
       contentful_model { "staticContent" }

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -149,6 +149,33 @@ feature "Anyone can start a journey" do
         expect(page).to have_content("12 Aug 2020")
       end
     end
+
+    context "when Contentful entry is of type checkboxes" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "1DqhwF2XkJJ0Um6NSweWlZ"
+        ) do
+          example.run
+        end
+      end
+
+      scenario "user can select multiple answers" do
+        stub_get_contentful_entry(
+          entry_id: "1DqhwF2XkJJ0Um6NSweWlZ",
+          fixture_filename: "checkbox-example.json"
+        )
+
+        visit root_path
+        click_on(I18n.t("generic.button.start"))
+
+        check "Breakfast"
+        check "Lunch"
+
+        click_on(I18n.t("generic.button.next"))
+
+        expect(page).to have_content("Breakfast, Lunch")
+      end
+    end
   end
 
   context "when the Contentful model is of type staticContent" do

--- a/spec/fixtures/contentful/checkbox-example.json
+++ b/spec/fixtures/contentful/checkbox-example.json
@@ -1,0 +1,41 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "1DqhwF2XkJJ0Um6NSweWlZ",
+        "type": "Entry",
+        "createdAt": "2020-12-09T11:53:52.744Z",
+        "updatedAt": "2020-12-09T11:53:52.744Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/everyday-services",
+        "type": "checkboxes",
+        "title": "Everyday services that are required and need to be considered",
+        "options": [
+            "breakfast",
+            "lunch",
+            "dinner"
+        ]
+    }
+}

--- a/spec/helpers/step_helper_spec.rb
+++ b/spec/helpers/step_helper_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe StepHelper, type: :helper do
+  describe "#radio_options" do
+    it "returns an array of OpenStruct objects" do
+      options = ["green", "yellow"]
+      result = helper.radio_options(array_of_options: options)
+      expect(result).to match([
+        OpenStruct.new(id: "green", name: "Green"),
+        OpenStruct.new(id: "yellow", name: "Yellow")
+      ])
+    end
+  end
+end

--- a/spec/helpers/step_helper_spec.rb
+++ b/spec/helpers/step_helper_spec.rb
@@ -11,4 +11,15 @@ RSpec.describe StepHelper, type: :helper do
       ])
     end
   end
+
+  describe "#checkbox_options" do
+    it "returns an array of OpenStruct objects" do
+      options = ["red", "blue"]
+      result = helper.checkbox_options(array_of_options: options)
+      expect(result).to match([
+        OpenStruct.new(id: "red", name: "Red"),
+        OpenStruct.new(id: "blue", name: "Blue")
+      ])
+    end
+  end
 end

--- a/spec/models/checkbox_answers_spec.rb
+++ b/spec/models/checkbox_answers_spec.rb
@@ -13,4 +13,20 @@ RSpec.describe CheckboxAnswers, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:response) }
   end
+
+  describe "#response=" do
+    context "when the response only includes blank items" do
+      it "should be invalid" do
+        answer = build(:checkbox_answers, response: ["", ""])
+        expect(answer.valid?).to eq(false)
+      end
+    end
+
+    context "when the response a mix of present and blank items" do
+      it "should only store the present values" do
+        answer = build(:checkbox_answers, response: ["Foo", ""])
+        expect(answer.response).to eq(["Foo"])
+      end
+    end
+  end
 end

--- a/spec/models/checkbox_answers_spec.rb
+++ b/spec/models/checkbox_answers_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe CheckboxAnswers, type: :model do
+  it { should belong_to(:step) }
+
+  describe "#response" do
+    it "returns an array of strings" do
+      answer = build(:checkbox_answers, response: ["Blue", "Green"])
+      expect(answer.response).to eq(["Blue", "Green"])
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:response) }
+  end
+end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Step, type: :model do
   it { should have_one(:short_text_answer) }
   it { should have_one(:long_text_answer) }
   it { should have_one(:single_date_answer) }
+  it { should have_one(:checkbox_answers) }
 
   it "store the basic fields of a contentful response" do
     step = build(:step,

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -60,5 +60,13 @@ RSpec.describe Step, type: :model do
         expect(step.answer).to eq(single_date_answer)
       end
     end
+
+    context "when a CheckboxAnswers is associated to the step" do
+      it "returns the CheckboxAnswers object" do
+        checkbox_answers = create(:checkbox_answers)
+        step = create(:step, :checkbox_answers, checkbox_answers: checkbox_answers)
+        expect(step.answer).to eq(checkbox_answers)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

A Contentful Entry to test this locally is: `1DqhwF2XkJJ0Um6NSweWlZ`.

- refactor existing `radio_options` method to a helper before we add the new `checkbox_options` method
- a new `CheckboxAnswers` resource allows us to capture one or more answers for a checkbox question - it's the first plural Answers resource
- an extra step to ensure presence validation fires correctly when no checks are made

To make sure the approach of storing an Array of Strings as the `response` as well as the approach of stripping blank options (`""`) options submitting by the form. I added a quick Edit journey in to make sure the form could render back the selected options. You're able to see that output in the screenshots attached.

We store an Array of Strings, rather than a different type like an `hstore` as the form helper produces an array eg. `["", "Choice 1", "Choice 2"]`. In order to keep compatiblity with the requirements of the edit form (to preselect the chosen values) without extra lifting, I chose to store it in the same structure. An hstore field may still be useful for patterns that want to record answers for "Other"

## Screenshots of UI changes

![Screenshot 2020-12-09 at 17 35 58](https://user-images.githubusercontent.com/912473/101666131-bcd28600-3a45-11eb-9ef8-a09e06663255.png)
![Screenshot 2020-12-09 at 17 47 02](https://user-images.githubusercontent.com/912473/101666881-9103d000-3a46-11eb-8497-67e1bdc8675a.png)
![Screenshot 2020-12-09 at 17 36 04](https://user-images.githubusercontent.com/912473/101666136-be9c4980-3a45-11eb-8493-62b4bbfe61bf.png)
![Screenshot 2020-12-09 at 17 36 10](https://user-images.githubusercontent.com/912473/101666140-c0660d00-3a45-11eb-9af4-05e5ec1f92cc.png)

## Next steps
