### PR TITLE
(115) Journey map endpoint which shows the sequence of Contentful entries shown to a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - form button content is configurable through Contentful
 - users can be asked to provide a single date answer
 - add Webmock to prevent real http requests in the test suite
+- content users can see a journey map of all the Contentful steps
 
 ## [release-003] - 2020-12-07
 

--- a/app/controllers/journey_maps_controller.rb
+++ b/app/controllers/journey_maps_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class JourneyMapsController < ApplicationController
+  def new
+    hash_of_entries = GetAllContentfulEntries.new.call.to_h { |entry| [entry.id, entry] }
+    @journey_map = recursive_path(
+      all_entries: hash_of_entries,
+      next_entry_id: ENV["CONTENTFUL_PLANNING_START_ENTRY_ID"],
+      entry_id_sequence: []
+    )
+  end
+
+  def recursive_path(all_entries:, next_entry_id:, entry_id_sequence:)
+    entry = all_entries.fetch(next_entry_id, nil)
+    entry_id_sequence << entry.id if entry.present?
+
+    if entry.respond_to?(:next)
+      recursive_path(
+        all_entries: all_entries,
+        next_entry_id: entry.next.id,
+        entry_id_sequence: entry_id_sequence
+      )
+    else
+      entry_id_sequence
+    end
+  end
+end

--- a/app/controllers/journey_maps_controller.rb
+++ b/app/controllers/journey_maps_controller.rb
@@ -2,26 +2,10 @@
 
 class JourneyMapsController < ApplicationController
   def new
-    hash_of_entries = GetAllContentfulEntries.new.call.to_h { |entry| [entry.id, entry] }
-    @journey_map = recursive_path(
-      all_entries: hash_of_entries,
-      next_entry_id: ENV["CONTENTFUL_PLANNING_START_ENTRY_ID"],
-      entry_id_sequence: []
-    )
-  end
-
-  def recursive_path(all_entries:, next_entry_id:, entry_id_sequence:)
-    entry = all_entries.fetch(next_entry_id, nil)
-    entry_id_sequence << entry.id if entry.present?
-
-    if entry.respond_to?(:next)
-      recursive_path(
-        all_entries: all_entries,
-        next_entry_id: entry.next.id,
-        entry_id_sequence: entry_id_sequence
-      )
-    else
-      entry_id_sequence
-    end
+    entries = GetAllContentfulEntries.new.call
+    @journey_map = BuildJourneyOrder.new(
+      entries: entries.to_a,
+      starting_entry_id: ENV["CONTENTFUL_PLANNING_START_ENTRY_ID"]
+    ).call
   end
 end

--- a/app/services/build_journey_order.rb
+++ b/app/services/build_journey_order.rb
@@ -1,0 +1,37 @@
+class BuildJourneyOrder
+  attr_accessor :entries, :starting_entry_id
+
+  def initialize(entries:, starting_entry_id:)
+    self.entries = entries
+    self.starting_entry_id = starting_entry_id
+  end
+
+  def call
+    recursive_path(
+      entry_lookup: entry_lookup_hash,
+      next_entry_id: starting_entry_id,
+      entries: []
+    )
+  end
+
+  private
+
+  def entry_lookup_hash
+    @entry_lookup_hash ||= entries.to_h { |entry| [entry.id, entry] }
+  end
+
+  def recursive_path(entry_lookup:, next_entry_id:, entries:)
+    entry = entry_lookup.fetch(next_entry_id, nil)
+    entries << entry if entry.present?
+
+    if entry.respond_to?(:next)
+      recursive_path(
+        entry_lookup: entry_lookup,
+        next_entry_id: entry.next.id,
+        entries: entries
+      )
+    else
+      entries
+    end
+  end
+end

--- a/app/views/journey_maps/new.html.erb
+++ b/app/views/journey_maps/new.html.erb
@@ -1,0 +1,7 @@
+<ol class="govuk-list govuk-list--number">
+  <% @journey_map.each do |entry_id| %>
+    <li>
+      <%= entry_id %>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/journey_maps/new.html.erb
+++ b/app/views/journey_maps/new.html.erb
@@ -1,7 +1,7 @@
 <ol class="govuk-list govuk-list--number">
-  <% @journey_map.each do |entry_id| %>
+  <% @journey_map.each do |entry| %>
     <li>
-      <%= entry_id %>
+      <%= entry.id %>
     </li>
   <% end %>
 </ol>

--- a/app/views/journey_maps/new.html.erb
+++ b/app/views/journey_maps/new.html.erb
@@ -1,7 +1,10 @@
+<%= content_for :title, I18n.t("journey_map.page_title") %>
+<h1 class="govuk-heading-xl"><%= I18n.t("journey_map.page_title") %></h1>
+
 <ol class="govuk-list govuk-list--number">
   <% @journey_map.each do |entry| %>
     <li>
-      <%= entry.id %>
+      <%= link_to entry.title, "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/#{entry.id}", target: :blank, class: "govuk-link" %>
     </li>
   <% end %>
 </ol>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,8 @@ en:
       before_you_start_body: "It will take around 3 minutes to complete the process"
     errors:
       contentful_entry_not_found: "An unexpected error occurred. The starting step has been revoked by the content team."
+  journey_map:
+    page_title: "Contentful entry map"
   errors:
     contentful_entry_not_found:
       page_title: "An unexpected error occurred"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get "health_check" => "application#health_check"
   root to: "high_voltage/pages#show", id: "planning_start_page"
 
+  resource :journey_map, only: [:new]
   resources :journeys, only: [:new, :show] do
     resources :steps, only: [:new, :show] do
       resources :answers, only: [:create]

--- a/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
@@ -1,0 +1,24 @@
+feature "Users can see all the steps of a journey" do
+  around do |example|
+    ClimateControl.modify(
+      CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+    ) do
+      example.run
+    end
+  end
+
+  scenario "Multiple journey steps" do
+    stub_get_contentful_entries(
+      entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+      fixture_filename: "closed-path-with-multiple-example.json"
+    )
+
+    visit new_journey_map_path
+
+    within(".govuk-list") do
+      list_items = find_all("li")
+      expect(list_items.first.text).to have_content("5kZ9hIFDvNCEhjWs72SFwj")
+      expect(list_items.last.text).to have_content("hfjJgWRg4xiiiImwVRDtZ")
+    end
+  end
+end

--- a/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
@@ -15,10 +15,16 @@ feature "Users can see all the steps of a journey" do
 
     visit new_journey_map_path
 
+    expect(page).to have_content(I18n.t("journey_map.page_title"))
+
     within(".govuk-list") do
       list_items = find_all("li")
-      expect(list_items.first.text).to have_content("5kZ9hIFDvNCEhjWs72SFwj")
-      expect(list_items.last.text).to have_content("hfjJgWRg4xiiiImwVRDtZ")
+      within(list_items.first) do
+        expect(page).to have_link("When you should start", href: "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/5kZ9hIFDvNCEhjWs72SFwj")
+      end
+      within(list_items.last) do
+        expect(page).to have_link("Which service do you need?", href: "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/hfjJgWRg4xiiiImwVRDtZ")
+      end
     end
   end
 end

--- a/spec/fixtures/contentful/closed-path-with-multiple-example.json
+++ b/spec/fixtures/contentful/closed-path-with-multiple-example.json
@@ -1,0 +1,95 @@
+{
+    "sys": {
+        "type": "Array"
+    },
+    "total": 2,
+    "skip": 0,
+    "limit": 100,
+    "items": [
+        {
+            "sys": {
+                "space": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Space",
+                        "id": "rwl7tyzv9sys"
+                    }
+                },
+                "id": "5kZ9hIFDvNCEhjWs72SFwj",
+                "type": "Entry",
+                "createdAt": "2020-12-02T10:48:35.748Z",
+                "updatedAt": "2020-12-02T10:48:35.748Z",
+                "environment": {
+                    "sys": {
+                        "id": "develop",
+                        "type": "Link",
+                        "linkType": "Environment"
+                    }
+                },
+                "revision": 1,
+                "contentType": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "ContentType",
+                        "id": "staticContent"
+                    }
+                },
+                "locale": "en-US"
+            },
+            "fields": {
+                "slug": "/timelines",
+                "title": "When you should start",
+                "body": "Procuring a new catering contract can take up to 6 months to consult, create, review and award. \n\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.",
+                "type": "paragraphs",
+                "next": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Entry",
+                        "id": "hfjJgWRg4xiiiImwVRDtZ"
+                    }
+                }
+            }
+        },
+        {
+            "sys": {
+                "space": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Space",
+                        "id": "rwl7tyzv9sys"
+                    }
+                },
+                "id": "hfjJgWRg4xiiiImwVRDtZ",
+                "type": "Entry",
+                "createdAt": "2020-11-04T12:28:30.442Z",
+                "updatedAt": "2020-11-26T16:39:54.188Z",
+                "environment": {
+                    "sys": {
+                        "id": "develop",
+                        "type": "Link",
+                        "linkType": "Environment"
+                    }
+                },
+                "revision": 6,
+                "contentType": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "ContentType",
+                        "id": "question"
+                    }
+                },
+                "locale": "en-US"
+            },
+            "fields": {
+                "slug": "/dev-start-which-service",
+                "title": "Which service do you need?",
+                "helpText": "Tell us which service you need.",
+                "type": "radios",
+                "options": [
+                    "Catering",
+                    "Cleaning"
+                ]
+            }
+        }
+    ]
+}

--- a/spec/fixtures/contentful/multiple-entries-example.json
+++ b/spec/fixtures/contentful/multiple-entries-example.json
@@ -2,7 +2,7 @@
     "sys": {
         "type": "Array"
     },
-    "total": 5,
+    "total": 2,
     "skip": 0,
     "limit": 100,
     "items": [

--- a/spec/jobs/warm_entry_cache_job_spec.rb
+++ b/spec/jobs/warm_entry_cache_job_spec.rb
@@ -21,13 +21,10 @@ RSpec.describe WarmEntryCacheJob, type: :job do
     end
 
     it "asks GetAllContentfulEntries for the Contentful entries" do
-      raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/multiple-entries-example.json")
-      response_hash = JSON.parse(raw_response)
-      fake_contentful_entry_array = Contentful::ResourceBuilder.new(response_hash).run
-
-      get_all_contentful_entries_double = instance_double(GetAllContentfulEntries)
-      allow(GetAllContentfulEntries).to receive(:new).and_return(get_all_contentful_entries_double)
-      allow(get_all_contentful_entries_double).to receive(:call).and_return(fake_contentful_entry_array)
+      stub_get_contentful_entries(
+        entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+        fixture_filename: "multiple-entries-example.json"
+      )
 
       described_class.perform_later
       perform_enqueued_jobs

--- a/spec/services/build_journey_order_spec.rb
+++ b/spec/services/build_journey_order_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe BuildJourneyOrder do
+  describe "#call" do
+    around do |example|
+      ClimateControl.modify(
+        CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+      ) do
+        example.run
+      end
+    end
+
+    context "when there are multiple entries" do
+      it "returns each ID in the order they appear" do
+        fake_entries = fake_contentful_entry_array(
+          contentful_fixture_filename: "closed-path-with-multiple-example.json"
+        )
+
+        result = described_class.new(
+          entries: fake_entries,
+          starting_entry_id: "5kZ9hIFDvNCEhjWs72SFwj"
+        ).call
+
+        expect(result).to match([fake_entries.first, fake_entries.last])
+      end
+    end
+  end
+end

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CreateJourneyStep do
     context "when the new step is of type step" do
       it "creates a local copy of the new step" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "radio-question-example.json"
         )
 
@@ -21,7 +21,7 @@ RSpec.describe CreateJourneyStep do
 
       it "updates the journey with a new next_entry_id" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "has-next-question-example.json"
         )
 
@@ -34,7 +34,7 @@ RSpec.describe CreateJourneyStep do
     context "when the question is of type 'short_text'" do
       it "sets help_text and options to nil" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "short-text-question-example.json"
         )
 
@@ -45,7 +45,7 @@ RSpec.describe CreateJourneyStep do
 
       it "replaces spaces with underscores" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "short-text-question-example.json"
         )
 
@@ -58,7 +58,7 @@ RSpec.describe CreateJourneyStep do
     context "when the new step does not have a following step" do
       it "updates the journey by setting the next_entry_id to nil" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "radio-question-example.json"
         )
 
@@ -71,7 +71,7 @@ RSpec.describe CreateJourneyStep do
     context "when the new entry has a body field" do
       it "updates the step with the body" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "static-content-example.json"
         )
 
@@ -89,7 +89,7 @@ process around March.")
     context "when the new entry has a 'primaryCallToAction' field" do
       it "updates the step with the body" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "primary-button-example.json"
         )
 
@@ -104,7 +104,7 @@ process around March.")
     context "when no 'primaryCallToAction' is provided" do
       it "default copy is used for the button" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "no-primary-button-example.json"
         )
 
@@ -119,7 +119,7 @@ process around March.")
     context "when the new entry has an unexpected content model" do
       it "raises an error" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "an-unexpected-model-example.json"
         )
 
@@ -130,7 +130,7 @@ process around March.")
       it "raises a rollbar event" do
         journey = create(:journey, :catering)
 
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "an-unexpected-model-example.json"
         )
 
@@ -153,7 +153,7 @@ process around March.")
     context "when the new step has an unexpected step type" do
       it "raises an error" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "an-unexpected-question-type-example.json"
         )
 
@@ -164,7 +164,7 @@ process around March.")
       it "raises a rollbar event" do
         journey = create(:journey, :catering)
 
-        fake_entry = fake_contentful_step_entry(
+        fake_entry = fake_contentful_entry(
           contentful_fixture_filename: "an-unexpected-question-type-example.json"
         )
 

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -30,12 +30,6 @@ module ContentfulHelpers
     contentful_client
   end
 
-  def stub_contentful_step(fake_entry: fake_contentful_step_entry)
-    get_contentful_step_double = instance_double(GetContentfulEntry)
-    allow(GetContentfulEntry).to receive(:new).and_return(get_contentful_step_double)
-    allow(get_contentful_step_double).to receive(:call).and_return(fake_entry)
-  end
-
   def fake_contentful_step_entry(contentful_fixture_filename:)
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{contentful_fixture_filename}")
     hash_response = JSON.parse(raw_response)

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -6,7 +6,7 @@ module ContentfulHelpers
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{fixture_filename}")
 
     contentful_connector = stub_contentful_connector
-    contentful_response = fake_contentful_step_entry(contentful_fixture_filename: fixture_filename)
+    contentful_response = fake_contentful_entry(contentful_fixture_filename: fixture_filename)
     allow(contentful_connector).to receive(:get_entry_by_id)
       .with(entry_id)
       .and_return(contentful_response)
@@ -30,7 +30,7 @@ module ContentfulHelpers
     contentful_client
   end
 
-  def fake_contentful_step_entry(contentful_fixture_filename:)
+  def fake_contentful_entry(contentful_fixture_filename:)
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{contentful_fixture_filename}")
     hash_response = JSON.parse(raw_response)
 

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -15,6 +15,21 @@ module ContentfulHelpers
       .and_return(raw_response)
   end
 
+  def stub_get_contentful_entries(
+    entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+    fixture_filename: "multiple-entries-example.json"
+  )
+    raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{fixture_filename}")
+
+    contentful_connector = stub_contentful_connector
+    contentful_response = fake_contentful_entry_array(contentful_fixture_filename: fixture_filename)
+    allow(contentful_connector).to receive(:get_all_entries)
+      .and_return(contentful_response)
+
+    allow(contentful_response).to receive(:raw)
+      .and_return(raw_response)
+  end
+
   def stub_contentful_connector
     contentful_connector = instance_double(ContentfulConnector)
     expect(ContentfulConnector).to receive(:new)
@@ -47,5 +62,12 @@ module ContentfulHelpers
       raw: raw_response,
       content_type: double(id: hash_response.dig("sys", "contentType", "sys", "id"))
     )
+  end
+
+  def fake_contentful_entry_array(contentful_fixture_filename:)
+    raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{contentful_fixture_filename}")
+    response_hash = JSON.parse(raw_response)
+
+    Contentful::ResourceBuilder.new(response_hash).run
   end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- a new hidden page at `/journey_map/new` for viewing the live map of all entries used in journey
- this map only supports a single linear journey, it starts from `ENV["CONTENTFUL_PLANNING_START_ENTRY_ID']` and continues until no `next` element can be found
- it doesn't read from the cache as we specified it should be live and reloadable
- it doesn't write back to the cache yet as that would introduce a cache busting mechanic, I think we should do the work to validate the paths look healthy before adding them to the cache

When designing the `EntryPathFinder` service and thinking about how this work could be extended to support multiple branches. We could replace the whole thing with a graphing tool or change this service so that it starts to build a proper tree data structure instead of a list.

## Screenshots of UI changes

Note the link in the bottom left.

![Screenshot 2020-12-14 at 11 02 42](https://user-images.githubusercontent.com/912473/102073923-eef43700-3dfb-11eb-91fc-e870321d55a6.png)