### PR TITLE
Test suite detects external HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - nightly task to warm the Contentful cache for all entries
 - form button content is configurable through Contentful
 - users can be asked to provide a single date answer
+- add Webmock to prevent real http requests in the test suite
 
 ## [release-003] - 2020-12-07
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov"
+  gem "webmock"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     contentful (2.15.4)
       http (> 0.8, < 5.0)
       multi_json (~> 1)
+    crack (0.4.4)
     crass (1.0.6)
     database_cleaner (1.8.5)
     diff-lcs (1.4.4)
@@ -133,6 +134,7 @@ GEM
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
+    hashdiff (1.0.1)
     high_voltage (3.1.2)
     http (4.4.1)
       addressable (~> 2.3)
@@ -326,6 +328,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.10.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -381,6 +387,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,9 @@ require "simplecov"
 SimpleCov.minimum_coverage 99
 SimpleCov.start "rails"
 
+require "webmock/rspec"
+WebMock.disable_net_connect!(allow_localhost: true)
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Using Webmock will give the team more explicit feedback on any failures due to a real request being made.

Instead of seeing a real Contentful 404 we should see a Webmock error that explains that a real HTTP request was detected and that we should look to stub it.

## Screenshots of UI changes

### Before
![Screenshot 2020-12-14 at 12 09 47](https://user-images.githubusercontent.com/912473/102080007-9cb81380-3e05-11eb-885a-54ec10a4d6e1.png)

### After
![Screenshot 2020-12-14 at 12 09 57](https://user-images.githubusercontent.com/912473/102080000-9a55b980-3e05-11eb-8892-1d95d805aed1.png)

## Next steps
