### PR TITLE
(121) Part 1 - Only generate a journey map if the journey path is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - add Webmock to prevent real http requests in the test suite
 - content users can see a journey map of all the Contentful steps
 - users can be asked to provide multiple answers via a checkbox question
+- journey map shows an error to the content team if a duplicate entry is detected
 
 ## [release-003] - 2020-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - content users can see a journey map of all the Contentful steps
 - users can be asked to provide multiple answers via a checkbox question
 - journey map shows an error to the content team if a duplicate entry is detected
+- journey map shows an error to the content team if the journey doesn't end within 50 steps
 
 ## [release-003] - 2020-12-07
 

--- a/app/controllers/journey_maps_controller.rb
+++ b/app/controllers/journey_maps_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class JourneyMapsController < ApplicationController
+  rescue_from BuildJourneyOrder::RepeatEntryDetected do |exception|
+    render "errors/repeat_step_in_the_contentful_journey", status: 500, locals: {error: exception}
+  end
+
   def new
     entries = GetAllContentfulEntries.new.call
     @journey_map = BuildJourneyOrder.new(

--- a/app/controllers/journey_maps_controller.rb
+++ b/app/controllers/journey_maps_controller.rb
@@ -5,6 +5,10 @@ class JourneyMapsController < ApplicationController
     render "errors/repeat_step_in_the_contentful_journey", status: 500, locals: {error: exception}
   end
 
+  rescue_from BuildJourneyOrder::TooManyChainedEntriesDetected do |exception|
+    render "errors/too_many_steps_in_the_contentful_journey", status: 500, locals: {error: exception}
+  end
+
   def new
     entries = GetAllContentfulEntries.new.call
     @journey_map = BuildJourneyOrder.new(

--- a/app/views/errors/repeat_step_in_the_contentful_journey.html.erb
+++ b/app/views/errors/repeat_step_in_the_contentful_journey.html.erb
@@ -1,0 +1,6 @@
+<%= content_for :title, I18n.t("errors.repeat_step_in_the_contentful_journey.page_title") %>
+
+<h1 class="govuk-heading-xl"><%= I18n.t("errors.repeat_step_in_the_contentful_journey.page_title") %></h1>
+<p class="govuk-body">
+  <%= I18n.t("errors.repeat_step_in_the_contentful_journey.page_body", entry_id: error.message) %>
+</p>

--- a/app/views/errors/too_many_steps_in_the_contentful_journey.html.erb
+++ b/app/views/errors/too_many_steps_in_the_contentful_journey.html.erb
@@ -1,0 +1,6 @@
+<%= content_for :title, I18n.t("errors.too_many_steps_in_the_contentful_journey.page_title") %>
+
+<h1 class="govuk-heading-xl"><%= I18n.t("errors.too_many_steps_in_the_contentful_journey.page_title") %></h1>
+<p class="govuk-body">
+  <%= I18n.t("errors.too_many_steps_in_the_contentful_journey.page_body", entry_id: error.message, step_count: BuildJourneyOrder::ENTRY_JOURNEY_MAX_LENGTH) %>
+</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,3 +46,6 @@ en:
     unexpected_contentful_step_type:
       page_title: "An unexpected error occurred"
       page_body: "The service has had a problem trying to retrieve the required step. The team have been notified of this problem and you should be able to retry shortly."
+    repeat_step_in_the_contentful_journey:
+      page_title: "An unexpected error occurred"
+      page_body: "One or more steps in the Contentful journey would leave the user in an infinite loop. This entry ID was presented more than once to the user: %{entry_id}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,3 +49,6 @@ en:
     repeat_step_in_the_contentful_journey:
       page_title: "An unexpected error occurred"
       page_body: "One or more steps in the Contentful journey would leave the user in an infinite loop. This entry ID was presented more than once to the user: %{entry_id}"
+    too_many_steps_in_the_contentful_journey:
+      page_title: "An unexpected error occurred"
+      page_body: "More than %{step_count} steps were found in the Contentful journey. Is the journey missing an end? The last Entry ID was: %{entry_id}"

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
 feature "Anyone can start a journey" do
+  around do |example|
+    ClimateControl.modify(
+      CONTENTFUL_PLANNING_START_ENTRY_ID: "1UjQurSOi5MWkcRuGxdXZS"
+    ) do
+      example.run
+    end
+  end
+
   scenario "Start page includes a call to action" do
     stub_get_contentful_entry
 

--- a/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
@@ -52,5 +52,30 @@ feature "Users can see all the steps of a journey" do
         )
       end
     end
+
+    context "when the chain becomes obviously too long" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+        ) do
+          example.run
+        end
+      end
+
+      it "returns an error message" do
+        stub_const("BuildJourneyOrder::ENTRY_JOURNEY_MAX_LENGTH", 1)
+        stub_get_contentful_entries(
+          entry_id: "hfjJgWRg4xiiiImwVRDtZ",
+          fixture_filename: "closed-path-with-multiple-example.json"
+        )
+
+        visit new_journey_map_path
+
+        expect(page).to have_content(I18n.t("errors.too_many_steps_in_the_contentful_journey.page_title"))
+        expect(page).to have_content(
+          I18n.t("errors.too_many_steps_in_the_contentful_journey.page_body", entry_id: "hfjJgWRg4xiiiImwVRDtZ", step_count: 1)
+        )
+      end
+    end
   end
 end

--- a/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
@@ -27,4 +27,30 @@ feature "Users can see all the steps of a journey" do
       end
     end
   end
+
+  context "when the map isn't valid" do
+    context "when the same entry is found twice" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+        ) do
+          example.run
+        end
+      end
+
+      it "returns an error message" do
+        stub_get_contentful_entries(
+          entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+          fixture_filename: "repeat-entry-example.json"
+        )
+
+        visit new_journey_map_path
+
+        expect(page).to have_content(I18n.t("errors.repeat_step_in_the_contentful_journey.page_title"))
+        expect(page).to have_content(
+          I18n.t("errors.repeat_step_in_the_contentful_journey.page_body", entry_id: "5kZ9hIFDvNCEhjWs72SFwj")
+        )
+      end
+    end
+  end
 end

--- a/spec/fixtures/contentful/repeat-entry-example.json
+++ b/spec/fixtures/contentful/repeat-entry-example.json
@@ -1,0 +1,146 @@
+{
+    "sys": {
+        "type": "Array"
+    },
+    "total": 4,
+    "skip": 0,
+    "limit": 100,
+    "items": [
+        {
+            "sys": {
+                "space": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Space",
+                        "id": "rwl7tyzv9sys"
+                    }
+                },
+                "id": "5kZ9hIFDvNCEhjWs72SFwj",
+                "type": "Entry",
+                "createdAt": "2020-12-02T10:48:35.748Z",
+                "updatedAt": "2020-12-02T10:48:35.748Z",
+                "environment": {
+                    "sys": {
+                        "id": "develop",
+                        "type": "Link",
+                        "linkType": "Environment"
+                    }
+                },
+                "revision": 1,
+                "contentType": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "ContentType",
+                        "id": "staticContent"
+                    }
+                },
+                "locale": "en-US"
+            },
+            "fields": {
+                "slug": "/timelines",
+                "title": "When you should start",
+                "body": "Procuring a new catering contract can take up to 6 months to consult, create, review and award. \n\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.",
+                "type": "paragraphs",
+                "next": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Entry",
+                        "id": "hfjJgWRg4xiiiImwVRDtZ"
+                    }
+                }
+            }
+        },
+        {
+            "sys": {
+                "space": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Space",
+                        "id": "rwl7tyzv9sys"
+                    }
+                },
+                "id": "hfjJgWRg4xiiiImwVRDtZ",
+                "type": "Entry",
+                "createdAt": "2020-11-04T12:28:30.442Z",
+                "updatedAt": "2020-11-26T16:39:54.188Z",
+                "environment": {
+                    "sys": {
+                        "id": "develop",
+                        "type": "Link",
+                        "linkType": "Environment"
+                    }
+                },
+                "revision": 6,
+                "contentType": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "ContentType",
+                        "id": "question"
+                    }
+                },
+                "locale": "en-US"
+            },
+            "fields": {
+                "slug": "/dev-start-which-service",
+                "title": "Which service do you need?",
+                "helpText": "Tell us which service you need.",
+                "type": "radios",
+                "options": [
+                    "Catering",
+                    "Cleaning"
+                ],
+                "next": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Entry",
+                        "id": "5kZ9hIFDvNCEhjWs72SFwj"
+                    }
+                }
+            }
+        },
+        {
+            "sys": {
+                "space": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Space",
+                        "id": "rwl7tyzv9sys"
+                    }
+                },
+                "id": "5kZ9hIFDvNCEhjWs72SFwj",
+                "type": "Entry",
+                "createdAt": "2020-12-02T10:48:35.748Z",
+                "updatedAt": "2020-12-02T10:48:35.748Z",
+                "environment": {
+                    "sys": {
+                        "id": "develop",
+                        "type": "Link",
+                        "linkType": "Environment"
+                    }
+                },
+                "revision": 1,
+                "contentType": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "ContentType",
+                        "id": "staticContent"
+                    }
+                },
+                "locale": "en-US"
+            },
+            "fields": {
+                "slug": "/timelines",
+                "title": "When you should start",
+                "body": "Procuring a new catering contract can take up to 6 months to consult, create, review and award. \n\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.",
+                "type": "paragraphs",
+                "next": {
+                    "sys": {
+                        "type": "Link",
+                        "linkType": "Entry",
+                        "id": "hfjJgWRg4xiiiImwVRDtZ"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/spec/services/build_journey_order_spec.rb
+++ b/spec/services/build_journey_order_spec.rb
@@ -24,5 +24,36 @@ RSpec.describe BuildJourneyOrder do
         expect(result).to match([fake_entries.first, fake_entries.last])
       end
     end
+
+    context "when the journey visits the same node twice" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+        ) do
+          example.run
+        end
+      end
+
+      it "raises a rollbar event" do
+        fake_entries = fake_contentful_entry_array(
+          contentful_fixture_filename: "repeat-entry-example.json"
+        )
+
+        expect(Rollbar).to receive(:error)
+          .with("A repeated Contentful entry was found in the same journey",
+            contentful_url: ENV["CONTENTFUL_URL"],
+            contentful_space_id: ENV["CONTENTFUL_SPACE"],
+            contentful_environment: ENV["CONTENTFUL_ENVIRONMENT"],
+            contentful_entry_id: "5kZ9hIFDvNCEhjWs72SFwj")
+          .and_call_original
+
+        expect {
+          described_class.new(
+            entries: fake_entries,
+            starting_entry_id: "5kZ9hIFDvNCEhjWs72SFwj"
+          ).call
+        }.to raise_error(BuildJourneyOrder::RepeatEntryDetected)
+      end
+    end
   end
 end

--- a/spec/services/build_journey_order_spec.rb
+++ b/spec/services/build_journey_order_spec.rb
@@ -55,5 +55,40 @@ RSpec.describe BuildJourneyOrder do
         }.to raise_error(BuildJourneyOrder::RepeatEntryDetected)
       end
     end
+
+    context "when the journey visits more than the maximum permitted number of entries" do
+      around do |example|
+        ClimateControl.modify(
+          CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj"
+        ) do
+          example.run
+        end
+      end
+
+      it "raises a rollbar event with the last entry" do
+        # Creating 50 linked entries in a fixture slows the test suite down
+        # We assume these 50 entries are chained together in a linear sequence.
+        fake_entries = fake_contentful_entry_array(
+          contentful_fixture_filename: "closed-path-with-multiple-example.json"
+        )
+        expect(BuildJourneyOrder::ENTRY_JOURNEY_MAX_LENGTH).to eq(50)
+        stub_const("BuildJourneyOrder::ENTRY_JOURNEY_MAX_LENGTH", 1)
+
+        expect(Rollbar).to receive(:error)
+          .with("More than #{BuildJourneyOrder::ENTRY_JOURNEY_MAX_LENGTH} steps were found in a journey map",
+            contentful_url: ENV["CONTENTFUL_URL"],
+            contentful_space_id: ENV["CONTENTFUL_SPACE"],
+            contentful_environment: ENV["CONTENTFUL_ENVIRONMENT"],
+            contentful_entry_id: "hfjJgWRg4xiiiImwVRDtZ")
+          .and_call_original
+
+        expect {
+          described_class.new(
+            entries: fake_entries,
+            starting_entry_id: "5kZ9hIFDvNCEhjWs72SFwj"
+          ).call
+        }.to raise_error(BuildJourneyOrder::TooManyChainedEntriesDetected)
+      end
+    end
   end
 end


### PR DESCRIPTION

<!-- Do you need to update the changelog? -->

Based on https://github.com/DFE-Digital/buy-for-your-school/pull/76

Do we need more rules? Can we think of any other reasons to invalidate a journey for now?

## Changes in this PR

My plan is that this is the first of a 2 parter. If this validation is OK then I'll look to apply it when warming the cache. If an error occurs we can extend the TTL of the existing entries to ensure a happy journey always persists.

- when the journey shows the user the same step twice we infer an infinite loop and show an error on `journey_map/new`
- when the journey steps a user see exceeds 50 we infer there's no end and show an error on `journey_map/new`
- generating a real fixture for 50+ entries slows down the test suite considerably (+2mins) so we opt for stubbing the limit to a lower value. I have a hunch it's to do with the internals of https://github.com/DFE-Digital/buy-for-your-school/blob/develop/spec/support/contentful_helpers.rb#L71 though I could see no value in continuing the investigation.

## Screenshots of UI changes

![Screenshot 2020-12-15 at 15 00 51](https://user-images.githubusercontent.com/912473/102239492-d284f700-3eee-11eb-86f0-f67daf7f1ba3.png)
![Screenshot 2020-12-15 at 15 00 29](https://user-images.githubusercontent.com/912473/102239497-d3b62400-3eee-11eb-9467-dd06e022b8e5.png)