### PR TITLE
(118) Users can edit their answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - journey map shows an error to the content team if a duplicate entry is detected
 - journey map shows an error to the content team if the journey doesn't end within 50 steps
 - refactor how we store and access a Step's associated Contentful Entry ID
+- users can edit their answers
 
 ## [release-003] - 2020-12-07
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -27,6 +27,21 @@ class AnswersController < ApplicationController
     end
   end
 
+  def update
+    @journey = Journey.find(journey_id)
+    @step = Step.find(step_id)
+    @answer = @step.answer
+
+    @answer.assign_attributes(answer_params)
+
+    if @answer.valid?
+      @answer.save
+      redirect_to journey_path(@journey)
+    else
+      render "steps/#{@step.contentful_type}", locals: {layout: "steps/edit_form_wrapper"}
+    end
+  end
+
   private
 
   def journey_id

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -34,6 +34,14 @@ class StepsController < ApplicationController
     render @step.contentful_type, locals: {layout: "steps/new_form_wrapper"}
   end
 
+  def edit
+    @journey = Journey.find(journey_id)
+    @step = Step.find(params[:id])
+    @answer = @step.answer
+
+    render "steps/#{@step.contentful_type}", locals: {layout: "steps/edit_form_wrapper"}
+  end
+
   private
 
   def journey_id

--- a/app/views/journeys/_long_text_answer.html.erb
+++ b/app/views/journeys/_long_text_answer.html.erb
@@ -1,4 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
   <dd class="govuk-summary-list__value"><%= simple_format(step.answer.response) %></dd>
+  <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_radios_answer.html.erb
+++ b/app/views/journeys/_radios_answer.html.erb
@@ -1,4 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
   <dd class="govuk-summary-list__value"><%= answer.response.capitalize %></dd>
+  <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_short_text_answer.html.erb
+++ b/app/views/journeys/_short_text_answer.html.erb
@@ -1,4 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
   <dd class="govuk-summary-list__value"><%= answer.response %></dd>
+  <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/steps/_edit_form_wrapper.html.erb
+++ b/app/views/steps/_edit_form_wrapper.html.erb
@@ -1,0 +1,5 @@
+<%= content_for :title, @step.title %>
+<%= form_for @answer, as: :answer, method: "put", url: journey_step_answer_path(@journey, @step, @answer) do |f| %>
+  <%= yield f %>
+  <%= f.submit I18n.t("generic.button.update"), class: "govuk-button" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,8 @@ en:
     button:
       start: "Continue"
       next: "Continue"
+      change_answer: "Change"
+      update: "Update"
   banner:
     beta:
       tag: "beta"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,8 @@ Rails.application.routes.draw do
 
   resource :journey_map, only: [:new]
   resources :journeys, only: [:new, :show] do
-    resources :steps, only: [:new, :show] do
-      resources :answers, only: [:create]
+    resources :steps, only: [:new, :show, :edit] do
+      resources :answers, only: [:create, :update]
     end
   end
 

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -1,18 +1,18 @@
 FactoryBot.define do
   factory :radio_answer do
-    association :step, factory: :step, contentful_type: "radios"
+    association :step, factory: :step, contentful_type: "radios", contentful_model: "question"
 
     response { "Green" }
   end
 
   factory :short_text_answer do
-    association :step, factory: :step, contentful_type: "short_text"
+    association :step, factory: :step, contentful_type: "short_text", contentful_model: "question"
 
     response { "Green" }
   end
 
   factory :long_text_answer do
-    association :step, factory: :step, contentful_type: "long_text"
+    association :step, factory: :step, contentful_type: "long_text", contentful_model: "question"
 
     response { "Lots of green" }
   end

--- a/spec/features/visitors/anyone_can_edit_their_answers_spec.rb
+++ b/spec/features/visitors/anyone_can_edit_their_answers_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+feature "Users can edit their answers" do
+  let(:answer) { create(:short_text_answer, response: "answer") }
+  scenario "The journey summary page displays a change link" do
+    visit journey_path(answer.step.journey)
+
+    expect(page).to have_content("answer")
+    expect(page).to have_content("Change")
+  end
+
+  scenario "The edited answer is saved" do
+    visit journey_path(answer.step.journey)
+
+    click_on(I18n.t("generic.button.change_answer"))
+
+    fill_in "answer[response]", with: "email@example.com"
+
+    click_on(I18n.t("generic.button.update"))
+
+    expect(page).to have_content("email@example.com")
+  end
+
+  context "An error is thrown" do
+    scenario "When an answer is invalid" do
+      visit journey_path(answer.step.journey)
+
+      click_on(I18n.t("generic.button.change_answer"))
+
+      fill_in "answer[response]", with: ""
+
+      click_on(I18n.t("generic.button.update"))
+
+      expect(page).to have_content("can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

-  The `Check Your Answers` page displays a `Change` link for each step and relating answer
- The `Edit` and `Update` actions are implemented to allow users to edit their answers once given


## Screenshots of UI changes

### `Check Your Answers` page with Change links
 
<img width="1121" alt="Screenshot 2020-12-15 at 15 59 41" src="https://user-images.githubusercontent.com/59832893/102239427-c26d1780-3eee-11eb-80ed-04c11eb6f0e9.png">

### Navigates to the specific step to amend answer

<img width="1121" alt="Screenshot 2020-12-15 at 16 00 23" src="https://user-images.githubusercontent.com/59832893/102239466-cac55280-3eee-11eb-9c44-003cda7a0bc2.png">

### Saves new content and updates answer on `Check Your Answers` page

<img width="1121" alt="Screenshot 2020-12-15 at 16 00 33" src="https://user-images.githubusercontent.com/59832893/102239494-d31d8d80-3eee-11eb-8786-fd6452c62c91.png">

