### PR TITLE
(121) Part 2 - Only warm the cache with entries that form valid journeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - journey map shows an error to the content team if the journey doesn't end within 50 steps
 - refactor how we store and access a Step's associated Contentful Entry ID
 - users can edit their answers
+- only add Contentful entries that form part of a valid journey to the cache
 
 ## [release-003] - 2020-12-07
 

--- a/app/jobs/warm_entry_cache_job.rb
+++ b/app/jobs/warm_entry_cache_job.rb
@@ -5,10 +5,17 @@ class WarmEntryCacheJob < ApplicationJob
   sidekiq_options retry: 5
 
   def perform
-    entries = GetAllContentfulEntries.new.call
+    entries = BuildJourneyOrder.new(
+      entries: GetAllContentfulEntries.new.call,
+      starting_entry_id: ENV["CONTENTFUL_PLANNING_START_ENTRY_ID"]
+    ).call
+
     entries.each do |entry|
       store_in_cache(cache: cache, key: "contentful:entry:#{entry.id}", entry: entry)
     end
+  rescue BuildJourneyOrder::RepeatEntryDetected,
+    BuildJourneyOrder::TooManyChainedEntriesDetected
+    cache.extend_ttl_on_all_entries
   end
 
   private

--- a/app/services/cache.rb
+++ b/app/services/cache.rb
@@ -26,4 +26,13 @@ class Cache
     redis_cache.set(key, value)
     redis_cache.expire(key, ttl)
   end
+
+  def extend_ttl_on_all_entries(extension: (60 * 60 * 24))
+    redis_cache.keys("contentful:entry:*").map do |key|
+      previous_ttl = redis_cache.ttl(key)
+      extended_ttl = extension + previous_ttl
+
+      redis_cache.expire(key, extended_ttl)
+    end
+  end
 end

--- a/spec/fixtures/contentful/multiple-entries-example.json
+++ b/spec/fixtures/contentful/multiple-entries-example.json
@@ -59,7 +59,7 @@
                         "id": "rwl7tyzv9sys"
                     }
                 },
-                "id": "52Ni9UFvZj8BYXSbhs373C",
+                "id": "hfjJgWRg4xiiiImwVRDtZ",
                 "type": "Entry",
                 "createdAt": "2020-11-04T12:28:30.442Z",
                 "updatedAt": "2020-11-26T16:39:54.188Z",
@@ -93,7 +93,7 @@
                     "sys": {
                         "type": "Link",
                         "linkType": "Entry",
-                        "id": "hfjJgWRg4xiiiImwVRDtZ"
+                        "id": "52Ni9UFvZj8BYXSbhs373C"
                     }
                 }
             }

--- a/spec/jobs/warm_entry_cache_job_spec.rb
+++ b/spec/jobs/warm_entry_cache_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe WarmEntryCacheJob, type: :job do
 
   around do |example|
     ClimateControl.modify(
+      CONTENTFUL_PLANNING_START_ENTRY_ID: "5kZ9hIFDvNCEhjWs72SFwj",
       CONTENTFUL_ENTRY_CACHING: "true"
     ) do
       example.run
@@ -33,9 +34,9 @@ RSpec.describe WarmEntryCacheJob, type: :job do
         .to eql(
           "\"{\\\"sys\\\":{\\\"space\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Space\\\",\\\"id\\\":\\\"rwl7tyzv9sys\\\"}},\\\"id\\\":\\\"5kZ9hIFDvNCEhjWs72SFwj\\\",\\\"type\\\":\\\"Entry\\\",\\\"createdAt\\\":\\\"2020-12-02T10:48:35.748Z\\\",\\\"updatedAt\\\":\\\"2020-12-02T10:48:35.748Z\\\",\\\"environment\\\":{\\\"sys\\\":{\\\"id\\\":\\\"develop\\\",\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Environment\\\"}},\\\"revision\\\":1,\\\"contentType\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"ContentType\\\",\\\"id\\\":\\\"staticContent\\\"}},\\\"locale\\\":\\\"en-US\\\"},\\\"fields\\\":{\\\"slug\\\":\\\"/timelines\\\",\\\"title\\\":\\\"When you should start\\\",\\\"body\\\":\\\"Procuring a new catering contract can take up to 6 months to consult, create, review and award. \\\\n\\\\nUsually existing contracts start and end in the month of September. We recommend starting this process around March.\\\",\\\"type\\\":\\\"paragraphs\\\",\\\"next\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Entry\\\",\\\"id\\\":\\\"hfjJgWRg4xiiiImwVRDtZ\\\"}}}}\""
         )
-      expect(RedisCache.redis.get("contentful:entry:52Ni9UFvZj8BYXSbhs373C"))
+      expect(RedisCache.redis.get("contentful:entry:hfjJgWRg4xiiiImwVRDtZ"))
         .to eql(
-          "\"{\\\"sys\\\":{\\\"space\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Space\\\",\\\"id\\\":\\\"rwl7tyzv9sys\\\"}},\\\"id\\\":\\\"52Ni9UFvZj8BYXSbhs373C\\\",\\\"type\\\":\\\"Entry\\\",\\\"createdAt\\\":\\\"2020-11-04T12:28:30.442Z\\\",\\\"updatedAt\\\":\\\"2020-11-26T16:39:54.188Z\\\",\\\"environment\\\":{\\\"sys\\\":{\\\"id\\\":\\\"develop\\\",\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Environment\\\"}},\\\"revision\\\":6,\\\"contentType\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"ContentType\\\",\\\"id\\\":\\\"question\\\"}},\\\"locale\\\":\\\"en-US\\\"},\\\"fields\\\":{\\\"slug\\\":\\\"/dev-start-which-service\\\",\\\"title\\\":\\\"Which service do you need?\\\",\\\"helpText\\\":\\\"Tell us which service you need.\\\",\\\"type\\\":\\\"radios\\\",\\\"options\\\":[\\\"Catering\\\",\\\"Cleaning\\\"],\\\"next\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Entry\\\",\\\"id\\\":\\\"hfjJgWRg4xiiiImwVRDtZ\\\"}}}}\""
+          "\"{\\\"sys\\\":{\\\"space\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Space\\\",\\\"id\\\":\\\"rwl7tyzv9sys\\\"}},\\\"id\\\":\\\"hfjJgWRg4xiiiImwVRDtZ\\\",\\\"type\\\":\\\"Entry\\\",\\\"createdAt\\\":\\\"2020-11-04T12:28:30.442Z\\\",\\\"updatedAt\\\":\\\"2020-11-26T16:39:54.188Z\\\",\\\"environment\\\":{\\\"sys\\\":{\\\"id\\\":\\\"develop\\\",\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Environment\\\"}},\\\"revision\\\":6,\\\"contentType\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"ContentType\\\",\\\"id\\\":\\\"question\\\"}},\\\"locale\\\":\\\"en-US\\\"},\\\"fields\\\":{\\\"slug\\\":\\\"/dev-start-which-service\\\",\\\"title\\\":\\\"Which service do you need?\\\",\\\"helpText\\\":\\\"Tell us which service you need.\\\",\\\"type\\\":\\\"radios\\\",\\\"options\\\":[\\\"Catering\\\",\\\"Cleaning\\\"],\\\"next\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Entry\\\",\\\"id\\\":\\\"52Ni9UFvZj8BYXSbhs373C\\\"}}}}\""
         )
     end
   end

--- a/spec/jobs/warm_entry_cache_job_spec.rb
+++ b/spec/jobs/warm_entry_cache_job_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe WarmEntryCacheJob, type: :job do
   include ActiveJob::TestHelper
 
   before(:each) { ActiveJob::Base.queue_adapter = :test }
+  after(:each) { RedisCache.redis.flushdb }
 
   around do |example|
     ClimateControl.modify(
@@ -38,6 +39,49 @@ RSpec.describe WarmEntryCacheJob, type: :job do
         .to eql(
           "\"{\\\"sys\\\":{\\\"space\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Space\\\",\\\"id\\\":\\\"rwl7tyzv9sys\\\"}},\\\"id\\\":\\\"hfjJgWRg4xiiiImwVRDtZ\\\",\\\"type\\\":\\\"Entry\\\",\\\"createdAt\\\":\\\"2020-11-04T12:28:30.442Z\\\",\\\"updatedAt\\\":\\\"2020-11-26T16:39:54.188Z\\\",\\\"environment\\\":{\\\"sys\\\":{\\\"id\\\":\\\"develop\\\",\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Environment\\\"}},\\\"revision\\\":6,\\\"contentType\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"ContentType\\\",\\\"id\\\":\\\"question\\\"}},\\\"locale\\\":\\\"en-US\\\"},\\\"fields\\\":{\\\"slug\\\":\\\"/dev-start-which-service\\\",\\\"title\\\":\\\"Which service do you need?\\\",\\\"helpText\\\":\\\"Tell us which service you need.\\\",\\\"type\\\":\\\"radios\\\",\\\"options\\\":[\\\"Catering\\\",\\\"Cleaning\\\"],\\\"next\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Entry\\\",\\\"id\\\":\\\"52Ni9UFvZj8BYXSbhs373C\\\"}}}}\""
         )
+    end
+
+    context "when the journey order cannot be built" do
+      it "does not add new items to the cache" do
+        allow_any_instance_of(BuildJourneyOrder)
+          .to receive(:call)
+          .and_raise(BuildJourneyOrder::RepeatEntryDetected)
+
+        stub_get_contentful_entries(
+          entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+          fixture_filename: "repeat-entry-example.json"
+        )
+
+        described_class.perform_later
+        perform_enqueued_jobs
+
+        expect(RedisCache.redis).not_to receive(:set).with("contentful:entry:5kZ9hIFDvNCEhjWs72SFwj", anything)
+      end
+
+      it "extends the TTL on all existing items by 24 hours" do
+        RedisCache.redis.set("contentful:entry:5kZ9hIFDvNCEhjWs72SFwj", "\"{\\}\"")
+
+        allow_any_instance_of(BuildJourneyOrder)
+          .to receive(:call)
+          .and_raise(BuildJourneyOrder::RepeatEntryDetected)
+
+        stub_get_contentful_entries(
+          entry_id: "5kZ9hIFDvNCEhjWs72SFwj",
+          fixture_filename: "repeat-entry-example.json"
+        )
+
+        freeze_time do
+          ttl_extension = 60 * 60 * 24
+          existing_ttl = -1
+
+          expect(RedisCache.redis)
+            .to receive(:expire)
+            .with("contentful:entry:5kZ9hIFDvNCEhjWs72SFwj", ttl_extension + existing_ttl)
+
+          described_class.perform_later
+          perform_enqueued_jobs
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

Based on https://github.com/DFE-Digital/buy-for-your-school/pull/80

## Changes in this PR

We use the validation added in https://github.com/DFE-Digital/buy-for-your-school/pull/80 in the nightly cache warming task.

If we find an error in the journey we no longer add it to the cache, instead we will extend all previous entries on the assumption that they were valid.
