### PR TITLE
(225) Refactor Steps so they now include an Contentful entry ID as a unique field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can be asked to provide multiple answers via a checkbox question
 - journey map shows an error to the content team if a duplicate entry is detected
 - journey map shows an error to the content team if the journey doesn't end within 50 steps
+- refactor how we store and access a Step's associated Contentful Entry ID
 
 ## [release-003] - 2020-12-07
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -21,4 +21,9 @@ class Step < ApplicationRecord
     return I18n.t("generic.button.next") unless super.present?
     super
   end
+
+  # TODO: Change raw field type to jsonb
+  def raw
+    JSON.parse super.gsub("=>", ":")
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -21,9 +21,4 @@ class Step < ApplicationRecord
     return I18n.t("generic.button.next") unless super.present?
     super
   end
-
-  # TODO: Change raw field type to jsonb
-  def raw
-    JSON.parse super.gsub("=>", ":")
-  end
 end

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -34,6 +34,7 @@ class CreateJourneyStep
       title: title,
       help_text: help_text,
       body: body,
+      contentful_id: content_entry_id,
       contentful_model: content_model,
       contentful_type: step_type,
       options: options,

--- a/db/migrate/20201216150806_add_contentful_id_to_step.rb
+++ b/db/migrate/20201216150806_add_contentful_id_to_step.rb
@@ -1,0 +1,18 @@
+class AddContentfulIdToStep < ActiveRecord::Migration[6.1]
+  def up
+    add_column :steps, :contentful_id, :string
+
+    ActiveRecord::Base.transaction do
+      Step.all.map do |step|
+        contentful_id = step.raw.dig("sys", "id")
+        step.update(contentful_id: contentful_id)
+      end
+    end
+
+    change_column :steps, :contentful_id, :string, null: false
+  end
+
+  def down
+    remove_column :steps, :contentful_id, :string
+  end
+end

--- a/db/migrate/20201216160028_change_step_raw_field_to_json_b.rb
+++ b/db/migrate/20201216160028_change_step_raw_field_to_json_b.rb
@@ -1,0 +1,25 @@
+class ChangeStepRawFieldToJsonB < ActiveRecord::Migration[6.1]
+  def up
+    add_column :steps, :raw_jsonb, :jsonb, null: false
+    ActiveRecord::Base.transaction do
+      Step.all.map do |step|
+        hash = JSON.parse(step.raw.gsub("=>", ":"))
+        step.update(raw_jsonb: hash)
+      end
+    end
+    remove_column :steps, :raw
+    rename_column :steps, :raw_jsonb, :raw
+  end
+
+  def down
+    add_column :steps, :raw_binary, :binary, null: false
+    ActiveRecord::Base.transaction do
+      Step.all.map do |step|
+        string = step.raw.to_s
+        step.update(raw_binary: string)
+      end
+    end
+    remove_column :steps, :raw
+    rename_column :steps, :raw_binary, :raw
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_150806) do
+ActiveRecord::Schema.define(version: 2020_12_16_160028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -70,13 +70,13 @@ ActiveRecord::Schema.define(version: 2020_12_16_150806) do
     t.string "help_text"
     t.string "contentful_type", null: false
     t.string "options", array: true
-    t.binary "raw", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
     t.string "contentful_model"
     t.string "primary_call_to_action_text"
     t.string "contentful_id", null: false
+    t.jsonb "raw", null: false
     t.index ["journey_id"], name: "index_steps_on_journey_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_122555) do
+ActiveRecord::Schema.define(version: 2020_12_16_150806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_122555) do
     t.text "body"
     t.string "contentful_model"
     t.string "primary_call_to_action_text"
+    t.string "contentful_id", null: false
     t.index ["journey_id"], name: "index_steps_on_journey_id"
   end
 

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :step do
     title { "What is your favourite colour?" }
     help_text { "Choose the primary colour closest to your choice" }
-    raw { "{\"sys\":{}}" }
+    raw { "{\"sys\":{\"id\"=>\"123\"}}" }
+    contentful_id { "123" }
 
     association :journey, factory: :journey
 

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -21,11 +21,8 @@ RSpec.describe Step, type: :model do
   end
 
   it "captures the raw contentful response" do
-    contentful_json_response = JSON("foo": {})
-    step = build(:step,
-      raw: contentful_json_response)
-
-    expect(step.raw).to eql({"foo" => {}})
+    step = build(:step, raw: {foo: "bar"})
+    expect(step.raw).to eql({"foo" => "bar"})
   end
 
   describe "#answer" do

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Step, type: :model do
     step = build(:step,
       raw: contentful_json_response)
 
-    expect(step.raw).to eql("{\"foo\":{}}")
+    expect(step.raw).to eql({"foo" => {}})
   end
 
   describe "#answer" do

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -16,7 +16,44 @@ RSpec.describe CreateJourneyStep do
         expect(step.contentful_model).to eq("question")
         expect(step.contentful_type).to eq("radios")
         expect(step.options).to eq(["Catering", "Cleaning"])
-        expect(step.raw).to eq(fake_entry.raw)
+        expect(step.raw).to eq(
+          "fields" => {
+            "helpText" => "Tell us which service you need.",
+            "options" => ["Catering", "Cleaning"],
+            "slug" => "/which-service",
+            "title" => "Which service do you need?",
+            "type" => "radios"
+          },
+          "sys" => {
+            "contentType" => {
+              "sys" => {
+                "id" => "question",
+                "linkType" => "ContentType",
+                "type" => "Link"
+              }
+            },
+            "createdAt" => "2020-09-07T10:56:40.585Z",
+            "environment" => {
+              "sys" => {
+                "id" => "master",
+                "linkType" => "Environment",
+                "type" => "Link"
+              }
+            },
+            "id" => "1UjQurSOi5MWkcRuGxdXZS",
+            "locale" => "en-US",
+            "revision" => 7,
+            "space" => {
+              "sys" => {
+                "id" => "jspwts36h1os",
+                "linkType" => "Space",
+                "type" => "Link"
+              }
+            },
+            "type" => "Entry",
+            "updatedAt" => "2020-09-14T22:16:54.633Z"
+          }
+        )
       end
 
       it "updates the journey with a new next_entry_id" do

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CreateJourneyStep do
 
         expect(step.title).to eq("Which service do you need?")
         expect(step.help_text).to eq("Tell us which service you need.")
+        expect(step.contentful_id).to eq("1UjQurSOi5MWkcRuGxdXZS")
         expect(step.contentful_model).to eq("question")
         expect(step.contentful_type).to eq("radios")
         expect(step.options).to eq(["Catering", "Cleaning"])

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -59,7 +59,7 @@ module ContentfulHelpers
       type: hash_response.dig("fields", "type"),
       next: double(id: hash_response.dig("fields", "next", "sys", "id")),
       primary_call_to_action: hash_response.dig("fields", "primaryCallToAction"),
-      raw: raw_response,
+      raw: hash_response,
       content_type: double(id: hash_response.dig("sys", "contentType", "sys", "id"))
     )
   end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

This change is a prior refactor ahead of the linking of Journeys to the [creation of their Specification](https://trello.com/c/5plFnXEs). We know that each Step will need to be linked to another Contentful Entry as part of this work.

I imagine that for a Journey we would:

1. Get the Specification Entry
2. Loop through each of the linked Specification Block Entries
3. For each Block Entry, find an associated Step
4. Add it to a new document based on the answer

Step 3 is what this pull request seeks to make easier. Instead of having to go into the `raw` attribute of each step we can do something like: `journey.steps.find(contentful_id: block_entry_id)`

## Changes in this PR

- a new `contentful_id` column exists on Steps
- we were storing the Contentful ID in the raw attribute. We can use this to migrate all existing records so that they have this field
- change the column type from `binary` to `jsonb` so we can recieve a hash when we access `raw`
