### PR TITLE
Fix Contentful ID migration so it can run

### DIFF
--- a/db/migrate/20201216150806_add_contentful_id_to_step.rb
+++ b/db/migrate/20201216150806_add_contentful_id_to_step.rb
@@ -4,7 +4,9 @@ class AddContentfulIdToStep < ActiveRecord::Migration[6.1]
 
     ActiveRecord::Base.transaction do
       Step.all.map do |step|
-        contentful_id = step.raw.dig("sys", "id")
+        contentful_id = JSON.parse(
+          step.raw.gsub("=>", ":")
+        ).dig("sys", "id")
         step.update(contentful_id: contentful_id)
       end
     end


### PR DESCRIPTION
[Currently staging migrations are failing](https://rollbar.com/dxw/dfe-buy-for-your-school/items/43/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification). 

The migration worked locally until I removed the temporary method that parsed the string into a hash in a later commit 🤦  https://github.com/DFE-Digital/buy-for-your-school/pull/84/commits/c3c5096bb14cf0c58bd5bc8323be5a69c8fa45a7#diff-d0a4710bfb2223d4b6f70da35e5d63f599611786b7b688571d372362c2f57df4L27

This change moves that code into the migration so it can run regardless of the state of the step methods.

I've tested this on the staging console on real data to check it definitely works:

![Screenshot 2020-12-17 at 11 59 01](https://user-images.githubusercontent.com/912473/102485556-b18fe380-405f-11eb-9f8b-f4aff4ab2fb2.png)
