### PR TITLE
Fix migration so presence validation is applied at the end

### DIFF
--- a/db/migrate/20201216160028_change_step_raw_field_to_json_b.rb
+++ b/db/migrate/20201216160028_change_step_raw_field_to_json_b.rb
@@ -1,6 +1,6 @@
 class ChangeStepRawFieldToJsonB < ActiveRecord::Migration[6.1]
   def up
-    add_column :steps, :raw_jsonb, :jsonb, null: false
+    add_column :steps, :raw_jsonb, :jsonb
     ActiveRecord::Base.transaction do
       Step.all.map do |step|
         hash = JSON.parse(step.raw.gsub("=>", ":"))
@@ -9,10 +9,11 @@ class ChangeStepRawFieldToJsonB < ActiveRecord::Migration[6.1]
     end
     remove_column :steps, :raw
     rename_column :steps, :raw_jsonb, :raw
+    change_column :steps, :raw, :jsonb, null: false
   end
 
   def down
-    add_column :steps, :raw_binary, :binary, null: false
+    add_column :steps, :raw_binary, :binary
     ActiveRecord::Base.transaction do
       Step.all.map do |step|
         string = step.raw.to_s
@@ -21,5 +22,6 @@ class ChangeStepRawFieldToJsonB < ActiveRecord::Migration[6.1]
     end
     remove_column :steps, :raw
     rename_column :steps, :raw_binary, :raw
+    change_column :steps, :raw, :binary, null: false
   end
 end


### PR DESCRIPTION
Applying this straight away fails because of course the new field has no value at all. This shouldn't have got through local testing but alas it did and now we have to fix it.

Create the new temp field without validation, and add it at the end. By adding it at the end, after populating the columns, we should the be told if we still have missing values. That failure is the one we want.
