### PR TITLE
Add missing change links to the new types of step (checkbox and date)

### DIFF
--- a/app/views/journeys/_checkboxes_answer.html.erb
+++ b/app/views/journeys/_checkboxes_answer.html.erb
@@ -1,4 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
   <dd class="govuk-summary-list__value"><%= answer.response.reject(&:blank?).map(&:capitalize).join(", ") %></dd>
+  <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_single_date_answer.html.erb
+++ b/app/views/journeys/_single_date_answer.html.erb
@@ -1,4 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
   <dd class="govuk-summary-list__value"><%= I18n.l(answer.response) %></dd>
+  <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Whilst adding the ability to change your answer we also added new types. These new types also need the change buttons.

## Screenshots of UI changes

### Before
![Screenshot 2020-12-17 at 14 35 02](https://user-images.githubusercontent.com/912473/102502233-48679a80-4076-11eb-8c96-bfbde20eeac1.png)

### After
![Screenshot 2020-12-17 at 14 41 39](https://user-images.githubusercontent.com/912473/102502230-47366d80-4076-11eb-9454-a524c87e4b26.png)
