### PR TITLE
Fix test so that step.raw returns as a hash rather than string

### DIFF
--- a/spec/requests/contentful_caching_spec.rb
+++ b/spec/requests/contentful_caching_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Contentful Caching", type: :request do
 
   it "stores the external contentful response in the cache" do
     journey = create(:journey, next_entry_id: "1UjQurSOi5MWkcRuGxdXZS")
-    raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/radio-question-example.json")
     stub_get_contentful_entry(
       entry_id: "1UjQurSOi5MWkcRuGxdXZS",
       fixture_filename: "radio-question-example.json"
@@ -35,7 +34,7 @@ RSpec.describe "Contentful Caching", type: :request do
     get new_journey_step_path(journey)
 
     expect(RedisCache.redis.get("contentful:entry:1UjQurSOi5MWkcRuGxdXZS"))
-      .to eq(JSON.dump(raw_response.to_json))
+      .to eq("\"{\\\"sys\\\":{\\\"space\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Space\\\",\\\"id\\\":\\\"jspwts36h1os\\\"}},\\\"id\\\":\\\"1UjQurSOi5MWkcRuGxdXZS\\\",\\\"type\\\":\\\"Entry\\\",\\\"createdAt\\\":\\\"2020-09-07T10:56:40.585Z\\\",\\\"updatedAt\\\":\\\"2020-09-14T22:16:54.633Z\\\",\\\"environment\\\":{\\\"sys\\\":{\\\"id\\\":\\\"master\\\",\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"Environment\\\"}},\\\"revision\\\":7,\\\"contentType\\\":{\\\"sys\\\":{\\\"type\\\":\\\"Link\\\",\\\"linkType\\\":\\\"ContentType\\\",\\\"id\\\":\\\"question\\\"}},\\\"locale\\\":\\\"en-US\\\"},\\\"fields\\\":{\\\"slug\\\":\\\"/which-service\\\",\\\"title\\\":\\\"Which service do you need?\\\",\\\"helpText\\\":\\\"Tell us which service you need.\\\",\\\"type\\\":\\\"radios\\\",\\\"options\\\":[\\\"Catering\\\",\\\"Cleaning\\\"]}}\"")
 
     RedisCache.redis.del("contentful:entry:1UjQurSOi5MWkcRuGxdXZS")
   end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -3,16 +3,11 @@ module ContentfulHelpers
     entry_id: "1UjQurSOi5MWkcRuGxdXZS",
     fixture_filename: "radio-question-example.json"
   )
-    raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{fixture_filename}")
-
     contentful_connector = stub_contentful_connector
     contentful_response = fake_contentful_entry(contentful_fixture_filename: fixture_filename)
     allow(contentful_connector).to receive(:get_entry_by_id)
       .with(entry_id)
       .and_return(contentful_response)
-
-    allow(contentful_response).to receive(:raw)
-      .and_return(raw_response)
   end
 
   def stub_get_contentful_entries(


### PR DESCRIPTION
## Changes in this PR

We expect the raw method to return a `hash`. This expectation ensures we can reliably interogate it with methods such as `fetch`.

In starting another piece of work I found that a couple of tests [1] that don't use `fake_contentful_entry` but instead only rely on `stub_get_contentful_entry` to stub out a fake Contentful response to use as the `raw` value. I found that the behaviour differs between methods. In `stub_get_contentful_entry` we set `raw` to the string contents of the file, but in `fake_contentful_entry` we have an extra step to parse the string into JSON. We find that where only `stub_get_contentful_entry` is used, `raw` is in fact a string.

This change removes the redundant code in `stub_get_contentful_entry`. We can see that only 1 test actually fails. We change that failure to check the exact output we expectm, instead of trying to be clean and use parsing methods in the test. This no doubt patched over the problem and made it harder to spot.

[1] ./spec/features/visitors/anyone_can_complete_a_journey_spec.rb:29

