### PR TITLE
Docker Compose server start auto purges any leftover pid file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         RAILS_ENV: "development"
         BUNDLE_EXTRA_GEM_GROUPS: "development test"
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"
     image: "buy_for_your_school:dev"


### PR DESCRIPTION
When we start the webserver it creates a pid file in tmp/.

When running the server locally with docker compose and you turn off your machine without gracefully terminating the server process the file remains.

When you start the server again you get an error asking you to remove the existing pid file.

This change automates this step so we don't have to do this manual step each time.

It doesn't affect production environments.

# Screenshots
## Before
![Screenshot 2021-01-15 at 11 23 22](https://user-images.githubusercontent.com/912473/104720298-e48fca80-5724-11eb-850c-6b7a8ad69500.png)

