### PR TITLE
(185) Users can be asked Radio questions that prompt for additional text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - questions are now all loaded at the start of a journey, rather than step by step
 - users start the journey at the task list instead of the first question
 - check your answers pattern has been replaced by a task list
+- radio questions can be configured to ask the user for additional text
 
 ## [release-004] - 2020-12-17
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -54,7 +54,7 @@ class AnswersController < ApplicationController
   end
 
   def answer_params
-    params.require(:answer).permit(:response)
+    params.require(:answer).permit(:response, :further_information)
   end
 
   def checkbox_params

--- a/app/presenters/checkboxes_answer_presenter.rb
+++ b/app/presenters/checkboxes_answer_presenter.rb
@@ -1,0 +1,5 @@
+class CheckboxesAnswerPresenter < SimpleDelegator
+  def response
+    super.reject(&:blank?).map(&:capitalize).join(", ")
+  end
+end

--- a/app/presenters/long_text_answer_presenter.rb
+++ b/app/presenters/long_text_answer_presenter.rb
@@ -1,0 +1,7 @@
+class LongTextAnswerPresenter < SimpleDelegator
+  include ActionView::Helpers::TextHelper
+
+  def response
+    simple_format(super)
+  end
+end

--- a/app/presenters/radio_answer_presenter.rb
+++ b/app/presenters/radio_answer_presenter.rb
@@ -1,0 +1,7 @@
+class RadioAnswerPresenter < SimpleDelegator
+  def response
+    return super.capitalize if further_information.blank?
+
+    "#{super.capitalize} - #{further_information}"
+  end
+end

--- a/app/presenters/short_text_answer_presenter.rb
+++ b/app/presenters/short_text_answer_presenter.rb
@@ -1,0 +1,2 @@
+class ShortTextAnswerPresenter < SimpleDelegator
+end

--- a/app/presenters/single_date_answer_presenter.rb
+++ b/app/presenters/single_date_answer_presenter.rb
@@ -1,0 +1,5 @@
+class SingleDateAnswerPresenter < SimpleDelegator
+  def response
+    I18n.l(super)
+  end
+end

--- a/app/views/journeys/_checkboxes_answer.html.erb
+++ b/app/views/journeys/_checkboxes_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= step.answer.response.reject(&:blank?).map(&:capitalize).join(", ") %></dd>
+  <dd class="govuk-summary-list__value"><%= CheckboxesAnswerPresenter.new(step.answer).response %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_checkboxes_answer.html.erb
+++ b/app/views/journeys/_checkboxes_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= answer.response.reject(&:blank?).map(&:capitalize).join(", ") %></dd>
+  <dd class="govuk-summary-list__value"><%= step.answer.response.reject(&:blank?).map(&:capitalize).join(", ") %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_long_text_answer.html.erb
+++ b/app/views/journeys/_long_text_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= simple_format(step.answer.response) %></dd>
+  <dd class="govuk-summary-list__value"><%= LongTextAnswerPresenter.new(step.answer).response %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_radios_answer.html.erb
+++ b/app/views/journeys/_radios_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= answer.response.capitalize %></dd>
+  <dd class="govuk-summary-list__value"><%= answer.response.capitalize %><%= " - #{answer.further_information}" if answer.further_information.present? %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_radios_answer.html.erb
+++ b/app/views/journeys/_radios_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= step.answer.response.capitalize %><%= " - #{step.answer.further_information}" if step.answer.further_information.present? %></dd>
+  <dd class="govuk-summary-list__value"><%= RadioAnswerPresenter.new(step.answer).response %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_radios_answer.html.erb
+++ b/app/views/journeys/_radios_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= answer.response.capitalize %><%= " - #{answer.further_information}" if answer.further_information.present? %></dd>
+  <dd class="govuk-summary-list__value"><%= step.answer.response.capitalize %><%= " - #{step.answer.further_information}" if step.answer.further_information.present? %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_short_text_answer.html.erb
+++ b/app/views/journeys/_short_text_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= answer.response %></dd>
+  <dd class="govuk-summary-list__value"><%= step.answer.response %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_short_text_answer.html.erb
+++ b/app/views/journeys/_short_text_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= step.answer.response %></dd>
+  <dd class="govuk-summary-list__value"><%= ShortTextAnswerPresenter.new(step.answer).response %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_single_date_answer.html.erb
+++ b/app/views/journeys/_single_date_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= I18n.l(answer.response) %></dd>
+  <dd class="govuk-summary-list__value"><%= I18n.l(step.answer.response) %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/journeys/_single_date_answer.html.erb
+++ b/app/views/journeys/_single_date_answer.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key"><%= step.title %></dt>
-  <dd class="govuk-summary-list__value"><%= I18n.l(step.answer.response) %></dd>
+  <dd class="govuk-summary-list__value"><%= SingleDateAnswerPresenter.new(step.answer).response %></dd>
   <dd class="govuk-summary-list__actions"><%= link_to I18n.t("generic.button.change_answer"), edit_journey_step_path(@journey, step), class: "govuk-link" %></dd>
 </div>

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -1,13 +1,21 @@
 <%= render layout: layout do |f| %>
   <%= f.hidden_field :response, value: nil %>
   <%= f.govuk_radio_buttons_fieldset(:response, legend: { size: 'm', text: @step.title }) do %>
+
     <% if @step.help_text.present? %>
       <span class="govuk-hint">
         <%= @step.help_text %>
       </span>
     <% end %>
+
     <% @step.options.each do |option| %>
-      <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] } %>
+      <% if option["display_further_information"] == true %>
+        <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } do %>
+          <%= f.govuk_text_area :further_information, rows: 1, label: { text: option["further_information_help_text"] } %>
+        <% end %>
+      <% else %>
+        <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/db/migrate/20210118123111_add_further_information_to_radio_answer.rb
+++ b/db/migrate/20210118123111_add_further_information_to_radio_answer.rb
@@ -1,0 +1,5 @@
+class AddFurtherInformationToRadioAnswer < ActiveRecord::Migration[6.1]
+  def change
+    add_column :radio_answers, :further_information, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_110545) do
+ActiveRecord::Schema.define(version: 2021_01_18_123111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_110545) do
     t.string "response", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "further_information"
     t.index ["step_id"], name: "index_radio_answers_on_step_id"
   end
 

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :step, factory: :step, contentful_type: "radios", contentful_model: "question"
 
     response { "Green" }
+    further_information { nil }
   end
 
   factory :short_text_answer do

--- a/spec/fixtures/contentful/closed-path-with-multiple-example.json
+++ b/spec/fixtures/contentful/closed-path-with-multiple-example.json
@@ -87,7 +87,9 @@
                 "type": "radios",
                 "extendedOptions": [
                   {
-                      "value": "Catering"
+                      "value": "Catering",
+                      "display_further_information": true,
+                      "further_information_help_text": "Do a thing"
                   },
                   {
                       "value": "Cleaning"

--- a/spec/fixtures/contentful/extended-radio-question-example.json
+++ b/spec/fixtures/contentful/extended-radio-question-example.json
@@ -1,0 +1,51 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "jspwts36h1os"
+            }
+        },
+        "id": "contentful-starting-step",
+        "type": "Entry",
+        "createdAt": "2020-09-07T10:56:40.585Z",
+        "updatedAt": "2020-09-14T22:16:54.633Z",
+        "environment": {
+            "sys": {
+                "id": "master",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 7,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/which-service",
+        "title": "Which service do you need?",
+        "helpText": "Tell us which service you need.",
+        "type": "radios",
+        "extendedOptions": [
+          {
+              "value": "Catering",
+              "help_text": "",
+              "display_further_information": true,
+              "further_information_help_text": "Briefly describe why you need catering"
+          },
+          {
+              "value": "Cleaning",
+              "help_text": "All interior areas of the school only",
+              "display_further_information": false,
+              "further_information_help_text": "Briefly describe why you need cleaning"
+          }
+        ]
+    }
+}

--- a/spec/presenters/checkboxes_answer_presenter_spec.rb
+++ b/spec/presenters/checkboxes_answer_presenter_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe CheckboxesAnswerPresenter do
+  describe "#response" do
+    it "returns all none nil values, capitalised as a comma separated string" do
+      step = build(:checkbox_answers, response: ["yes", "no", ""])
+      presenter = described_class.new(step)
+      expect(presenter.response).to eq("Yes, No")
+    end
+  end
+end

--- a/spec/presenters/long_text_answer_presenter_spec.rb
+++ b/spec/presenters/long_text_answer_presenter_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe LongTextAnswerPresenter do
+  describe "#response" do
+    it "returns the response in HTML using the Rails simple_format method" do
+      step = build(:long_text_answer, response: "Lots of text")
+      presenter = described_class.new(step)
+      expect(presenter.response).to eq("<p>Lots of text</p>")
+    end
+
+    context "when the text includes line breaks" do
+      it "returns 2 HTML paragraphs" do
+        step = build(:long_text_answer, response: "First line\r\nSecond line")
+        presenter = described_class.new(step)
+        expect(presenter.response).to eq("<p>First line\n<br />Second line</p>")
+      end
+    end
+  end
+end

--- a/spec/presenters/radio_answer_presenter_spec.rb
+++ b/spec/presenters/radio_answer_presenter_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe RadioAnswerPresenter do
+  describe "#response" do
+    it "returns the option chosen" do
+      step = build(:radio_answer, response: "Yes", further_information: "")
+      presenter = described_class.new(step)
+      expect(presenter.response).to eq("Yes")
+    end
+
+    context "when further information is provided" do
+      it "returns the option chosen and the further information" do
+        step = build(:radio_answer, response: "Yes", further_information: "This is really important")
+        presenter = described_class.new(step)
+        expect(presenter.response).to eq("Yes - This is really important")
+      end
+    end
+  end
+end

--- a/spec/presenters/short_text_answer_presenter_spec.rb
+++ b/spec/presenters/short_text_answer_presenter_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe ShortTextAnswerPresenter do
+  describe "#response" do
+    it "returns the response" do
+      step = build(:short_text_answer, response: "A little of text")
+      presenter = described_class.new(step)
+      expect(presenter.response).to eq("A little of text")
+    end
+  end
+end

--- a/spec/presenters/single_date_answer_presenter_spec.rb
+++ b/spec/presenters/single_date_answer_presenter_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe SingleDateAnswerPresenter do
+  describe "#response" do
+    it "returns the response formatted as a date" do
+      step = build(:single_date_answer, response: Date.new(2000, 12, 30))
+      presenter = described_class.new(step)
+      expect(presenter.response).to eq("30 Dec 2000")
+    end
+  end
+end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

To review locally you can use Entry ID `QvmpHjUCDyx0EofNDn9hX` in your .env as the starting entry.

Use this [1] pattern from the DFE Form builder gem. We take the behaviour that is applied to the 'Other' option in the example and make it applicable to any radio option, or none.

This change also includes a refactoring of teh way we present answers to different answer types. Moving the logic from the view into tested presenters. These commits are on the end and can be easily removed if controversial in any way. The goal is to chip away at a secondary problem in passing.

- Contentful always supplies JSON for a list of options. It is now possible to provide more than a simple list of values in thei JSON blob. If the Content user provides keys `display_further_information` and `further_information_help_text` then the question will render an extra text input. This is per option and is not required.
- This new text input is then shown back as a composite string value to the user at the end of the journey.
- The field is a text area rather than a field as the content team wanted the user to drag the text area bigger if a longer answer was necessary.
- We think we may want to toggle validation through configuration in future. For now these text fields are optional and won't fire validation errors.

[1] https://govuk-form-builder.netlify.app/form-elements/radios/#radio-buttons-fieldset-with-conditional-content-and-a-divider

## Screenshots of UI changes

![Screenshot 2021-01-18 at 14 18 24](https://user-images.githubusercontent.com/912473/104927543-7acc2680-5999-11eb-87cc-5eed9a95efad.png)
![Screenshot 2021-01-18 at 14 19 25](https://user-images.githubusercontent.com/912473/104927549-7d2e8080-5999-11eb-9e77-9788e5a9ba57.png)
![Screenshot 2021-01-18 at 14 20 18](https://user-images.githubusercontent.com/912473/104927563-815a9e00-5999-11eb-83fe-ccc6e3b23c97.png)
![Screenshot 2021-01-18 at 14 20 10](https://user-images.githubusercontent.com/912473/104927569-828bcb00-5999-11eb-861f-bda498f030e3.png)

