### PR TITLE
Fix radio question label size inconsistency

### DIFF
--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -3,6 +3,6 @@
     checkbox_options(array_of_options: @step.options_list),
     :id,
     :name,
-    legend: { text: @step.title, size: "xl" }
+    legend: { text: @step.title, size: "l" }
   %>
 <% end %>

--- a/app/views/steps/long_text.html.erb
+++ b/app/views/steps/long_text.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_area :response,
-    label: { text: @step.title, size: 'xl' },
+    label: { text: @step.title, size: "l" },
     hint: { text: @step.help_text },
     width: "one-third",
     rows: 9

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.hidden_field :response, value: nil %>
-  <%= f.govuk_radio_buttons_fieldset(:response, legend: { size: 'xl', text: @step.title }) do %>
+  <%= f.govuk_radio_buttons_fieldset(:response, legend: { size: "l", text: @step.title }) do %>
     <% if @step.help_text.present? %>
       <span class="govuk-hint">
         <%= @step.help_text %>

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -1,7 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.hidden_field :response, value: nil %>
-  <%= f.govuk_radio_buttons_fieldset(:response, legend: { size: 'm', text: @step.title }) do %>
-
+  <%= f.govuk_radio_buttons_fieldset(:response, legend: { size: 'xl', text: @step.title }) do %>
     <% if @step.help_text.present? %>
       <span class="govuk-hint">
         <%= @step.help_text %>

--- a/app/views/steps/short_text.html.erb
+++ b/app/views/steps/short_text.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_field :response,
-    label: { text: @step.title, size: 'xl' },
+    label: { text: @step.title, size: "l" },
     hint: { text: @step.help_text },
     width: "one-third"
   %>

--- a/app/views/steps/single_date.html.erb
+++ b/app/views/steps/single_date.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_date_field :response,
-    legend: { text: @step.title, size: "xl" },
+    legend: { text: @step.title, size: "l" },
     hint: { text: @step.help_text }
   %>
 <% end %>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- make radio questions "XL" again inline with all other question types
- reduce all question label size down one notch to "L" given the length of real questions we are starting to see

## Screenshots of UI changes

Radio questions had very form small labels/page title:

![Screenshot 2021-01-19 at 11 06 37](https://user-images.githubusercontent.com/912473/105026430-6d20aa80-5a46-11eb-88cf-911293333f09.png)

Radio questions now have slightly bigger labels:
![Screenshot 2021-01-19 at 11 05 54](https://user-images.githubusercontent.com/912473/105026370-59754400-5a46-11eb-8861-c34a3c71b0ed.png)

Real questions looked _really_ big:
![Screenshot 2021-01-19 at 10 56 45](https://user-images.githubusercontent.com/912473/105025992-f5eb1680-5a45-11eb-88de-a6397db6f81b.png)

We make them slightly smaller:
![Screenshot 2021-01-19 at 11 07 57](https://user-images.githubusercontent.com/912473/105026587-9a6d5880-5a46-11eb-9d01-8ee885d00f74.png)
