### PR TITLE
Update service with newest service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users start the journey at the task list instead of the first question
 - check your answers pattern has been replaced by a task list
 - radio questions can be configured to ask the user for additional text
+- update the service name to the latest decision
 
 ## [release-004] - 2020-12-17
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,6 @@
 en:
   app:
-    name: Buy for your school
+    name: Get help buying for schools
   date:
     formats:
       default: "%-d %b %Y"


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- I noticed a message/[decision made about the service name in Slack](https://ukgovernmentdfe.slack.com/archives/C0148EM740M/p1610470150119900) and I had 5 minutes to fill. If it's a controversial one I'm very happy to close this for now.
- It seems unecessary to push this change further than what the user sees. For example in application.rb and on the github repo we still use "Buy for your School". As our service name could change multiple times as a result of research, it did not seem worth the effort of changing?
  
## Screenshots of UI changes

### Before

![Screenshot 2021-01-19 at 11 09 33](https://user-images.githubusercontent.com/912473/105027020-297a7080-5a47-11eb-9ce8-179cfce622fd.png)

### After

![Screenshot 2021-01-19 at 11 09 38](https://user-images.githubusercontent.com/912473/105027030-2bdcca80-5a47-11eb-83b7-bcef0271df00.png)

## Next steps
