### PR TITLE
Update the specification template for remaining Food and Menu questions

### DIFF
--- a/lib/specification_templates/catering.production.liquid
+++ b/lib/specification_templates/catering.production.liquid
@@ -3,28 +3,48 @@
     <h2>Menus and ordering</h2>
     <h3>Food standards</h3>
     <ol>
+      <!-- 5. Static text -->
       <li>
         <p>It will be the suppliers responsibility to ensure that all food served within the school day complies with both current and future government legislation and guidelines on the provision of healthy school meals. </p>
         <p>The supplier should encourage the use of seasonal produce and promotion of healthy eating to pupils wherever practical and desirable.</p>
         <p>It will be the suppliers responsibility to comply fully with DfE food and nutrient based standards, and to promote and comply with this policy throughout the contract term through effective menu planning.</p>
       </li>
-      <!-- /food-standards -->
+      <!-- 6. /food-standards -->
       {% if answer_2fVajdGxgwD58vt4VvAI9Y %}
         <li>
           <p>The school also requires the service to comply with the following non-mandatory food standards or schemes:</p>
           <p>{{answer_2fVajdGxgwD58vt4VvAI9Y}}</p>
         </li>
       {% endif %}
+      <!-- 8. -->
       <li>
         <p>The supplier must work with the school to provide safe and enjoyable meals for any pupils with allergies or intolerances, ensuring that the ingredients, preparation and handling of food for those children are completely allergen-free.</p>
       </li>
-      <!-- /track-allergens -->
+      <!-- 9. -->
+      <li>
+        <p>All food and drink must comply with food labelling law, which says you must provide information to customers on any of the 14 allergens used as ingredients in foods you make and sell. It is important that all staff receive training and information on the 14 allergens contained in food.</p>
+      </li>
+      <!-- 10. /detail-allergens-to-avoid -->
+      {% if answer_ypxhCAkhp2qmFiapHpVpK contains "yes"  %}
+        <li>
+          <p>All ingredients, handling and preparation of food and drink provided by the supplier must be free from:</p>
+          <p>{{answer_ypxhCAkhp2qmFiapHpVpK}}</p>
+        </li>
+      {% endif %}
+      <!-- 11. /track-allergens -->
       {% if answer_5tq13woHxVnzfOZFixoqku contains "yes" %}
         <li>
           <p>The supplier is required to track allergen information through their supply chain and must be able to demonstrate their allergen tracking plan.</p>
         </li>
       {% endif %}
-      <!-- /food-objectives -->
+      <!-- 12. /track-allergens -->
+      {% if answer_17OxghBLlrGQypc5NflRSW contains "yes" %}
+        <li>
+          <p>The school has the following requirements for how the School Food Standards are met:</p>
+          <p>{{answer_17OxghBLlrGQypc5NflRSW}}</p>
+        </li>
+      {% endif %}
+      <!-- 13. /food-objectives -->
       {% if answer_nJBe4ba05Av5JfKEFIxn7 %}
         <li>
           <p>The school has the following objectives around the quantity, quality or variety of food offered, beyond the mandatory standards:</p>


### PR DESCRIPTION
The remaining questions now exist in Contentful for all the steps that are currently identified. https://miro.com/app/board/o9J_lb34sdM=/?moveToWidget=3074457352505279555&cot=14.

NB. The extended radio questions are set up with the old and new options configuration. They will not present their further information back into the spec until it is collected by the new question pattern.

The ordering logic for presenting the spec is coming from this word document https://docs.google.com/document/d/1LAxX2ysWk3cBn3LOjkdjeKhx4S28p4pOSlk0EG2FLkU/edit#heading=h.pfdijzqb68v9

I've added some comments to help us connect word doc, contentful and this template whilst we have to keep hardcoding the changes in.


