### PR TITLE
Responses used in Specifications are formatted by presenters

### DIFF
--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -28,8 +28,18 @@ class JourneysController < ApplicationController
     ).find(journey_id)
     @steps = @journey.steps.map { |step| StepPresenter.new(step) }
 
+    # TODO: Move this logic into a tested class along with a Presenter factory
     @answers = @journey.steps.that_are_questions.each_with_object({}) { |step, hash|
-      hash["answer_#{step.contentful_id}"] = step.answer&.response.to_s
+      answer = case step.answer.class.name
+      when "ShortTextAnswer" then ShortTextAnswerPresenter.new(step.answer)
+      when "LongTextAnswer" then LongTextAnswerPresenter.new(step.answer)
+      when "RadioAnswer" then RadioAnswerPresenter.new(step.answer)
+      when "SingleDateAnswer" then SingleDateAnswerPresenter.new(step.answer)
+      when "CheckboxAnswers" then CheckboxesAnswerPresenter.new(step.answer)
+      else
+        step.answer
+      end
+      hash["answer_#{step.contentful_id}"] = answer&.response.to_s
     }
 
     @specification_template = Liquid::Template.parse(

--- a/lib/specification_templates/catering.production.liquid
+++ b/lib/specification_templates/catering.production.liquid
@@ -37,8 +37,8 @@
           <p>The supplier is required to track allergen information through their supply chain and must be able to demonstrate their allergen tracking plan.</p>
         </li>
       {% endif %}
-      <!-- 12. /track-allergens -->
       {% if answer_17OxghBLlrGQypc5NflRSW contains "yes" %}
+      <!-- 12. /meeting-standard-requirements -->
         <li>
           <p>The school has the following requirements for how the School Food Standards are met:</p>
           <p>{{answer_17OxghBLlrGQypc5NflRSW}}</p>

--- a/lib/specification_templates/catering.production.liquid
+++ b/lib/specification_templates/catering.production.liquid
@@ -25,20 +25,20 @@
         <p>All food and drink must comply with food labelling law, which says you must provide information to customers on any of the 14 allergens used as ingredients in foods you make and sell. It is important that all staff receive training and information on the 14 allergens contained in food.</p>
       </li>
       <!-- 10. /detail-allergens-to-avoid -->
-      {% if answer_ypxhCAkhp2qmFiapHpVpK contains "yes"  %}
+      {% if answer_ypxhCAkhp2qmFiapHpVpK contains "Yes" %}
         <li>
           <p>All ingredients, handling and preparation of food and drink provided by the supplier must be free from:</p>
           <p>{{answer_ypxhCAkhp2qmFiapHpVpK}}</p>
         </li>
       {% endif %}
       <!-- 11. /track-allergens -->
-      {% if answer_5tq13woHxVnzfOZFixoqku contains "yes" %}
+      {% if answer_5tq13woHxVnzfOZFixoqku contains "Yes" %}
         <li>
           <p>The supplier is required to track allergen information through their supply chain and must be able to demonstrate their allergen tracking plan.</p>
         </li>
       {% endif %}
-      {% if answer_17OxghBLlrGQypc5NflRSW contains "yes" %}
       <!-- 12. /meeting-standard-requirements -->
+      {% if answer_17OxghBLlrGQypc5NflRSW contains "Yes" %}
         <li>
           <p>The school has the following requirements for how the School Food Standards are met:</p>
           <p>{{answer_17OxghBLlrGQypc5NflRSW}}</p>

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -16,4 +16,19 @@ feature "Users can see their catering specification" do
       expect(page).to have_content(answer.response)
     end
   end
+
+  scenario "renders responses that need extra formatting" do
+    liquid_template = stub_liquid_template(filename: "food_catering.liquid")
+    journey = create(:journey, :catering, liquid_template: liquid_template)
+    step = create(:step, :radio, radio_answer: nil, journey: journey, contentful_id: "NxJWpbiFeEAmvcw17EysX")
+    _answer = create(:radio_answer, step: step, response: "Red tractor", further_information: "Lots more detail")
+
+    visit journey_path(journey)
+
+    expect(page).to have_content(I18n.t("journey.specification.header"))
+
+    within("article#specification") do
+      expect(page).to have_content("Red tractor - Lots more detail")
+    end
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR
This fixes an immediate issue we can see where radio answers show "Yes" without the `futher_information`. It should be "Yes - Further information" and the logic already exists within presenters.

We need to get a fix for this quickly to unblock the production deploy. I've left a note to prompt us to refactor this controller code the next time we pass it.

## Screenshots of UI changes

### Before
![Screenshot 2021-01-19 at 14 34 58](https://user-images.githubusercontent.com/912473/105048886-f98d9600-5a63-11eb-8e02-186e08f3a86e.png)

### After

The last answer is now a composite value.
![Screenshot 2021-01-19 at 14 34 45](https://user-images.githubusercontent.com/912473/105048903-ff837700-5a63-11eb-9569-7ef6e6ac848f.png)

## Next steps
