### PR TITLE
Previewing a question now specifies a liquid_template

### DIFF
--- a/app/controllers/preview/entries_controller.rb
+++ b/app/controllers/preview/entries_controller.rb
@@ -1,6 +1,6 @@
 class Preview::EntriesController < ApplicationController
   def show
-    @journey = Journey.create(category: "catering")
+    @journey = Journey.create(category: "catering", liquid_template: "<p>N/A</p>")
     contentful_entry = GetContentfulEntry.new(entry_id: entry_id).call
     @step = CreateJourneyStep.new(
       journey: @journey, contentful_entry: contentful_entry

--- a/spec/features/visitors/anyone_can_preview_a_journey_step_spec.rb
+++ b/spec/features/visitors/anyone_can_preview_a_journey_step_spec.rb
@@ -1,0 +1,14 @@
+feature "Users can preview a journey step" do
+  scenario "the appropriate step is displayed" do
+    stub_get_contentful_entry(
+      entry_id: "contentful-radio-question",
+      fixture_filename: "radio-question-example.json"
+    )
+
+    visit preview_entry_path("contentful-radio-question")
+
+    expect(page).to have_content("Which service do you need?")
+    expect(page).to have_content("Catering")
+    expect(page).to have_content("Cleaning")
+  end
+end

--- a/spec/requests/entry_preview_spec.rb
+++ b/spec/requests/entry_preview_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Entry previews", type: :request do
     entry_id = "123"
     fake_journey = create(:journey)
     expect(Journey).to receive(:create)
-      .with(category: anything)
+      .with(category: anything, liquid_template: anything)
       .and_return(fake_journey)
 
     fake_get_contentful_entry = instance_double(Contentful::Entry)


### PR DESCRIPTION
`liquid_template` is a required part of a `Journey` which was not being provided whilst previewing a question, leading to the `Journey` not being persisted and a redirect to the step within the journey being impossible.

This commit adds a very short stub template to preview journeys.

It also adds a feature spec to ensure that a user attempting to preview a step does reach the intended view.