### PR TITLE
Hide specification until all tasks are complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- specification is no longer displayed before all tasks are completed
+
 ## [release-005] - 2021-1-19
 
 - users can see an initial slice of their specification as HTML at the end of their journey

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -3,4 +3,14 @@ class Journey < ApplicationRecord
   has_many :steps
 
   validates :liquid_template, presence: true
+
+  def all_tasks_completed?
+    # return false if any step does not have an answer
+    steps.each do |step|
+      if !step.answer
+        return false
+      end
+    end
+    true
+  end
 end

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -25,6 +25,8 @@
   </li>
 </ol>
 
-<h1 class="govuk-heading-l"><%= I18n.t("journey.specification.header") %></h1>
-<%= link_to "Download (.docx)", journey_path(@journey, format: :docx), class: "govuk-button" %>
-<%= @specification_template.render(@answers).html_safe %>
+<% if @journey.all_tasks_completed? %>
+  <h1 class="govuk-heading-l"><%= I18n.t("journey.specification.header") %></h1>
+  <%= link_to "Download (.docx)", journey_path(@journey, format: :docx), class: "govuk-button" %>
+  <%= @specification_template.render(@answers).html_safe %>
+<% end %>

--- a/spec/features/visitors/anyone_can_view_a_list_of_tasks_spec.rb
+++ b/spec/features/visitors/anyone_can_view_a_list_of_tasks_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 feature "Users can view the task list" do
+  context "When a question has not been answered" do
+    let(:step) { create(:step, :short_text) }
+
+    scenario "The task is marked as not started" do
+      visit journey_path(step.journey)
+
+      expect(page).to have_content(I18n.t("task_list.status.not_started"))
+    end
+  end
+
   context "When a question has been answered" do
     let(:answer) { create(:short_text_answer, response: "answer") }
 

--- a/spec/features/visitors/anyone_can_view_a_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_view_a_specification_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+feature "Users can view a specification" do
+  context "The specification is displayed" do
+    scenario "when all tasks have been completed" do
+      journey = create(:journey)
+
+      step_1 = create(:step, :radio, journey: journey)
+      create(:radio_answer, step: step_1)
+
+      step_2 = create(:step, :radio, journey: journey)
+      create(:radio_answer, step: step_2)
+
+      visit journey_path(journey)
+
+      expect(page).to have_content(I18n.t("journey.specification.header"))
+    end
+  end
+
+  context "The specification is not displayed" do
+    scenario "when some tasks have been completed" do
+      journey = create(:journey)
+
+      step_1 = create(:step, :radio, journey: journey)
+      create(:radio_answer, step: step_1)
+
+      create(:step, :radio, journey: journey)
+
+      visit journey_path(journey)
+
+      expect(page).not_to have_content(I18n.t("journey.specification.header"))
+    end
+
+    scenario "when no tasks have been completed" do
+      journey = create(:journey)
+
+      create(:step, :radio, journey: journey)
+
+      create(:step, :radio, journey: journey)
+
+      visit journey_path(journey)
+
+      expect(page).not_to have_content(I18n.t("journey.specification.header"))
+    end
+  end
+end

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -11,4 +11,39 @@ RSpec.describe Journey, type: :model do
     journey = build(:journey, :catering)
     expect(journey.category).to eql("catering")
   end
+
+  describe "all_tasks_completed?" do
+    it "returns true when all tasks have been completed" do
+      journey = create(:journey)
+
+      step_1 = create(:step, :radio, journey: journey)
+      create(:radio_answer, step: step_1)
+
+      step_2 = create(:step, :radio, journey: journey)
+      create(:radio_answer, step: step_2)
+
+      expect(journey.all_tasks_completed?).to be true
+    end
+
+    it "returns false when no tasks have been completed" do
+      journey = create(:journey)
+
+      create(:step, :radio, journey: journey)
+
+      create(:step, :radio, journey: journey)
+
+      expect(journey.all_tasks_completed?).to be false
+    end
+
+    it "returns false when only some tasks have been completed" do
+      journey = create(:journey)
+
+      step_1 = create(:step, :radio, journey: journey)
+      create(:radio_answer, step: step_1)
+
+      create(:step, :radio, journey: journey)
+
+      expect(journey.all_tasks_completed?).to be false
+    end
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Specification now only shows when all steps are completed

## Screenshots of UI changes

### Before

![localhost_3000_journeys_067ce62f-5326-48f5-9c01-32ad502a1d96 (1)](https://user-images.githubusercontent.com/619082/105872814-bcd91600-5ff2-11eb-92d8-44cd91f9340a.png)

### After

![localhost_3000_journeys_067ce62f-5326-48f5-9c01-32ad502a1d96](https://user-images.githubusercontent.com/619082/105872834-c2366080-5ff2-11eb-96a9-e4ba38c74ded.png)

