### PR TITLE
Tell a user how they can recover their current journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - specification templates are now sourced from the Contentful Category entry
 - refactor how we find all journey answers into isolated service
+- users are now told how they can resume a journey, and an address is provided for this
+- robots.txt now excludes all journey and step pages
 
 ## [release-005] - 2021-1-19
 

--- a/app/views/journeys/_resume_journey_notice.html.erb
+++ b/app/views/journeys/_resume_journey_notice.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-notification-banner" role="region" id="govuk-recovery-advice-banner" aria-labelledby="govuk-recovery-advice-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-recovery-advice-banner-title">
+      <%= I18n.t("resume.notification.title") %>
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-body">
+      <%= I18n.t("resume.notification.body") %>
+    </p>
+    <p class="govuk-body">
+      <code><%=journey_url(@journey) %></code>
+    </p>
+  </div>
+</div>

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -25,6 +25,8 @@
   </li>
 </ol>
 
+<%= render "resume_journey_notice" %>
+
 <h1 class="govuk-heading-l"><%= I18n.t("journey.specification.header") %></h1>
 <%= link_to "Download (.docx)", journey_path(@journey, format: :docx), class: "govuk-button" %>
 <%= @specification_template.render(@answers).html_safe %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,10 @@ en:
       completed: Completed
   journey_map:
     page_title: "Contentful entry map"
+  resume:
+    notification:
+      title: "Returning to this specification"
+      body: "You can return to this page to make changes or view your specification at any time, either by bookmarking this page in your browser or by making a note of the following address:"
   errors:
     contentful_entry_not_found:
       page_title: "An unexpected error occurred"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+Disallow: /journeys/

--- a/spec/features/visitors/anyone_can_resume_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_resume_a_journey_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+feature "Users can see how to resume a journey" do
+  context "on the task list" do
+    let(:journey) { create(:journey) }
+    scenario "displays the notification banner" do
+      visit journey_path(journey)
+      expect(page).to have_content(I18n.t("resume.notification.title"))
+    end
+    scenario "displays the journey URL" do
+      visit journey_path(journey)
+      expect(page).to have_content(journey_url(journey))
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- Users are now told how they can resume a journey (either by bookmarking a page to return to, or revisiting the same address) and an address is provided for this on the journey task list. This functionality has always been available, just never promoted.
- `robots.txt` now excludes all journey and step pages. Although these are (currently) accessible by anyone, they should not be easily discoverable.

## Screenshots of UI changes

### Before

![localhost_3000_journeys_06021d31-a436-4e1e-86a2-04d162c76126 (1)](https://user-images.githubusercontent.com/619082/106615546-7476a680-6564-11eb-99e2-08c6e0b9f829.png)

### After

![localhost_3000_journeys_06021d31-a436-4e1e-86a2-04d162c76126](https://user-images.githubusercontent.com/619082/106615559-76406a00-6564-11eb-9f68-9fdf77a2d8ed.png)
