### PR TITLE
Improvements to journey map to assist content team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - steps/questions/tasks in the task lists are now grouped by Contentful Section entries
 - start page now has revised copy with details on eligibility and what to expect
 - The journey map is now clearer about what happens when you click a link
+- The journey map now includes links to preview a step
 
 ## [release-005] - 2021-1-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - start page now has revised copy with details on eligibility and what to expect
 - The journey map is now clearer about what happens when you click a link
 - The journey map now includes links to preview a step
+- The journey map now displays markup to include a step's answer in the specification template
 
 ## [release-005] - 2021-1-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - robots.txt now excludes all journey and step pages
 - steps/questions/tasks in the task lists are now grouped by Contentful Section entries
 - start page now has revised copy with details on eligibility and what to expect
+- The journey map is now clearer about what happens when you click a link
 
 ## [release-005] - 2021-1-19
 

--- a/app/views/journey_maps/new.html.erb
+++ b/app/views/journey_maps/new.html.erb
@@ -7,7 +7,8 @@
       <b><%= entry.title %></b><br>
       <small>
         <%= link_to I18n.t("journey_map.edit_step_link_text"), "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/#{entry.id}", target: :blank, class: "govuk-link" %> &middot;
-        <%= link_to I18n.t("journey_map.preview_step_link_text"), preview_entry_path(entry.id), target: :blank, class: "govuk-link" %>
+        <%= link_to I18n.t("journey_map.preview_step_link_text"), preview_entry_path(entry.id), target: :blank, class: "govuk-link" %><br>
+        <%= I18n.t("journey_map.spec_template_tag_title") %>: <code>{{ answer_<%= entry.id %> }}</code>
       </small>
     </li>
   <% end %>

--- a/app/views/journey_maps/new.html.erb
+++ b/app/views/journey_maps/new.html.erb
@@ -5,7 +5,10 @@
   <% @steps.each do |entry| %>
     <li class="govuk-!-margin-bottom-4">
       <b><%= entry.title %></b><br>
-      <small><%= link_to I18n.t("journey_map.edit_step_link_text"), "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/#{entry.id}", target: :blank, class: "govuk-link" %></small>
+      <small>
+        <%= link_to I18n.t("journey_map.edit_step_link_text"), "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/#{entry.id}", target: :blank, class: "govuk-link" %> &middot;
+        <%= link_to I18n.t("journey_map.preview_step_link_text"), preview_entry_path(entry.id), target: :blank, class: "govuk-link" %>
+      </small>
     </li>
   <% end %>
 </ol>

--- a/app/views/journey_maps/new.html.erb
+++ b/app/views/journey_maps/new.html.erb
@@ -4,7 +4,8 @@
 <ol class="govuk-list govuk-list--number">
   <% @steps.each do |entry| %>
     <li>
-      <%= link_to entry.title, "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/#{entry.id}", target: :blank, class: "govuk-link" %>
+      <b><%= entry.title %></b><br>
+      <small><%= link_to I18n.t("journey_map.edit_step_link_text"), "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/#{entry.id}", target: :blank, class: "govuk-link" %></small>
     </li>
   <% end %>
 </ol>

--- a/app/views/journey_maps/new.html.erb
+++ b/app/views/journey_maps/new.html.erb
@@ -3,7 +3,7 @@
 
 <ol class="govuk-list govuk-list--number">
   <% @steps.each do |entry| %>
-    <li>
+    <li class="govuk-!-margin-bottom-4">
       <b><%= entry.title %></b><br>
       <small><%= link_to I18n.t("journey_map.edit_step_link_text"), "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/#{entry.id}", target: :blank, class: "govuk-link" %></small>
     </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
   journey_map:
     page_title: "Contentful entry map"
     edit_step_link_text: "Edit step in Contentful"
+    preview_step_link_text: "Preview step in service"
   resume:
     notification:
       title: "Returning to this specification"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
     page_title: "Contentful entry map"
     edit_step_link_text: "Edit step in Contentful"
     preview_step_link_text: "Preview step in service"
+    spec_template_tag_title: "Specification tag"
   resume:
     notification:
       title: "Returning to this specification"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,7 @@ en:
       completed: Completed
   journey_map:
     page_title: "Contentful entry map"
+    edit_step_link_text: "Edit step in Contentful"
   resume:
     notification:
       title: "Returning to this specification"

--- a/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
@@ -28,6 +28,11 @@ feature "Users can see all the steps of a journey" do
             I18n.t("journey_map.edit_step_link_text"),
             href: "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/radio-question"
           )
+        expect(page)
+          .to have_link(
+            I18n.t("journey_map.preview_step_link_text"),
+            href: preview_entry_path("radio-question")
+          )
       end
       within(list_items[1]) do
         expect(page)
@@ -39,6 +44,11 @@ feature "Users can see all the steps of a journey" do
             I18n.t("journey_map.edit_step_link_text"),
             href: "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/short-text-question"
           )
+        expect(page)
+          .to have_link(
+            I18n.t("journey_map.preview_step_link_text"),
+            href: preview_entry_path("short-text-question")
+          )
       end
       within(list_items[2]) do
         expect(page)
@@ -49,6 +59,11 @@ feature "Users can see all the steps of a journey" do
           .to have_link(
             I18n.t("journey_map.edit_step_link_text"),
             href: "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/long-text-question"
+          )
+        expect(page)
+          .to have_link(
+            I18n.t("journey_map.preview_step_link_text"),
+            href: preview_entry_path("long-text-question")
           )
       end
     end

--- a/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
@@ -33,6 +33,10 @@ feature "Users can see all the steps of a journey" do
             I18n.t("journey_map.preview_step_link_text"),
             href: preview_entry_path("radio-question")
           )
+        expect(page)
+          .to have_content(
+            "{{ answer_radio-question }}"
+          )
       end
       within(list_items[1]) do
         expect(page)
@@ -49,6 +53,10 @@ feature "Users can see all the steps of a journey" do
             I18n.t("journey_map.preview_step_link_text"),
             href: preview_entry_path("short-text-question")
           )
+        expect(page)
+          .to have_content(
+            "{{ answer_short-text-question }}"
+          )
       end
       within(list_items[2]) do
         expect(page)
@@ -64,6 +72,10 @@ feature "Users can see all the steps of a journey" do
           .to have_link(
             I18n.t("journey_map.preview_step_link_text"),
             href: preview_entry_path("long-text-question")
+          )
+        expect(page)
+          .to have_content(
+            "{{ answer_long-text-question }}"
           )
       end
     end

--- a/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_the_map_of_journey_steps_page_spec.rb
@@ -20,22 +20,34 @@ feature "Users can see all the steps of a journey" do
       list_items = find_all("li")
       within(list_items[0]) do
         expect(page)
+          .to have_content(
+            "Which service do you need?"
+          )
+        expect(page)
           .to have_link(
-            "Which service do you need?",
+            I18n.t("journey_map.edit_step_link_text"),
             href: "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/radio-question"
           )
       end
       within(list_items[1]) do
         expect(page)
+          .to have_content(
+            "What email address did you use?"
+          )
+        expect(page)
           .to have_link(
-            "What email address did you use?",
+            I18n.t("journey_map.edit_step_link_text"),
             href: "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/short-text-question"
           )
       end
       within(list_items[2]) do
         expect(page)
+          .to have_content(
+            "Describe what you need"
+          )
+        expect(page)
           .to have_link(
-            "Describe what you need",
+            I18n.t("journey_map.edit_step_link_text"),
             href: "https://app.contentful.com/spaces/#{ENV["CONTENTFUL_SPACE"]}/environments/#{ENV["CONTENTFUL_ENVIRONMENT"]}/entries/long-text-question"
           )
       end


### PR DESCRIPTION
A collection of improvements to make the journey map easier to understand, and more useful for the content team.

## Changes in this PR

- The journey map is now clearer about what happens when you click a link
- The journey map now includes links to preview a step
- The journey map now displays markup to include a step's answer in the specification template

## Screenshots of UI changes

### Before

![localhost_3000_journey_map_new (1)](https://user-images.githubusercontent.com/619082/106900933-07434c80-66ef-11eb-924c-536a5f1f062d.png)

### After

![localhost_3000_journey_map_new](https://user-images.githubusercontent.com/619082/106900887-fa265d80-66ee-11eb-9f1c-4b65a107b6cf.png)
