### PR TITLE
Users can answer questions which expect a currency 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can answer questions which expect a number
 - checkbox questions no longer alter the capitalisation of options
 - fix ordering of section and step items
+- users can answer questions which expect a currency
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -24,7 +24,7 @@ class JourneysController < ApplicationController
 
   def show
     @journey = Journey.includes(
-      steps: [:radio_answer, :short_text_answer, :long_text_answer, :single_date_answer, :checkbox_answers, :number_answer]
+      steps: [:radio_answer, :short_text_answer, :long_text_answer, :single_date_answer, :checkbox_answers, :number_answer, :currency_answer]
     ).find(journey_id)
     @steps = @journey.steps.map { |step| StepPresenter.new(step) }
 

--- a/app/models/currency_answer.rb
+++ b/app/models/currency_answer.rb
@@ -1,0 +1,14 @@
+class CurrencyAnswer < ActiveRecord::Base
+  self.implicit_order_column = "created_at"
+  belongs_to :step
+
+  validates :response, presence: true, numericality: {greater_than_or_equal_to: 0, message: "does not accept £ signs or other non numerical characters"}
+
+  def response=(value)
+    if value.is_a?(String)
+      super(value.delete(","))
+      return
+    end
+    super(value)
+  end
+end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -8,6 +8,7 @@ class Step < ApplicationRecord
   has_one :single_date_answer
   has_one :checkbox_answers
   has_one :number_answer
+  has_one :currency_answer
 
   scope :that_are_questions, -> { where(contentful_model: "question") }
 
@@ -18,7 +19,8 @@ class Step < ApplicationRecord
       long_text_answer ||
       single_date_answer ||
       checkbox_answers ||
-      number_answer
+      number_answer ||
+      currency_answer
   end
 
   def primary_call_to_action_text

--- a/app/presenters/currency_answer_presenter.rb
+++ b/app/presenters/currency_answer_presenter.rb
@@ -1,0 +1,7 @@
+class CurrencyAnswerPresenter < SimpleDelegator
+  include ActionView::Helpers::NumberHelper
+
+  def response
+    number_to_currency(super, unit: "£", precision: 2)
+  end
+end

--- a/app/services/answer_factory.rb
+++ b/app/services/answer_factory.rb
@@ -11,6 +11,7 @@ class AnswerFactory
     case step.contentful_type
     when "radios" then RadioAnswer.new
     when "number" then NumberAnswer.new
+    when "currency" then CurrencyAnswer.new
     when "short_text" then ShortTextAnswer.new
     when "long_text" then LongTextAnswer.new
     when "single_date" then SingleDateAnswer.new

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -12,6 +12,7 @@ class CreateJourneyStep
     single_date
     checkboxes
     number
+    currency
   ].freeze
 
   attr_accessor :journey, :contentful_entry

--- a/app/services/find_all_journey_answers.rb
+++ b/app/services/find_all_journey_answers.rb
@@ -17,6 +17,7 @@ class FindAllJourneyAnswers
       when "SingleDateAnswer" then SingleDateAnswerPresenter.new(step.answer)
       when "CheckboxAnswers" then CheckboxesAnswerPresenter.new(step.answer)
       when "NumberAnswer" then NumberAnswerPresenter.new(step.answer)
+      when "CurrencyAnswer" then CurrencyAnswerPresenter.new(step.answer)
       else raise UnexpectedAnswer.new("Trying to present an unknown type of answer: #{step.answer.class.name}")
       end
 

--- a/app/views/steps/currency.html.erb
+++ b/app/views/steps/currency.html.erb
@@ -1,0 +1,7 @@
+<%= render layout: layout do |f| %>
+  <%= f.govuk_text_field :response,
+    label: { text: @step.title, size: "l" },
+    prefix_text: "£",
+    hint: { text: @step.help_text }
+  %>
+<% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -65,5 +65,6 @@ Rails.application.configure do
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :single_date_answer
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :checkbox_answers
     Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :number_answer
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "Step", association: :currency_answer
   end
 end

--- a/db/migrate/20210202120716_create_currency_answer.rb
+++ b/db/migrate/20210202120716_create_currency_answer.rb
@@ -1,0 +1,13 @@
+class CreateCurrencyAnswer < ActiveRecord::Migration[6.1]
+  def up
+    create_table :currency_answers, id: :uuid do |t|
+      t.references :step, type: :uuid
+      t.decimal :response, null: false, precision: 11, scale: 2
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :currency_answers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,6 +25,14 @@ ActiveRecord::Schema.define(version: 2021_02_02_170113) do
     t.index ["step_id"], name: "index_checkbox_answers_on_step_id"
   end
 
+  create_table "currency_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "step_id"
+    t.decimal "response", precision: 11, scale: 2, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["step_id"], name: "index_currency_answers_on_step_id"
+  end
+
   create_table "journeys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "category", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -35,4 +35,10 @@ FactoryBot.define do
 
     response { 150 }
   end
+
+  factory :currency_answer do
+    association :step, factory: :step, contentful_type: "currency", contentful_model: "question"
+
+    response { 1000.01 }
+  end
 end

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -43,6 +43,12 @@ FactoryBot.define do
       contentful_type { "number" }
     end
 
+    trait :currency do
+      options { nil }
+      contentful_model { "question" }
+      contentful_type { "currency" }
+    end
+
     trait :static_content do
       options { nil }
       contentful_model { "staticContent" }

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -76,6 +76,28 @@ feature "Anyone can start a journey" do
       end
     end
 
+    context "when Contentful entry is of type currency" do
+      scenario "user can answer using a currency number input" do
+        start_journey_from_category_and_go_to_question(category: "currency-question.json")
+
+        fill_in "answer[response]", with: "1,000.01"
+        click_on(I18n.t("generic.button.next"))
+
+        click_first_link_in_task_list
+
+        expect(find_field("answer-response-field").value).to eql("1000.01")
+      end
+
+      scenario "throws error when non numerical values are entered" do
+        start_journey_from_category_and_go_to_question(category: "currency-question.json")
+
+        fill_in "answer[response]", with: "one hundred pounds"
+        click_on(I18n.t("generic.button.next"))
+
+        expect(page).to have_content("does not accept £ signs or other non numerical characters")
+      end
+    end
+
     context "when Contentful entry is of type long_text" do
       scenario "user can answer using free text with multiple lines" do
         start_journey_from_category_and_go_to_question(category: "long-text-question.json")

--- a/spec/fixtures/contentful/categories/currency-question.json
+++ b/spec/fixtures/contentful/categories/currency-question.json
@@ -1,0 +1,44 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Currency",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "currency-section"
+            }
+          }
+        ],
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+    }
+}

--- a/spec/fixtures/contentful/sections/currency-section.json
+++ b/spec/fixtures/contentful/sections/currency-section.json
@@ -1,0 +1,43 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "currency-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section A",
+        "steps": [
+            {
+                "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "currency-question"
+                }
+            }
+        ]
+    }
+}

--- a/spec/fixtures/contentful/steps/currency-question.json
+++ b/spec/fixtures/contentful/steps/currency-question.json
@@ -1,0 +1,37 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "currency-question",
+        "type": "Currency",
+        "createdAt": "2020-11-05T16:42:58.340Z",
+        "updatedAt": "2020-11-05T16:42:58.340Z",
+        "environment": {
+            "sys": {
+                "id": "master",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/what-funds-does-the-school-have-available-for-the-maintenance-or-replacement-of-heavy-equipment-in-the-coming-year",
+        "title": "What funds does the school have available for the maintenance or replacement of heavy equipment in the coming year?",
+        "helpText": "Give an estimate of the funds available.",
+        "type": "currency"
+    }
+}

--- a/spec/models/currency_answer_spec.rb
+++ b/spec/models/currency_answer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe CurrencyAnswer, type: :model do
+  it { should belong_to(:step) }
+
+  describe "#response" do
+    it "correctly strips out commas from a string" do
+      answer = build(:currency_answer, response: "1,000.01")
+      expect(answer.response).to eq(1000.01)
+    end
+
+    it "returns a number" do
+      answer = build(:currency_answer, response: "1000.01")
+      expect(answer.response).to eq(1000.01)
+    end
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:response) }
+  end
+end

--- a/spec/presenters/currency_answer_presenter_spec.rb
+++ b/spec/presenters/currency_answer_presenter_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe CurrencyAnswerPresenter do
+  describe "#response" do
+    it "returns the response formatted as a currency" do
+      step = build(:currency_answer, response: 1000.01)
+      presenter = described_class.new(step)
+      expect(presenter.response).to eq("£1,000.01")
+    end
+  end
+end

--- a/spec/services/answer_factory_spec.rb
+++ b/spec/services/answer_factory_spec.rb
@@ -43,4 +43,12 @@ RSpec.describe AnswerFactory do
       expect(result).to be_kind_of(NumberAnswer)
     end
   end
+
+  context "when the step is for currency" do
+    it "returns a new CurrencyAnswer object" do
+      step = create(:step, :currency)
+      result = described_class.new(step: step).call
+      expect(result).to be_kind_of(CurrencyAnswer)
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- Users can answer questions which expect a currency
- Currency is saved as a decimal with precision 11 to ensure that all currency amounts required for this service are valid

## Screenshots of UI changes
Currency step view has a prefix text of a `£` value to indicate that it requires a currency input

![Screen Shot 2021-02-08 at 10 33 07](https://user-images.githubusercontent.com/59832893/107208234-3a405580-69f9-11eb-83d5-514965ace540.png)

An error is thrown when non numerical values are entered

![Screen Shot 2021-02-10 at 10 51 17](https://user-images.githubusercontent.com/59832893/107500337-f29f0280-6b8d-11eb-874c-bc4f16c4ebec.png)

![Screen Shot 2021-02-10 at 10 48 28](https://user-images.githubusercontent.com/59832893/107500110-b1a6ee00-6b8d-11eb-980a-39e5304b1145.png)


Currency values are saved as decimals in the database

![Screen Shot 2021-02-08 at 10 38 16](https://user-images.githubusercontent.com/59832893/107208640-c9e60400-69f9-11eb-94c5-379218e3375a.png)


The specification displays the currency with the full currency formatting to include the `£` and all appropriate commas

![Screen Shot 2021-02-08 at 10 48 27](https://user-images.githubusercontent.com/59832893/107209807-39102800-69fb-11eb-86bd-cde39bbcf9ba.png)

