### PR TITLE
Options are no longer capitalised in checkbox questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - The journey map now includes links to preview a step
 - The journey map now displays markup to include a step's answer in the specification template
 - users can answer questions which expect a number
+- checkbox questions no longer alter the capitalisation of options
 
 ## [release-005] - 2021-1-19
 

--- a/app/helpers/step_helper.rb
+++ b/app/helpers/step_helper.rb
@@ -3,7 +3,7 @@
 module StepHelper
   def checkbox_options(array_of_options:)
     array_of_options.map { |option|
-      OpenStruct.new(id: option.downcase, name: option.titleize)
+      OpenStruct.new(id: option.downcase, name: option)
     }
   end
 end

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -121,6 +121,11 @@ feature "Anyone can start a journey" do
         expect(page).to have_checked_field("answer-response-breakfast-field")
         expect(page).to have_checked_field("answer-response-lunch-field")
       end
+
+      scenario "options follow the capitalisation given" do
+        start_journey_from_category_and_go_to_question(category: "checkboxes-question.json")
+        expect(page).to have_content("Morning break")
+      end
     end
 
     context "when Contentful entry is of type radios" do

--- a/spec/fixtures/contentful/steps/checkboxes-question.json
+++ b/spec/fixtures/contentful/steps/checkboxes-question.json
@@ -33,9 +33,10 @@
         "type": "checkboxes",
         "title": "Everyday services that are required and need to be considered",
         "extendedOptions": [
-          { "value": "breakfast" },
-          { "value": "lunch" },
-          { "value": "dinner" }
+          { "value": "Breakfast" },
+          { "value": "Morning break" },
+          { "value": "Lunch" },
+          { "value": "Dinner" }
         ]
     }
 }

--- a/spec/helpers/step_helper_spec.rb
+++ b/spec/helpers/step_helper_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe StepHelper, type: :helper do
       options = ["red", "blue"]
       result = helper.checkbox_options(array_of_options: options)
       expect(result).to match([
-        OpenStruct.new(id: "red", name: "Red"),
-        OpenStruct.new(id: "blue", name: "Blue")
+        OpenStruct.new(id: "red", name: "red"),
+        OpenStruct.new(id: "blue", name: "blue")
       ])
     end
   end

--- a/spec/presenters/checkboxes_answer_presenter_spec.rb
+++ b/spec/presenters/checkboxes_answer_presenter_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe CheckboxesAnswerPresenter do
   describe "#response" do
     it "returns all none nil values, capitalised as a comma separated string" do
-      step = build(:checkbox_answers, response: ["yes", "no", ""])
+      step = build(:checkbox_answers, response: ["yes", "no", "morning break", ""])
       presenter = described_class.new(step)
-      expect(presenter.response).to eq("Yes, No")
+      expect(presenter.response).to eq("Yes, No, Morning break")
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

The desired behaviour is that fields as displayed to the user in checkbox questions are provided exactly as in Contentful. This commit changes the behavior of `checkbox_options` in `StepHelper` to no longer capitalise options.

## Next steps

NB: This does _not_ modify how checkbox options are rendered in specification output, as further work is planned to provide a wider range of options in output (such as an actual array of checked options) which will supersede this.