### PR TITLE
(372) Fix ordering of sections and steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - The journey map now displays markup to include a step's answer in the specification template
 - users can answer questions which expect a number
 - checkbox questions no longer alter the capitalisation of options
+- fix ordering of section and step items
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -27,9 +27,6 @@ class JourneysController < ApplicationController
       steps: [:radio_answer, :short_text_answer, :long_text_answer, :single_date_answer, :checkbox_answers, :number_answer]
     ).find(journey_id)
     @steps = @journey.steps.map { |step| StepPresenter.new(step) }
-    @section_groups = @journey.section_groups.each_with_object({}) { |group, result|
-      result[group[0]] = @steps.select { |step| group[1].include?(step.contentful_id) }
-    }
 
     @specification_template = Liquid::Template.parse(
       @journey.liquid_template, error_mode: :strict

--- a/app/helpers/journey_helper.rb
+++ b/app/helpers/journey_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module JourneyHelper
+  def section_group_with_steps(journey:, steps:)
+    step_lookup = steps.group_by(&:contentful_id)
+
+    journey.section_groups.each do |section|
+      ordered_step_objects = section["steps"].each_with_object([]) { |step, result|
+        result[step["order"]] = step_lookup[step["contentful_id"]].first
+      }
+      section["steps"] = ordered_step_objects.compact
+    end
+  end
+end

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -13,9 +13,7 @@ class CreateJourney
       liquid_template: category.specification_template
     )
 
-    journey.section_groups = sections.each_with_object({}) { |section, result|
-      result[section.title] = section.steps.map(&:id)
-    }
+    journey.section_groups = build_section_groupings(sections: sections)
     journey.save
 
     sections.each do |section|
@@ -28,5 +26,17 @@ class CreateJourney
     end
 
     journey
+  end
+
+  private def build_section_groupings(sections:)
+    sections.each_with_object([]).with_index { |(section, result), index|
+      result[index] = {
+        order: index,
+        title: section.title,
+        steps: section.steps.each_with_object([]).with_index { |(step, result), index|
+          result << {contentful_id: step.id, order: index}
+        }
+      }
+    }
   end
 end

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -2,10 +2,11 @@
 
 <h1 class="govuk-heading-xl"><%= @journey.category.capitalize %></h1>
 <ol class="app-task-list">
-  <% @section_groups.each_pair do |section_title, steps| %>
-    <h2 class="app-task-list__section"><%= section_title %></h2>
+  
+  <% section_group_with_steps(journey: @journey, steps: @steps).each do |grouping| %>
+    <h2 class="app-task-list__section"><%= grouping["title"] %></h2>
     <li>
-      <%= render "step_list", journey: @journey, steps: steps %>
+      <%= render "step_list", journey: @journey, steps: grouping["steps"] %>
     </li>
   <% end %>
 </ol>

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :step do
     title { "What is your favourite colour?" }
     help_text { "Choose the primary colour closest to your choice" }
-    raw { {"sys": {"id" => "123"}} }
-    contentful_id { "123" }
+    contentful_id { SecureRandom.hex }
+    raw { |attrs| {"sys": {"id" => attrs["contentful_id"]}} }
 
     association :journey, factory: :journey
 

--- a/spec/features/visitors/anyone_can_edit_their_answers_spec.rb
+++ b/spec/features/visitors/anyone_can_edit_their_answers_spec.rb
@@ -3,7 +3,18 @@ require "rails_helper"
 feature "Users can edit their answers" do
   before do
     journey = answer.step.journey
-    journey.update(section_groups: {"Section A" => [answer.step.contentful_id]})
+    journey.update(section_groups: [
+      {
+        "order" => 0,
+        "title" => "Section A",
+        "steps" => [
+          {
+            "contentful_id" => answer.step.contentful_id,
+            "order" => 0
+          }
+        ]
+      }
+    ])
   end
   let(:answer) { create(:short_text_answer, response: "answer") }
 

--- a/spec/features/visitors/anyone_can_view_a_list_of_tasks_spec.rb
+++ b/spec/features/visitors/anyone_can_view_a_list_of_tasks_spec.rb
@@ -27,7 +27,18 @@ feature "Users can view the task list" do
   context "When a question has been answered" do
     before do
       journey = answer.step.journey
-      journey.update(section_groups: {"Section A" => [answer.step.contentful_id]})
+      journey.update(section_groups: [
+        {
+          "order" => 0,
+          "title" => "Section A",
+          "steps" => [
+            {
+              "contentful_id" => answer.step.contentful_id,
+              "order" => 0
+            }
+          ]
+        }
+      ])
     end
     let(:answer) { create(:short_text_answer, response: "answer") }
 

--- a/spec/fixtures/contentful/categories/multiple-sections-and-steps.json
+++ b/spec/fixtures/contentful/categories/multiple-sections-and-steps.json
@@ -1,0 +1,51 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "multiple-radio-section"
+            }
+          },
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "multiple-long-text-section"
+            }
+          }
+        ],
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+    }
+}

--- a/spec/fixtures/contentful/sections/multiple-long-text-section.json
+++ b/spec/fixtures/contentful/sections/multiple-long-text-section.json
@@ -1,0 +1,50 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "long-text-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section B",
+        "steps": [
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "long-text-question"
+              }
+            },
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "short-text-question"
+              }
+            }
+        ]
+    }
+}

--- a/spec/fixtures/contentful/sections/multiple-radio-section.json
+++ b/spec/fixtures/contentful/sections/multiple-radio-section.json
@@ -1,0 +1,50 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "radio-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section A",
+        "steps": [
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "radio-question"
+              }
+            },
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "single-date-question"
+              }
+            }
+        ]
+    }
+}

--- a/spec/helpers/journey_helper_spec.rb
+++ b/spec/helpers/journey_helper_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe JourneyHelper, type: :helper do
+  describe "#section_group_with_steps" do
+    it "returns an ordered array of steps" do
+      journey = create(:journey, section_groups: "", steps: [])
+      step_1 = StepPresenter.new(create(:step, :radio, journey: journey))
+      step_2 = StepPresenter.new(create(:step, :long_text, journey: journey))
+      step_3 = StepPresenter.new(create(:step, :short_text, journey: journey))
+
+      section_groups = [
+        {
+          "order" => 0,
+          "title" => "Objectives",
+          "steps" => [
+            {
+              "contentful_id" => step_1.contentful_id,
+              "order" => 0
+            },
+            {
+              "contentful_id" => step_2.contentful_id,
+              "order" => 1
+            }
+          ]
+        },
+        {
+          "order" => 1,
+          "title" => "Social value",
+          "steps" => [
+            {
+              "contentful_id" => step_3.contentful_id,
+              "order" => 0
+            }
+          ]
+        }
+      ]
+      journey.update(section_groups: section_groups)
+
+      result = helper.section_group_with_steps(
+        journey: journey, steps: [step_1, step_2, step_3]
+      )
+
+      expect(result.first["steps"]).to eq([step_1, step_2])
+      expect(result.second["steps"]).to eq([step_3])
+    end
+  end
+
+  context "when the ordering we want does not match the order saved in the database" do
+    it "the ordering defined by 'order' is preserved" do
+      journey = create(:journey, section_groups: "", steps: [])
+      step_1 = StepPresenter.new(create(:step, :radio, title: "First question", journey: journey))
+      step_2 = StepPresenter.new(create(:step, :long_text, title: "Second question", journey: journey))
+      step_3 = StepPresenter.new(create(:step, :short_text, title: "Third question", journey: journey))
+      step_4 = StepPresenter.new(create(:step, :short_text, title: "Fourth question", journey: journey))
+
+      section_groups = [
+        {
+          "order" => 1,
+          "title" => "Objectives",
+          "steps" => [
+            {
+              "contentful_id" => step_2.contentful_id,
+              "order" => 2
+            },
+            {
+              "contentful_id" => step_1.contentful_id,
+              "order" => 1
+            },
+            {
+              "contentful_id" => step_3.contentful_id,
+              "order" => 3
+            }
+          ]
+        },
+        {
+          "order" => 0,
+          "title" => "Social value",
+          "steps" => [
+            {
+              "contentful_id" => step_4.contentful_id,
+              "order" => 0
+            }
+          ]
+        }
+      ]
+      journey.update(section_groups: section_groups)
+
+      result = helper.section_group_with_steps(
+        journey: journey, steps: [step_1, step_2, step_3, step_4]
+      )
+
+      expect(result.first["steps"]).to eq([step_1, step_2, step_3])
+      expect(result.second["steps"]).to eq([step_4])
+    end
+  end
+end

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -30,5 +30,34 @@ RSpec.describe CreateJourney do
       expect(Journey.last.liquid_template)
         .to eql("<article id='specification'><h1>Liquid {{templating}}</h1></article>")
     end
+
+    it "stores the section grouping on the journey in the expected order" do
+      stub_contentful_category(
+        fixture_filename: "multiple-sections-and-steps.json"
+      )
+
+      described_class.new(category_name: "catering").call
+
+      journey = Journey.last
+
+      expect(journey.reload.section_groups).to eq([
+        {
+          "order" => 0,
+          "title" => "Section A",
+          "steps" => [
+            {"contentful_id" => "radio-question", "order" => 0},
+            {"contentful_id" => "single-date-question", "order" => 1}
+          ]
+        },
+        {
+          "order" => 1,
+          "title" => "Section B",
+          "steps" => [
+            {"contentful_id" => "long-text-question", "order" => 0},
+            {"contentful_id" => "short-text-question", "order" => 1}
+          ]
+        }
+      ])
+    end
   end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Sections and steps are now ordered correctly, fixing a bug that appeared when a specific combination of named sections were presented incorrectly.

We change the type of data structure we store for the `journey.section_group` and are explicit about the `order` we expect each section and each step (starting from 0).

- minor improvement to the Step factory to make the `contentful_id` dynamic with each new fake step
 
## Screenshots of UI changes

This is what Contentful specifies the order to be:

![Screenshot 2021-02-08 at 14 32 19](https://user-images.githubusercontent.com/912473/107233431-8059e100-6a1a-11eb-82f1-72a60da4e9dc.png)

### Before

This is the order where we can see the bug:

![Screenshot_2021-02-08 Catering(1)](https://user-images.githubusercontent.com/912473/107232595-7daabc00-6a19-11eb-8e46-e4cf7b552cc4.png)

### After

And after the bug is fixed:
![Screenshot_2021-02-08 Catering](https://user-images.githubusercontent.com/912473/107232631-87342400-6a19-11eb-982b-4e156c24cc8c.png)

