### PR TITLE
(374) Move "resume journey" notification directly below title

### DIFF
--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -1,8 +1,11 @@
 <%= content_for :title, @journey.category.capitalize %>
 
 <h1 class="govuk-heading-xl"><%= @journey.category.capitalize %></h1>
+
+<%= render "resume_journey_notice" %>
+
 <ol class="app-task-list">
-  
+
   <% section_group_with_steps(journey: @journey, steps: @steps).each do |grouping| %>
     <h2 class="app-task-list__section"><%= grouping["title"] %></h2>
     <li>
@@ -10,8 +13,6 @@
     </li>
   <% end %>
 </ol>
-
-<%= render "resume_journey_notice" %>
 
 <h1 class="govuk-heading-l"><%= I18n.t("journey.specification.header") %></h1>
 <%= link_to "Download (.docx)", journey_path(@journey, format: :docx), class: "govuk-button" %>


### PR DESCRIPTION
This better matches the pattern as given by the GOV.UK Design Framework.

## Changes in this PR

- Move the "resume journey" notification banner from the bottom of the task list to the top.

## Screenshots of UI changes

### Before

![localhost_3000_journeys_c5c8567f-7dd0-4c8b-a2b2-becafbc74e4b (1)](https://user-images.githubusercontent.com/619082/107377005-697ec180-6ae2-11eb-917c-40f4db0ef78f.png)

### After

![localhost_3000_journeys_c5c8567f-7dd0-4c8b-a2b2-becafbc74e4b](https://user-images.githubusercontent.com/619082/107377014-6b488500-6ae2-11eb-83de-be1bea46442f.png)