### PR TITLE
(343) Fix date validation

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AnswersController < ApplicationController
+  include DateHelper
+
   def create
     @journey = Journey.find(journey_id)
     @step = Step.find(step_id)
@@ -9,7 +11,7 @@ class AnswersController < ApplicationController
     @answer.step = @step
 
     result = SaveAnswer.new(answer: @answer)
-      .call(checkbox_params: checkbox_params, answer_params: answer_params)
+      .call(checkbox_params: checkbox_params, answer_params: answer_params, date_params: date_params)
     @answer = result.object
 
     if result.success?
@@ -24,7 +26,7 @@ class AnswersController < ApplicationController
     @step = Step.find(step_id)
 
     result = SaveAnswer.new(answer: @step.answer)
-      .call(checkbox_params: checkbox_params, answer_params: answer_params)
+      .call(checkbox_params: checkbox_params, answer_params: answer_params, date_params: date_params)
     @answer = result.object
 
     if result.success?
@@ -50,5 +52,11 @@ class AnswersController < ApplicationController
 
   def checkbox_params
     params.require(:answer).permit(response: [])
+  end
+
+  def date_params
+    answer = params.require(:answer).permit(:response)
+    date_hash = {day: answer["response(3i)"], month: answer["response(2i)"], year: answer["response(1i)"]}
+    {response: format_date(date_hash)}
   end
 end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,0 +1,11 @@
+module DateHelper
+  def format_date(params)
+    date_parts = params.values_at(:day, :month, :year)
+    return unless date_parts.all?(&:present?)
+
+    day, month, year = date_parts.map(&:to_i)
+    Date.new(year, month, day)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/models/single_date_answer.rb
+++ b/app/models/single_date_answer.rb
@@ -2,5 +2,5 @@ class SingleDateAnswer < ActiveRecord::Base
   self.implicit_order_column = "created_at"
   belongs_to :step
 
-  validates :response, presence: true
+  validates :response, presence: {message: I18n.t("activerecord.errors.models.single_date_answer.attributes.response")}
 end

--- a/app/services/save_answer.rb
+++ b/app/services/save_answer.rb
@@ -5,12 +5,14 @@ class SaveAnswer
     self.step = answer.step
   end
 
-  def call(answer_params: {}, checkbox_params: {})
+  def call(answer_params: {}, checkbox_params: {}, date_params: {})
     result = Result.new(false, answer)
 
     case step.contentful_type
     when "checkboxes"
       answer.assign_attributes(checkbox_params)
+    when "single_date"
+      answer.assign_attributes(date_params)
     else
       answer.assign_attributes(answer_params)
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,9 @@ module BuyForYourSchool
     end
 
     config.active_job.queue_adapter = :sidekiq
+
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
+    config.i18n.default_locale = :en
+    config.i18n.enforce_available_locales = false
   end
 end

--- a/config/locales/models/single_date_answer.en.yml
+++ b/config/locales/models/single_date_answer.en.yml
@@ -1,0 +1,8 @@
+---
+en:
+  activerecord:
+    errors:
+      models:
+        single_date_answer:
+          attributes:
+            response: Provide a real date for this answer

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -127,6 +127,17 @@ feature "Anyone can start a journey" do
         expect(find_field("answer_response_2i").value).to eql("8")
         expect(find_field("answer_response_1i").value).to eql("2020")
       end
+
+      scenario "date validations" do
+        start_journey_from_category_and_go_to_question(category: "single-date-question.json")
+
+        fill_in "answer[response(3i)]", with: "2"
+        fill_in "answer[response(2i)]", with: "0"
+        fill_in "answer[response(1i)]", with: "0"
+
+        click_on(I18n.t("generic.button.next"))
+        expect(page).to have_content(I18n.t("activerecord.errors.models.single_date_answer.attributes.response"))
+      end
     end
 
     context "when Contentful entry is of type checkboxes" do

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe DateHelper, type: :helper do
+  describe "#format_date" do
+    it "returns a Date object from params" do
+      params = {day: "1", month: "2", year: "2020"}
+      expect(helper.format_date(params)).to eq(Date.new(2020, 2, 1))
+    end
+
+    it "returns nil when passed nil" do
+      params = {}
+      expect(helper.format_date(params)).to eq(nil)
+    end
+
+    it "returns nil when the date params are incomplete" do
+      params = {day: "", month: "", year: "2019"}
+      expect(helper.format_date(params)).to eq(nil)
+    end
+
+    it "returns nil when given an invalid date" do
+      params = {day: "40", month: "13", year: "2020"}
+      expect(helper.format_date(params)).to eq(nil)
+    end
+
+    it "returns nil when given a zero parameter" do
+      params = {day: "40", month: "0", year: "2020"}
+      expect(helper.format_date(params)).to eq(nil)
+    end
+  end
+end

--- a/spec/models/single_date_answer_spec.rb
+++ b/spec/models/single_date_answer_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe SingleDateAnswer, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:response) }
+    it "validates missing response" do
+      answer = build(:single_date_answer, response: nil)
+
+      expect(answer.valid?).to eq(false)
+      expect(answer.errors.full_messages.first).to include(I18n.t("activerecord.errors.models.single_date_answer.attributes.response"))
+    end
   end
 end

--- a/spec/services/save_answer_spec.rb
+++ b/spec/services/save_answer_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe SaveAnswer do
       end
     end
 
+    context "when the step is a date question" do
+      it "updates the answer with the date_params" do
+        answer = build(:single_date_answer, response: nil)
+        date = Date.new(2000, 1, 29)
+        params = {response: date}
+
+        result = described_class.new(answer: answer).call(date_params: params)
+
+        expect(result.success?).to eql(true)
+        expect(result.object.response).to eql(date)
+      end
+    end
+
     context "when the answer is invalid" do
       it "does not try to save the answer" do
         answer = create(:checkbox_answers)


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Incorrect values for dates will return an error to the user, rather than causing [a crash](https://rollbar.com/dxw/dfe-buy-for-your-school/items/72/?item_page=0&item_count=100&#traceback). 

When the user adds `0, 0, 2` into the 3 fields Ruby would fail to parse this as a Date when assigning to the answer object. This happens before traditional model validation can take place, leaving us a bit stuck.

Using the [MOJ Form builder we can do this by adding a widget](https://github.com/ministryofjustice/gov_uk_date_fields#3-tell-your-models-attributes-are-gov_uk_dates) called `acts_as_gov_uk_date`. This does not appear to be present in the DfE Form builder which we are using, and that is very much part of our service (not something easily swapped out to).

Given that we have spent many days on hunting for the conventional approach to solving this problem, this solution takes a "functional over elegant" approach. The approach for this work is [based on the one the RODA team settled on](https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/blob/f94d7fdb18dcf8df15f8d3a36de7e9a67e2e822a/app/controllers/staff/activity_forms_controller.rb#L81) (as they use the same DfE gem) and should be equivalant.

The error copy says "real" which I confess is not the best use of language to convey an abstract "your date doesn't look quite right but we can't tell you exactly why". Any suggestions are of course welcome!

## Screenshots of UI changes

### Before
![Screenshot 2021-02-15 at 15 34 45](https://user-images.githubusercontent.com/912473/107966346-9bd96480-6fa3-11eb-9758-eb9eb27a2511.png)

### After
![Screenshot 2021-02-15 at 15 27 48](https://user-images.githubusercontent.com/912473/107966474-d0e5b700-6fa3-11eb-9bc7-3c78ea781ed8.png)
