### PR TITLE
(352) Users see a spec warning when there are incomplete steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix ordering of section and step items
 - users can answer questions which expect a currency
 - questions can be hidden from view
+- specification warning if there are incomplete tasks
 
 ## [release-005] - 2021-1-19
 

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -4,4 +4,8 @@ class Journey < ApplicationRecord
   has_many :visible_steps, -> { where(steps: {hidden: false}) }, class_name: "Step"
 
   validates :liquid_template, presence: true
+
+  def all_steps_completed?
+    visible_steps.all? { |step| step.answer.present? }
+  end
 end

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -15,5 +15,14 @@
 </ol>
 
 <h1 class="govuk-heading-l"><%= I18n.t("journey.specification.header") %></h1>
+<% unless @journey.all_steps_completed? %>
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      <%= I18n.t("journey.specification.warning") %>
+    </strong>
+  </div>
+<% end %>
 <%= link_to "Download (.docx)", journey_path(@journey, format: :docx), class: "govuk-button" %>
 <%= @specification_template.render(@answers).html_safe %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
   journey:
     specification:
       header: "Your specification"
+      warning: "There are incomplete tasks, this specification is not ready for use."
   task_list:
     status:
       not_started: Not started

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -32,4 +32,16 @@ feature "Users can see their catering specification" do
       expect(page).to have_content("Catering - The school needs the kitchen cleaned once a day")
     end
   end
+
+  context "when the spec is incomplete" do
+    it "warns the user that the contents are in a partially completed state" do
+      stub_contentful_category(fixture_filename: "extended-radio-question.json")
+      visit root_path
+      click_on(I18n.t("generic.button.start"))
+
+      # Don't answer any questions to create a in progress spec
+
+      expect(page).to have_content("There are incomplete tasks, this specification is not ready for use.")
+    end
+  end
 end

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -11,4 +11,56 @@ RSpec.describe Journey, type: :model do
     journey = build(:journey, :catering)
     expect(journey.category).to eql("catering")
   end
+
+  describe "all_steps_completed?" do
+    context "when all steps have been completed" do
+      it "returns true" do
+        journey = create(:journey)
+
+        step_1 = create(:step, :radio, journey: journey)
+        create(:radio_answer, step: step_1)
+
+        step_2 = create(:step, :radio, journey: journey)
+        create(:radio_answer, step: step_2)
+
+        expect(journey.all_steps_completed?).to be true
+      end
+    end
+
+    context "when no steps have been completed" do
+      it "returns false " do
+        journey = create(:journey)
+
+        create_list(:step, 2, :radio, journey: journey)
+
+        expect(journey.all_steps_completed?).to be false
+      end
+    end
+
+    context "when only some steps have been completed" do
+      it "returns false" do
+        journey = create(:journey)
+
+        step_1 = create(:step, :radio, journey: journey)
+        create(:radio_answer, step: step_1)
+
+        create(:step, :radio, journey: journey)
+
+        expect(journey.all_steps_completed?).to be false
+      end
+    end
+
+    context "when there are uncompleted hidden steps" do
+      it "ignores them and returns true" do
+        journey = create(:journey)
+
+        step_1 = create(:step, :radio, journey: journey)
+        create(:radio_answer, step: step_1)
+
+        _hidden_step_without_an_answer = create(:step, :radio, journey: journey, hidden: true)
+
+        expect(journey.all_steps_completed?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Use warning text pattern from the design system https://design-system.service.gov.uk/components/warning-text/

## Screenshots of UI changes

When there are any (visible) incomplete tasks we show a warning
![Screenshot 2021-02-15 at 16 20 01](https://user-images.githubusercontent.com/912473/107971722-bc58ed00-6faa-11eb-9d7c-d1816cd590a6.png)

When all visibl steps are complete, we hide the warning.
![Screenshot 2021-02-15 at 16 21 05](https://user-images.githubusercontent.com/912473/107971713-b9f69300-6faa-11eb-9e42-df10d5f08d84.png)
