### PR TITLE
Only reshow hidden questions that qualify

### DIFF
--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -188,11 +188,12 @@ feature "Anyone can start a journey" do
         click_on(I18n.t("generic.button.next"))
 
         # This question should be made visible after the previous step
+        expect(page).not_to have_content("You should NOT be able to see this question?")
         click_on("What colour is the sky?")
         choose("Red")
         click_on(I18n.t("generic.button.next"))
 
-        # This question should be made visible after the previous step
+        # This question should only be made visible after the previous step
         click_on("You should NOT be able to see this question?")
         choose("School expert")
         click_on(I18n.t("generic.button.next"))


### PR DESCRIPTION
* Before this change the user could show a question and it would go and show all dependent questions regardless of them having answers, or indeed answers that were required.
* This change turns the `matching_answer?` method into a functional method so it can be reused within the recursion as well as outside it
* We continue to hide all dependent child questions regardless of their answer

