### PR TITLE
Fix redis connection failures by depending only on REDIS_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,7 @@ ROLLBAR_ACCESS_TOKEN=ROLLBAR_ACCESS_TOKEN
 ROLLBAR_ENV=development
 
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-development
-REDIS_CACHE_URL=redis://localhost:6379/1
-REDIS_SIDEKIQ_URL=redis://localhost:6379/2
+REDIS_URL=redis://localhost:6379
 
 # Contentful
 CONTENTFUL_URL=cdn.contentful.com

--- a/.env.test
+++ b/.env.test
@@ -6,8 +6,7 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-test
-REDIS_CACHE_URL=redis://localhost:6379/11
-REDIS_SIDEKIQ_URL=redis://localhost:6379/12
+REDIS_URL=redis://localhost:6379
 
 # Contentful
 CONTENTFUL_URL=cdn.contentful.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - hidden questions can be shown through a new show_additional_question field for each question
 - hidden questions can be rehidden again after changing the original answer
 - hidden questions that were at one point answered, will be reshown with a change to an earlier question
+- fix Redis connection errors on Heroku
 
 ## [release-005] - 2021-1-19
 

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -6,7 +6,7 @@ module RedisCache
       else
         Redis::Namespace.new(
           "buy_for_your_school",
-          redis: Redis.new(url: ENV["REDIS_CACHE_URL"])
+          redis: Redis.new(url: ENV["REDIS_URL"], db: 1)
         )
       end
     end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,5 @@
 Sidekiq.configure_server do |config|
-  config.redis = {url: ENV["REDIS_SIDEKIQ_URL"]}
+  config.redis = {url: "#{ENV["REDIS_URL"]}/2"}
 
   # Sidekiq Cron
   schedule_file = "config/schedule.yml"
@@ -9,5 +9,5 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = {url: ENV["REDIS_SIDEKIQ_URL"]}
+  config.redis = {url: "#{ENV["REDIS_URL"]}/2"}
 end

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -16,7 +16,7 @@ services:
        - .env.test
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
-      REDIS_CACHE_URL: redis://test-redis:6379/1
+      REDIS_URL: redis://redis:6379
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
     networks:
       - test

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,7 +16,7 @@ services:
        - .env.test
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
-      REDIS_CACHE_URL: redis://test-redis:6379/1
+      REDIS_URL: redis://redis:6379
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
     volumes:
       - .:/srv/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,7 @@ services:
        - .env.development.local
     environment:
       DATABASE_URL: postgres://postgres:password@db:5432/buy-for-your-school-development
-      REDIS_CACHE_URL: redis://redis:6379/1
-      REDIS_SIDEKIQ_URL: redis://redis:6379/2
+      REDIS_URL: redis://redis:6379
     volumes:
       - .:/srv/app
     tty: true


### PR DESCRIPTION
## Changes in this PR

The Heroku Redis addon controls the REDIS_URL environment variable. Sometimes this value changes[1] and the host and/or port changes leading to connection failures after a random interval, and without warning.

This commit changes our approach from making the database number configurable through ENV (using `REDIS_CACHE_URL` and `REDIS_SIDEKIQ_URL`) to being hardcoded into each service that uses Redis: Sidekiq and Redis for caching.

[1] https://data.heroku.com/datastores/49f12bfc-2341-465f-ae43-70f7c4edabcd#settings

> Please note that these credentials are not permanent.
Heroku rotates credentials periodically and updates applications where this datastore is attached.

![Screenshot 2021-02-16 at 17 10 23](https://user-images.githubusercontent.com/912473/108097368-f34a0400-7079-11eb-917c-b6764e4d2f23.png)
