### PR TITLE
(342) Users can answer using the extended checkbox pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - hidden questions can be rehidden again after changing the original answer
 - hidden questions that were at one point answered, will be reshown with a change to an earlier question
 - fix Redis connection errors on Heroku
+- users can be asked extended checkbox questions which ask for further information
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -51,7 +51,20 @@ class AnswersController < ApplicationController
   end
 
   def checkbox_params
-    params.require(:answer).permit(:further_information, response: [])
+    answer_params = params.require(:answer)
+
+    if @step.options
+      allowed_further_information_keys = @step.options.map { |option|
+        "#{option["value"].tr(" ", "_").downcase}_further_information".to_sym
+      }
+    end
+
+    further_information_params = answer_params.permit(*allowed_further_information_keys)
+    further_information = further_information_params.to_hash
+
+    all_params = answer_params.permit(response: [])
+    all_params[:further_information] = further_information
+    all_params
   end
 
   def date_params

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -51,7 +51,7 @@ class AnswersController < ApplicationController
   end
 
   def checkbox_params
-    params.require(:answer).permit(response: [])
+    params.require(:answer).permit(:further_information, response: [])
   end
 
   def date_params

--- a/app/helpers/step_helper.rb
+++ b/app/helpers/step_helper.rb
@@ -6,4 +6,19 @@ module StepHelper
       OpenStruct.new(id: option.downcase, name: option)
     }
   end
+
+  def monkey_patch_form_object_with_further_information_field(
+    form_object:,
+    associated_choice:
+  )
+    existing_further_information = form_object&.further_information&.fetch(
+      "#{associated_choice}_further_information", nil
+    )
+
+    form_object.define_singleton_method("#{associated_choice}_further_information") do
+      existing_further_information
+    end
+
+    form_object
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -27,8 +27,4 @@ class Step < ApplicationRecord
     return I18n.t("generic.button.next") unless super.present?
     super
   end
-
-  def options_list
-    options.map { |hash| hash["value"] }
-  end
 end

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -7,12 +7,16 @@
     <% end %>
 
     <% @step.options.each do |option| %>
+      <% machine_value = option["value"].tr(" ", "_").downcase %>
+
       <% if option["further_information_required"] == true %>
-        <%= f.govuk_check_box :response, option["value"].downcase, label: { text: option["value"] } do %>
-          <%= f.govuk_text_field :further_information, label: { text: option["further_information_help_text"] } %>
+        <% f.object = monkey_patch_form_object_with_further_information_field(form_object: f.object, associated_choice: machine_value) %>
+        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
+          <%= f.govuk_text_field "#{machine_value}_further_information",
+            label: { text: option["further_information_help_text"] } %>
         <% end %>
       <% else %>
-        <%= f.govuk_check_box :response, option["value"].downcase, label: { text: option["value"] } %>
+        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -1,8 +1,19 @@
 <%= render layout: layout do |f| %>
-  <%= f.govuk_collection_check_boxes :response,
-    checkbox_options(array_of_options: @step.options_list),
-    :id,
-    :name,
-    legend: { text: @step.title, size: "l" }
-  %>
+  <%= f.govuk_check_boxes_fieldset :response, legend: { text: @step.title, size: "l" } do %>
+    <% if @step.help_text.present? %>
+      <span class="govuk-hint">
+        <%= @step.help_text %>
+      </span>
+    <% end %>
+
+    <% @step.options.each do |option| %>
+      <% if option["further_information_required"] == true %>
+        <%= f.govuk_check_box :response, option["value"].downcase, label: { text: option["value"] } do %>
+          <%= f.govuk_text_field :further_information, label: { text: option["further_information_help_text"] } %>
+        <% end %>
+      <% else %>
+        <%= f.govuk_check_box :response, option["value"].downcase, label: { text: option["value"] } %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/db/migrate/20210217145518_add_further_information_to_checkboxes.rb
+++ b/db/migrate/20210217145518_add_further_information_to_checkboxes.rb
@@ -1,0 +1,5 @@
+class AddFurtherInformationToCheckboxes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :checkbox_answers, :further_information, :text
+  end
+end

--- a/db/migrate/20210217145518_add_further_information_to_checkboxes.rb
+++ b/db/migrate/20210217145518_add_further_information_to_checkboxes.rb
@@ -1,5 +1,5 @@
 class AddFurtherInformationToCheckboxes < ActiveRecord::Migration[6.1]
   def change
-    add_column :checkbox_answers, :further_information, :text
+    add_column :checkbox_answers, :further_information, :jsonb
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_11_104039) do
+ActiveRecord::Schema.define(version: 2021_02_17_145518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_104039) do
     t.string "response", default: [], array: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "further_information"
     t.index ["step_id"], name: "index_checkbox_answers_on_step_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2021_02_17_145518) do
     t.string "response", default: [], array: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "further_information"
+    t.jsonb "further_information"
     t.index ["step_id"], name: "index_checkbox_answers_on_step_id"
   end
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -165,15 +165,22 @@ feature "Anyone can start a journey" do
           start_journey_from_category_and_go_to_question(category: "extended-checkboxes-question.json")
 
           check("Yes")
-          fill_in "answer[further_information]", with: "The school needs the kitchen cleaned once a day"
+          fill_in "answer[yes_further_information]", with: "The first piece of further information"
+
+          check("No")
+          fill_in "answer[no_further_information]", with: "A second piece of further information"
 
           click_on(I18n.t("generic.button.next"))
 
           click_first_link_in_task_list
 
           expect(page).to have_checked_field("Yes")
-          expect(find_field("answer-further-information-field").value)
-            .to eql("The school needs the kitchen cleaned once a day")
+          expect(find_field("answer-yes-further-information-field").value)
+            .to eql("The first piece of further information")
+
+          expect(page).to have_checked_field("No")
+          expect(find_field("answer-no-further-information-field").value)
+            .to eql("A second piece of further information")
         end
       end
     end

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -159,6 +159,23 @@ feature "Anyone can start a journey" do
         start_journey_from_category_and_go_to_question(category: "checkboxes-question.json")
         expect(page).to have_content("Morning break")
       end
+
+      context "when extra configuration is passed to collect further info" do
+        scenario "asks the user for further information" do
+          start_journey_from_category_and_go_to_question(category: "extended-checkboxes-question.json")
+
+          check("Yes")
+          fill_in "answer[further_information]", with: "The school needs the kitchen cleaned once a day"
+
+          click_on(I18n.t("generic.button.next"))
+
+          click_first_link_in_task_list
+
+          expect(page).to have_checked_field("Yes")
+          expect(find_field("answer-further-information-field").value)
+            .to eql("The school needs the kitchen cleaned once a day")
+        end
+      end
     end
 
     context "when Contentful entry is of type radios" do

--- a/spec/fixtures/contentful/categories/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/extended-checkboxes-question.json
@@ -1,0 +1,44 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "extended-checkboxes-section"
+            }
+          }
+        ],
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+    }
+}

--- a/spec/fixtures/contentful/sections/extended-checkboxes-section.json
+++ b/spec/fixtures/contentful/sections/extended-checkboxes-section.json
@@ -1,0 +1,43 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "extended-checkboxes-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section A",
+        "steps": [
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "extended-checkboxes-question"
+              }
+            }
+        ]
+    }
+}

--- a/spec/fixtures/contentful/steps/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/steps/extended-checkboxes-question.json
@@ -1,0 +1,47 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "extended-checkboxes-question",
+        "type": "Entry",
+        "createdAt": "2021-02-17T14:09:56.405Z",
+        "updatedAt": "2021-02-17T14:38:07.806Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/extended-checkboxes",
+        "type": "checkboxes",
+        "title": "Extended checkboxes",
+        "extendedOptions": [
+            {
+                "value": "Yes",
+                "further_information_required": true,
+                "further_information_help_text": "You should tell us more"
+            },
+            {
+              "value": "No"
+            }
+        ],
+        "alwaysShowTheUser": true
+    }
+}

--- a/spec/fixtures/contentful/steps/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/steps/extended-checkboxes-question.json
@@ -39,7 +39,9 @@
                 "further_information_help_text": "You should tell us more"
             },
             {
-              "value": "No"
+                "value": "No",
+                "further_information_required": true,
+                "further_information_help_text": "You should tell us more"
             }
         ],
         "alwaysShowTheUser": true

--- a/spec/helpers/step_helper_spec.rb
+++ b/spec/helpers/step_helper_spec.rb
@@ -11,4 +11,36 @@ RSpec.describe StepHelper, type: :helper do
       ])
     end
   end
+
+  describe "#monkey_patch_form_object_with_further_information_field" do
+    it "returns the modified form_object" do
+      object = OpenStruct.new
+      result = helper.monkey_patch_form_object_with_further_information_field(
+        form_object: object,
+        associated_choice: "foo"
+      )
+      expect(result).to eq(object)
+    end
+
+    it "adds a singleton method to the object" do
+      object = OpenStruct.new
+      result = helper.monkey_patch_form_object_with_further_information_field(
+        form_object: object,
+        associated_choice: "foo"
+      )
+      expect(result.foo_further_information).to eq(nil)
+      expect(result.foo_further_information = "bar").to eql("bar")
+    end
+
+    context "when the object has a further_information field" do
+      it "adds a singleton method with the same value as the return value" do
+        object = OpenStruct.new(further_information: {"foo_further_information" => :bar})
+        result = helper.monkey_patch_form_object_with_further_information_field(
+          form_object: object,
+          associated_choice: "foo"
+        )
+        expect(result.foo_further_information).to eq(:bar)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Users can now be asked to provide further information for the choice they've made, if Contentful has specified that behaviour for the given answer

There should be no surprises here since we are following the precedent set by the extended-radio pattern. Fortunately the [DfE Form builder gem supports this "Other" mechanism](https://govuk-form-builder.netlify.app/form-elements/checkboxes/#generating-checkboxes-with-a-conditionally-revealed-text-field) in the same way. 

## Screenshots of UI changes

### Before

![Screenshot 2021-02-17 at 15 07 35](https://user-images.githubusercontent.com/912473/108224292-aa09bb00-7132-11eb-97bf-5cf8bc985ed4.png)

### After

![Screenshot 2021-02-17 at 15 07 40](https://user-images.githubusercontent.com/912473/108224288-a8d88e00-7132-11eb-9863-9d20a1fee3dd.png)

With multiple options we can save multiple bits of further info:
![Screenshot 2021-02-18 at 17 40 14](https://user-images.githubusercontent.com/912473/108397934-66857e80-7210-11eb-8b1f-d31d539e89f2.png)

