### PR TITLE
(409) Multiple optional questions can be shown and hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix Redis connection errors on Heroku
 - users can be asked extended checkbox questions which ask for further information
 - markdown in help text fields is now parsed into HTML
+- show and hide more than one additional question at a time
 
 ## [release-005] - 2021-1-19
 

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -26,12 +26,12 @@ class ToggleAdditionalSteps
     step.additional_step_rule
   end
 
-  def additional_step_id
+  def additional_step_ids
     additional_step_rule["question_identifier"]
   end
 
   def additional_step
-    journey_steps.find_by(contentful_id: additional_step_id)
+    journey_steps.find_by(contentful_id: additional_step_ids)
   end
 
   def matching_answer?(a:, b:)
@@ -45,41 +45,43 @@ class ToggleAdditionalSteps
   end
 
   def check_to_show_additional_steps!
-    recursively_show_additional_steps!(current_step: step, next_step_id: additional_step_id)
+    recursively_show_additional_steps!(current_step: step, next_step_ids: additional_step_ids)
   end
 
   def check_to_hide_additional_steps!
     return if matching_answer?(a: step.additional_step_rule["required_answer"], b: step.answer.response)
 
-    recursively_hide_additional_steps!(current_step: step, next_step_id: additional_step_id)
+    recursively_hide_additional_steps!(next_step_ids: additional_step_ids)
   end
 
-  def recursively_hide_additional_steps!(current_step:, next_step_id:)
-    if next_step_id
-
-      next_step = journey_steps.find_by(contentful_id: next_step_id)
-      next_step.update(hidden: true)
+  def recursively_hide_additional_steps!(next_step_ids:)
+    if next_step_ids.compact.present?
+      next_steps = journey_steps.where(contentful_id: next_step_ids)
+      next_steps.update_all(hidden: true)
 
       recursively_hide_additional_steps!(
-        current_step: next_step,
-        next_step_id: next_step.additional_step_rule&.fetch("question_identifier", nil)
+        next_step_ids: next_steps.map { |next_step|
+          next_step.additional_step_rule&.fetch("question_identifier", nil)
+        }.flatten.compact
       )
     end
   end
 
-  def recursively_show_additional_steps!(current_step:, next_step_id:)
+  def recursively_show_additional_steps!(current_step:, next_step_ids:)
     return unless current_step.answer && current_step.additional_step_rule
 
-    if next_step_id
+    if next_step_ids
       return unless matching_answer?(a: current_step.additional_step_rule["required_answer"], b: current_step.answer.response)
 
-      next_step = journey_steps.find_by(contentful_id: next_step_id)
-      next_step.update(hidden: false)
+      next_steps = journey_steps.where(contentful_id: next_step_ids)
+      next_steps.update_all(hidden: false)
 
-      recursively_show_additional_steps!(
-        current_step: next_step,
-        next_step_id: next_step.additional_step_rule&.fetch("question_identifier", nil)
-      )
+      next_steps.map { |next_step|
+        recursively_show_additional_steps!(
+          current_step: next_step,
+          next_step_ids: next_step.additional_step_rule&.fetch("question_identifier", nil)
+        )
+      }
     end
   end
 end

--- a/spec/fixtures/contentful/steps/hidden-field-that-shows-an-additional-question.json
+++ b/spec/fixtures/contentful/steps/hidden-field-that-shows-an-additional-question.json
@@ -44,7 +44,7 @@
         "alwaysShowTheUser": false,
         "showAdditionalQuestion": {
             "required_answer": "Red",
-            "question_identifier": "hidden-field"
+            "question_identifier": ["hidden-field"]
         }
     }
 }

--- a/spec/fixtures/contentful/steps/show-additional-question.json
+++ b/spec/fixtures/contentful/steps/show-additional-question.json
@@ -48,7 +48,7 @@
         ],
         "showAdditionalQuestion": {
             "required_answer": "School expert",
-            "question_identifier": "hidden-field-that-shows-an-additional-question"
+            "question_identifier": ["hidden-field-that-shows-an-additional-question"]
         }
     }
 }

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -162,7 +162,7 @@ process around March.")
         expect(step.additional_step_rule).to eql(
           {
             "required_answer" => "School expert",
-            "question_identifier" => "hidden-field-that-shows-an-additional-question"
+            "question_identifier" => ["hidden-field-that-shows-an-additional-question"]
           }
         )
       end

--- a/spec/services/toggle_additional_steps_spec.rb
+++ b/spec/services/toggle_additional_steps_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rule: {"required_answer" => "Red", "question_identifier" => "123"})
+            additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]})
           create(:radio_answer, step: step, response: "Red")
 
           another_step_to_show = create(:step,
@@ -37,12 +37,46 @@ RSpec.describe ToggleAdditionalSteps do
           expect(another_step_from_a_different_journey_to_keep_hidden.reload.hidden).to eq(true)
         end
 
+        it "shows all additional_steps within the same journey" do
+          step = create(:step,
+            :radio,
+            journey: journey,
+            additional_step_rule: {
+              "required_answer" => "Red",
+              "question_identifier" => ["123", "456"]
+            })
+          create(:radio_answer, step: step, response: "Red")
+
+          first_additional_step_to_show = create(:step,
+            :radio,
+            journey: journey,
+            contentful_id: "123",
+            hidden: true)
+
+          second_additional_step_to_show = create(:step,
+            :radio,
+            journey: journey,
+            contentful_id: "456",
+            hidden: true)
+
+          another_step_from_a_different_journey_to_keep_hidden = create(:step,
+            :radio,
+            contentful_id: "123",
+            hidden: true)
+
+          described_class.new(step: step).call
+
+          expect(first_additional_step_to_show.reload.hidden).to eq(false)
+          expect(second_additional_step_to_show.reload.hidden).to eq(false)
+          expect(another_step_from_a_different_journey_to_keep_hidden.reload.hidden).to eq(true)
+        end
+
         context "when the required_answer matches the answer exactly" do
           it "updates the referenced step's hidden field to false" do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "Red", "question_identifier" => "123"})
+              additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]})
             create(:radio_answer, step: step, response: "Red")
 
             step_to_show = create(:step,
@@ -62,7 +96,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "RED", "question_identifier" => "123"})
+              additional_step_rule: {"required_answer" => "RED", "question_identifier" => ["123"]})
             create(:radio_answer, step: step, response: "red")
 
             step_to_show = create(:step,
@@ -82,7 +116,7 @@ RSpec.describe ToggleAdditionalSteps do
             first_step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "Red", "question_identifier" => "123"},
+              additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]},
               hidden: false)
             create(:radio_answer, step: first_step, response: "Red")
 
@@ -90,7 +124,7 @@ RSpec.describe ToggleAdditionalSteps do
               :radio,
               journey: journey,
               contentful_id: "123",
-              additional_step_rule: {"required_answer" => "Blue", "question_identifier" => "456"},
+              additional_step_rule: {"required_answer" => "Blue", "question_identifier" => ["456"]},
               hidden: true)
             create(:radio_answer, step: second_step, response: "Blue")
 
@@ -113,7 +147,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rule: {"required_answer" => "Red", "question_identifier" => "123"})
+            additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]})
           create(:radio_answer, step: step, response: "Blue")
 
           step_to_show = create(:step,
@@ -127,12 +161,46 @@ RSpec.describe ToggleAdditionalSteps do
           expect(step_to_show.reload.hidden).to eq(true)
         end
 
+        it "hides all additional_steps within the same journey" do
+          step = create(:step,
+            :radio,
+            journey: journey,
+            additional_step_rule: {
+              "required_answer" => "Red",
+              "question_identifier" => ["123", "456"]
+            })
+          create(:radio_answer, step: step, response: "NOT Red")
+
+          first_additional_step_to_hide = create(:step,
+            :radio,
+            journey: journey,
+            contentful_id: "123",
+            hidden: false)
+
+          second_additional_step_to_hide = create(:step,
+            :radio,
+            journey: journey,
+            contentful_id: "456",
+            hidden: false)
+
+          another_step_from_a_different_journey_to_keep_hidden = create(:step,
+            :radio,
+            contentful_id: "123",
+            hidden: true)
+
+          described_class.new(step: step).call
+
+          expect(first_additional_step_to_hide.reload.hidden).to eq(true)
+          expect(second_additional_step_to_hide.reload.hidden).to eq(true)
+          expect(another_step_from_a_different_journey_to_keep_hidden.reload.hidden).to eq(true)
+        end
+
         context "when the required_answer has different case to the answer" do
           it "does not hide the step" do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "RED", "question_identifier" => "123"})
+              additional_step_rule: {"required_answer" => "RED", "question_identifier" => ["123"]})
             create(:radio_answer, step: step, response: "red")
 
             step_to_show = create(:step,
@@ -152,7 +220,7 @@ RSpec.describe ToggleAdditionalSteps do
             first_step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "Red", "question_identifier" => "123"},
+              additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]},
               hidden: false)
             create(:radio_answer, step: first_step, response: "Changed from red")
 
@@ -160,7 +228,7 @@ RSpec.describe ToggleAdditionalSteps do
               :radio,
               journey: journey,
               contentful_id: "123",
-              additional_step_rule: {"required_answer" => "Blue", "question_identifier" => "456"},
+              additional_step_rule: {"required_answer" => "Blue", "question_identifier" => ["456"]},
               hidden: false)
             create(:radio_answer, step: second_step, response: "Blue")
 
@@ -183,7 +251,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :checkbox_answers,
             journey: journey,
-            additional_step_rule: {"required_answer" => "Red", "question_identifier" => "123"})
+            additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]})
           create(:checkbox_answers, step: step, response: ["Blue", "Red"])
 
           step_to_show = create(:step,


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Before this change we allowed the content user to "bolt on" **one** additional question if the answer matched an expected pattern.

This change allows them to show as many additional questions as they like. Though the current need is for 2 additonal questions. We do this by accepting an array of identifiers rather than a single string.

The amount of calculation required to determine and follow the question branches through to their resolution is not ideal and we know this. A better approach would be to keep track of the state of the tree of questions and make the required database updates with fewer database queries. This would require more time than we have in the last sprint so we are opting for something that works and accepting the technical debt will need to be repaid.

## Screenshots of UI changes

For this example we have a tree structure as follows. We have one question that is "Always shown" and 3 hidden questions with another subtree of the first and third hidden question being connected:

![Screenshot 2021-02-22 at 11 34 19](https://user-images.githubusercontent.com/912473/108703008-edcd3d80-7501-11eb-8dca-2578fab58ab1.png)

We start with a single question. We only need to pay attention to the first section in this example:
![Screenshot_2021-02-22 Catering](https://user-images.githubusercontent.com/912473/108702696-857e5c00-7501-11eb-88df-e1dc79707579.png)

We answer it with a non-matching answer (so no new questions are shown)
![Screenshot_2021-02-22 Catering(1)](https://user-images.githubusercontent.com/912473/108702699-86af8900-7501-11eb-828b-7347862e2c98.png)

We change our answer to the matching answer (and now expect 2 new questions to be shown)
![Screenshot_2021-02-22 Catering(2)](https://user-images.githubusercontent.com/912473/108702703-87e0b600-7501-11eb-97b5-d5591a237843.png)

We change our original answer and check both new questions are hidden again:
![Screenshot_2021-02-22 Catering(3)](https://user-images.githubusercontent.com/912473/108702705-88794c80-7501-11eb-9992-9474076c025b.png)

We check the subtree by answering the first hidden question with a matching answer and expect the third question to be revealed:
![Screenshot_2021-02-22 Catering(4)](https://user-images.githubusercontent.com/912473/108702710-8911e300-7501-11eb-9962-e1f2166b3d14.png)

Finally we change our original answer again and check that all 3 connected questions are hidden:
![Screenshot_2021-02-22 Catering(5)](https://user-images.githubusercontent.com/912473/108702713-89aa7980-7501-11eb-865c-5c2bc3fc05f3.png)

## Next steps

Update Contentful entries that have optional logic already and change their value into an array of one item, rather than a string.