### PR TITLE
(409) User answers can fork a journey into multiple paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can be asked extended checkbox questions which ask for further information
 - markdown in help text fields is now parsed into HTML
 - show and hide more than one additional question at a time
+- users can be presenting with forking/branching question chains based on any one answer
 
 ## [release-005] - 2021-1-19
 

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -42,7 +42,7 @@ class CreateJourneyStep
       options: options,
       primary_call_to_action_text: primary_call_to_action_text,
       hidden: hidden,
-      additional_step_rule: additional_step_rule,
+      additional_step_rules: additional_step_rules,
       raw: raw,
       journey: journey
     )
@@ -108,7 +108,7 @@ class CreateJourneyStep
     !contentful_entry.always_show_the_user
   end
 
-  def additional_step_rule
+  def additional_step_rules
     return nil unless contentful_entry.respond_to?(:show_additional_question)
     contentful_entry.show_additional_question
   end

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -28,7 +28,7 @@ class ToggleAdditionalSteps
     }.flatten
   end
 
-  def additional_steps_to_show
+  def additional_steps_to_show(step:)
     matching_next_step_ids = step.additional_step_rules.map { |rule|
       rule.fetch("question_identifiers", nil) if step.answer && matching_answer?(a: rule["required_answer"], b: step.answer.response)
     }.flatten
@@ -80,14 +80,9 @@ class ToggleAdditionalSteps
       next_steps.map { |next_step|
         next unless next_step.additional_step_rules
 
-        matching_next_step_ids = next_step.additional_step_rules.map { |rule|
-          rule.fetch("question_identifiers", nil) if next_step.answer && matching_answer?(a: rule["required_answer"], b: next_step.answer.response)
-        }
-        matching_next_steps = journey_steps.where(contentful_id: matching_next_step_ids)
-
         recursively_show_additional_steps!(
           current_step: next_step,
-          next_steps: matching_next_steps
+          next_steps: additional_steps_to_show(step: next_step)
         )
       }
     end

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -27,11 +27,23 @@ class ToggleAdditionalSteps
   end
 
   def additional_step_ids
-    additional_step_rules["question_identifier"]
+    additional_step_rules.map { |rule|
+      rule["question_identifier"]
+    }.flatten
   end
 
-  def additional_step
-    journey_steps.find_by(contentful_id: additional_step_ids)
+  def additional_steps_to_show
+    matching_next_step_ids = step.additional_step_rules.map { |rule|
+      rule.fetch("question_identifier", nil) if step.answer && matching_answer?(a: rule["required_answer"], b: step.answer.response)
+    }.flatten
+    journey_steps.where(contentful_id: matching_next_step_ids)
+  end
+
+  def additional_steps_to_hide
+    non_matching_next_step_ids = step.additional_step_rules.map { |rule|
+      rule.fetch("question_identifier", nil) unless matching_answer?(a: rule["required_answer"], b: step.answer.response)
+    }.flatten
+    journey_steps.where(contentful_id: non_matching_next_step_ids)
   end
 
   def matching_answer?(a:, b:)
@@ -45,41 +57,49 @@ class ToggleAdditionalSteps
   end
 
   def check_to_show_additional_steps!
-    recursively_show_additional_steps!(current_step: step, next_step_ids: additional_step_ids)
+    recursively_show_additional_steps!(current_step: step, next_steps: additional_steps_to_show)
   end
 
   def check_to_hide_additional_steps!
-    return if matching_answer?(a: step.additional_step_rules["required_answer"], b: step.answer.response)
-
-    recursively_hide_additional_steps!(next_step_ids: additional_step_ids)
+    recursively_hide_additional_steps!(next_steps: additional_steps_to_hide)
   end
 
-  def recursively_hide_additional_steps!(next_step_ids:)
-    if next_step_ids.compact.present?
-      next_steps = journey_steps.where(contentful_id: next_step_ids)
+  def recursively_hide_additional_steps!(next_steps:)
+    if next_steps
       next_steps.update_all(hidden: true)
 
-      recursively_hide_additional_steps!(
-        next_step_ids: next_steps.map { |next_step|
-          next_step.additional_step_rules&.fetch("question_identifier", nil)
-        }.flatten.compact
-      )
+      next_steps.map { |next_step|
+        next unless next_step.additional_step_rules
+
+        all_next_step_ids = next_step.additional_step_rules.map { |rule|
+          rule.fetch("question_identifier", nil)
+        }
+        all_next_steps = journey_steps.where(contentful_id: all_next_step_ids)
+
+        recursively_hide_additional_steps!(
+          next_steps: all_next_steps
+        )
+      }
     end
   end
 
-  def recursively_show_additional_steps!(current_step:, next_step_ids:)
+  def recursively_show_additional_steps!(current_step:, next_steps:)
     return unless current_step.answer && current_step.additional_step_rules
 
-    if next_step_ids
-      return unless matching_answer?(a: current_step.additional_step_rules["required_answer"], b: current_step.answer.response)
-
-      next_steps = journey_steps.where(contentful_id: next_step_ids)
+    if next_steps
       next_steps.update_all(hidden: false)
 
       next_steps.map { |next_step|
+        next unless next_step.additional_step_rules
+
+        matching_next_step_ids = next_step.additional_step_rules.map { |rule|
+          rule.fetch("question_identifier", nil) if next_step.answer && matching_answer?(a: rule["required_answer"], b: next_step.answer.response)
+        }
+        matching_next_steps = journey_steps.where(contentful_id: matching_next_step_ids)
+
         recursively_show_additional_steps!(
           current_step: next_step,
-          next_step_ids: next_step.additional_step_rules&.fetch("question_identifier", nil)
+          next_steps: matching_next_steps
         )
       }
     end

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -28,20 +28,20 @@ class ToggleAdditionalSteps
 
   def additional_step_ids
     additional_step_rules.map { |rule|
-      rule["question_identifier"]
+      rule["question_identifiers"]
     }.flatten
   end
 
   def additional_steps_to_show
     matching_next_step_ids = step.additional_step_rules.map { |rule|
-      rule.fetch("question_identifier", nil) if step.answer && matching_answer?(a: rule["required_answer"], b: step.answer.response)
+      rule.fetch("question_identifiers", nil) if step.answer && matching_answer?(a: rule["required_answer"], b: step.answer.response)
     }.flatten
     journey_steps.where(contentful_id: matching_next_step_ids)
   end
 
   def additional_steps_to_hide
     non_matching_next_step_ids = step.additional_step_rules.map { |rule|
-      rule.fetch("question_identifier", nil) unless matching_answer?(a: rule["required_answer"], b: step.answer.response)
+      rule.fetch("question_identifiers", nil) unless matching_answer?(a: rule["required_answer"], b: step.answer.response)
     }.flatten
     journey_steps.where(contentful_id: non_matching_next_step_ids)
   end
@@ -72,7 +72,7 @@ class ToggleAdditionalSteps
         next unless next_step.additional_step_rules
 
         all_next_step_ids = next_step.additional_step_rules.map { |rule|
-          rule.fetch("question_identifier", nil)
+          rule.fetch("question_identifiers", nil)
         }
         all_next_steps = journey_steps.where(contentful_id: all_next_step_ids)
 
@@ -93,7 +93,7 @@ class ToggleAdditionalSteps
         next unless next_step.additional_step_rules
 
         matching_next_step_ids = next_step.additional_step_rules.map { |rule|
-          rule.fetch("question_identifier", nil) if next_step.answer && matching_answer?(a: rule["required_answer"], b: next_step.answer.response)
+          rule.fetch("question_identifiers", nil) if next_step.answer && matching_answer?(a: rule["required_answer"], b: next_step.answer.response)
         }
         matching_next_steps = journey_steps.where(contentful_id: matching_next_step_ids)
 

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -6,7 +6,7 @@ class ToggleAdditionalSteps
   end
 
   def call
-    return unless additional_step_rule
+    return unless additional_step_rules
 
     check_to_show_additional_steps!
     check_to_hide_additional_steps!
@@ -22,12 +22,12 @@ class ToggleAdditionalSteps
     @journey_steps ||= journey.steps
   end
 
-  def additional_step_rule
-    step.additional_step_rule
+  def additional_step_rules
+    step.additional_step_rules
   end
 
   def additional_step_ids
-    additional_step_rule["question_identifier"]
+    additional_step_rules["question_identifier"]
   end
 
   def additional_step
@@ -49,7 +49,7 @@ class ToggleAdditionalSteps
   end
 
   def check_to_hide_additional_steps!
-    return if matching_answer?(a: step.additional_step_rule["required_answer"], b: step.answer.response)
+    return if matching_answer?(a: step.additional_step_rules["required_answer"], b: step.answer.response)
 
     recursively_hide_additional_steps!(next_step_ids: additional_step_ids)
   end
@@ -61,17 +61,17 @@ class ToggleAdditionalSteps
 
       recursively_hide_additional_steps!(
         next_step_ids: next_steps.map { |next_step|
-          next_step.additional_step_rule&.fetch("question_identifier", nil)
+          next_step.additional_step_rules&.fetch("question_identifier", nil)
         }.flatten.compact
       )
     end
   end
 
   def recursively_show_additional_steps!(current_step:, next_step_ids:)
-    return unless current_step.answer && current_step.additional_step_rule
+    return unless current_step.answer && current_step.additional_step_rules
 
     if next_step_ids
-      return unless matching_answer?(a: current_step.additional_step_rule["required_answer"], b: current_step.answer.response)
+      return unless matching_answer?(a: current_step.additional_step_rules["required_answer"], b: current_step.answer.response)
 
       next_steps = journey_steps.where(contentful_id: next_step_ids)
       next_steps.update_all(hidden: false)
@@ -79,7 +79,7 @@ class ToggleAdditionalSteps
       next_steps.map { |next_step|
         recursively_show_additional_steps!(
           current_step: next_step,
-          next_step_ids: next_step.additional_step_rule&.fetch("question_identifier", nil)
+          next_step_ids: next_step.additional_step_rules&.fetch("question_identifier", nil)
         )
       }
     end

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -8,15 +8,11 @@ class ToggleAdditionalSteps
   def call
     return unless additional_step_rules
 
-    check_to_show_additional_steps!
-    check_to_hide_additional_steps!
+    recursively_show_additional_steps!(current_step: step, next_steps: additional_steps_to_show(step: step))
+    recursively_hide_additional_steps!(next_steps: additional_steps_to_hide)
   end
 
   private
-
-  def answer
-    step.answer
-  end
 
   def journey_steps
     @journey_steps ||= journey.steps
@@ -54,14 +50,6 @@ class ToggleAdditionalSteps
     else
       expected_answer == b.downcase
     end
-  end
-
-  def check_to_show_additional_steps!
-    recursively_show_additional_steps!(current_step: step, next_steps: additional_steps_to_show)
-  end
-
-  def check_to_hide_additional_steps!
-    recursively_hide_additional_steps!(next_steps: additional_steps_to_hide)
   end
 
   def recursively_hide_additional_steps!(next_steps:)

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -8,8 +8,8 @@ class ToggleAdditionalSteps
   def call
     return unless additional_step_rule
 
-    check_to_show_additional_steps! if additional_step.hidden?
-    check_to_hide_additional_steps! unless additional_step.hidden?
+    check_to_show_additional_steps!
+    check_to_hide_additional_steps!
   end
 
   private

--- a/db/migrate/20210223102716_change_additional_step_rule_name.rb
+++ b/db/migrate/20210223102716_change_additional_step_rule_name.rb
@@ -1,0 +1,5 @@
+class ChangeAdditionalStepRuleName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :steps, :additional_step_rule, :additional_step_rules
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_17_145518) do
+ActiveRecord::Schema.define(version: 2021_02_23_102716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 2021_02_17_145518) do
     t.jsonb "raw", null: false
     t.jsonb "options"
     t.boolean "hidden", default: false
-    t.jsonb "additional_step_rule"
+    t.jsonb "additional_step_rules"
     t.index ["journey_id"], name: "index_steps_on_journey_id"
   end
 

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     contentful_id { SecureRandom.hex }
     raw { |attrs| {"sys": {"id" => attrs["contentful_id"]}} }
     hidden { false }
+    additional_step_rules { nil }
 
     association :journey, factory: :journey
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -210,7 +210,7 @@ feature "Anyone can start a journey" do
 
     context "when Contentful entry includes a 'show additional question' rule" do
       scenario "additional questions are shown" do
-        start_journey_from_category_and_go_to_question(category: "show-additional-question.json")
+        start_journey_from_category_and_go_to_question(category: "show-one-additional-question.json")
 
         choose("School expert")
         click_on(I18n.t("generic.button.next"))

--- a/spec/features/visitors/anyone_can_edit_their_answers_spec.rb
+++ b/spec/features/visitors/anyone_can_edit_their_answers_spec.rb
@@ -93,7 +93,7 @@ feature "Users can edit their answers" do
 
   context "when Contentful entry includes a 'show additional question' rule" do
     scenario "an additional question is shown" do
-      start_journey_from_category_and_go_to_question(category: "show-additional-question.json")
+      start_journey_from_category_and_go_to_question(category: "show-one-additional-question.json")
 
       choose("School expert")
       click_on(I18n.t("generic.button.next"))

--- a/spec/fixtures/contentful/categories/show-one-additional-question.json
+++ b/spec/fixtures/contentful/categories/show-one-additional-question.json
@@ -35,7 +35,7 @@
             "sys": {
                 "type": "Link",
                 "linkType": "Entry",
-                "id": "show-additional-question-section"
+                "id": "show-one-additional-question-section"
             }
           }
         ],

--- a/spec/fixtures/contentful/sections/show-one-additional-question-section.json
+++ b/spec/fixtures/contentful/sections/show-one-additional-question-section.json
@@ -35,7 +35,7 @@
                 "sys": {
                     "type": "Link",
                     "linkType": "Entry",
-                    "id": "show-additional-question"
+                    "id": "show-one-additional-question"
                 }
             },
             {

--- a/spec/fixtures/contentful/steps/hidden-field-that-shows-an-additional-question.json
+++ b/spec/fixtures/contentful/steps/hidden-field-that-shows-an-additional-question.json
@@ -45,7 +45,7 @@
         "showAdditionalQuestion": [
           {
               "required_answer": "Red",
-              "question_identifier": ["hidden-field"]
+              "question_identifiers": ["hidden-field"]
           }
         ]
     }

--- a/spec/fixtures/contentful/steps/show-multiple-additional-questions.json
+++ b/spec/fixtures/contentful/steps/show-multiple-additional-questions.json
@@ -7,7 +7,7 @@
                 "id": "rwl7tyzv9sys"
             }
         },
-        "id": "hidden-field-that-shows-an-additional-question",
+        "id": "show-additional-question",
         "type": "Entry",
         "createdAt": "2020-11-04T12:28:24.460Z",
         "updatedAt": "2021-02-09T11:28:12.031Z",
@@ -31,21 +31,33 @@
     "fields": {
         "slug": "/available-support",
         "type": "radios",
-        "title": "What colour is the sky?",
+        "title": "What support do you have available?",
         "helpText": "Tell us what support you have available to you.",
         "extendedOptions": [
             {
-                "value": "Red"
+                "value": "School expert",
+                "display_further_information": true,
+                "further_information_help_text": "Explain why this is the case"
             },
             {
-                "value": "Blue"
+                "value": "External expert"
+            },
+            {
+                "value": "None"
             }
         ],
-        "alwaysShowTheUser": false,
         "showAdditionalQuestion": [
           {
-              "required_answer": "Red",
-              "question_identifier": ["hidden-field"]
+              "required_answer": "Yes",
+              "question_identifier": [
+                  "ZoOchclnfw6tPZ0xfYL0h"
+              ]
+          },
+          {
+              "required_answer": "No",
+              "question_identifier": [
+                  "wSeEY4HlESoDJSUsE2wJQ"
+              ]
           }
         ]
     }

--- a/spec/fixtures/contentful/steps/show-multiple-additional-questions.json
+++ b/spec/fixtures/contentful/steps/show-multiple-additional-questions.json
@@ -49,13 +49,13 @@
         "showAdditionalQuestion": [
           {
               "required_answer": "Yes",
-              "question_identifier": [
+              "question_identifiers": [
                   "ZoOchclnfw6tPZ0xfYL0h"
               ]
           },
           {
               "required_answer": "No",
-              "question_identifier": [
+              "question_identifiers": [
                   "wSeEY4HlESoDJSUsE2wJQ"
               ]
           }

--- a/spec/fixtures/contentful/steps/show-one-additional-question.json
+++ b/spec/fixtures/contentful/steps/show-one-additional-question.json
@@ -49,7 +49,7 @@
         "showAdditionalQuestion": [
           {
               "required_answer": "School expert",
-              "question_identifier": ["hidden-field-that-shows-an-additional-question"]
+              "question_identifiers": ["hidden-field-that-shows-an-additional-question"]
           }
         ]
     }

--- a/spec/fixtures/contentful/steps/show-one-additional-question.json
+++ b/spec/fixtures/contentful/steps/show-one-additional-question.json
@@ -46,9 +46,11 @@
                 "value": "None"
             }
         ],
-        "showAdditionalQuestion": {
-            "required_answer": "School expert",
-            "question_identifier": ["hidden-field-that-shows-an-additional-question"]
-        }
+        "showAdditionalQuestion": [
+          {
+              "required_answer": "School expert",
+              "question_identifier": ["hidden-field-that-shows-an-additional-question"]
+          }
+        ]
     }
 }

--- a/spec/fixtures/contentful/steps/show-one-additional-question.json
+++ b/spec/fixtures/contentful/steps/show-one-additional-question.json
@@ -7,7 +7,7 @@
                 "id": "rwl7tyzv9sys"
             }
         },
-        "id": "show-additional-question",
+        "id": "show-one-additional-question",
         "type": "Entry",
         "createdAt": "2020-11-04T12:28:24.460Z",
         "updatedAt": "2021-02-09T11:28:12.031Z",

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -159,12 +159,12 @@ process around March.")
           journey: journey, contentful_entry: fake_entry
         ).call
 
-        expect(step.additional_step_rules).to eql(
+        expect(step.additional_step_rules).to eql([
           {
             "required_answer" => "School expert",
             "question_identifier" => ["hidden-field-that-shows-an-additional-question"]
           }
-        )
+        ])
       end
     end
 

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -152,7 +152,7 @@ process around March.")
       it "stores the rule as JSON" do
         journey = create(:journey, :catering)
         fake_entry = fake_contentful_step(
-          contentful_fixture_filename: "steps/show-additional-question.json"
+          contentful_fixture_filename: "steps/show-one-additional-question.json"
         )
 
         step, _answer = described_class.new(

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -162,7 +162,7 @@ process around March.")
         expect(step.additional_step_rules).to eql([
           {
             "required_answer" => "School expert",
-            "question_identifier" => ["hidden-field-that-shows-an-additional-question"]
+            "question_identifiers" => ["hidden-field-that-shows-an-additional-question"]
           }
         ])
       end

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CreateJourneyStep do
         expect(step.contentful_type).to eq("radios")
         expect(step.options).to eq([{"value" => "Catering"}, {"value" => "Cleaning"}])
         expect(step.hidden).to eq(false)
-        expect(step.additional_step_rule).to eq(nil)
+        expect(step.additional_step_rules).to eq(nil)
         expect(step.raw).to eq(
           "fields" => {
             "helpText" => "Tell us which service you need.",
@@ -159,7 +159,7 @@ process around March.")
           journey: journey, contentful_entry: fake_entry
         ).call
 
-        expect(step.additional_step_rule).to eql(
+        expect(step.additional_step_rules).to eql(
           {
             "required_answer" => "School expert",
             "question_identifier" => ["hidden-field-that-shows-an-additional-question"]

--- a/spec/services/toggle_additional_steps_spec.rb
+++ b/spec/services/toggle_additional_steps_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}])
+            additional_step_rules: [{"required_answer" => "Red", "question_identifiers" => ["123"]}])
           create(:radio_answer, step: step, response: "Red")
 
           another_step_to_show = create(:step,
@@ -43,7 +43,7 @@ RSpec.describe ToggleAdditionalSteps do
             journey: journey,
             additional_step_rules: [{
               "required_answer" => "Red",
-              "question_identifier" => ["123", "456"]
+              "question_identifiers" => ["123", "456"]
             }])
           create(:radio_answer, step: step, response: "Red")
 
@@ -76,7 +76,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}])
+              additional_step_rules: [{"required_answer" => "Red", "question_identifiers" => ["123"]}])
             create(:radio_answer, step: step, response: "Red")
 
             step_to_show = create(:step,
@@ -96,7 +96,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: [{"required_answer" => "RED", "question_identifier" => ["123"]}])
+              additional_step_rules: [{"required_answer" => "RED", "question_identifiers" => ["123"]}])
             create(:radio_answer, step: step, response: "red")
 
             step_to_show = create(:step,
@@ -116,7 +116,7 @@ RSpec.describe ToggleAdditionalSteps do
             first_step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}],
+              additional_step_rules: [{"required_answer" => "Red", "question_identifiers" => ["123"]}],
               hidden: false)
             create(:radio_answer, step: first_step, response: "Red")
 
@@ -124,7 +124,7 @@ RSpec.describe ToggleAdditionalSteps do
               :radio,
               journey: journey,
               contentful_id: "123",
-              additional_step_rules: [{"required_answer" => "Blue", "question_identifier" => ["456"]}],
+              additional_step_rules: [{"required_answer" => "Blue", "question_identifiers" => ["456"]}],
               hidden: true)
             create(:radio_answer, step: second_step, response: "Blue")
 
@@ -147,7 +147,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}])
+            additional_step_rules: [{"required_answer" => "Red", "question_identifiers" => ["123"]}])
           create(:radio_answer, step: step, response: "Blue")
 
           step_to_show = create(:step,
@@ -167,7 +167,7 @@ RSpec.describe ToggleAdditionalSteps do
             journey: journey,
             additional_step_rules: [{
               "required_answer" => "Red",
-              "question_identifier" => ["123", "456"]
+              "question_identifiers" => ["123", "456"]
             }])
           create(:radio_answer, step: step, response: "NOT Red")
 
@@ -200,7 +200,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: [{"required_answer" => "RED", "question_identifier" => ["123"]}])
+              additional_step_rules: [{"required_answer" => "RED", "question_identifiers" => ["123"]}])
             create(:radio_answer, step: step, response: "red")
 
             step_to_show = create(:step,
@@ -220,7 +220,7 @@ RSpec.describe ToggleAdditionalSteps do
             first_step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}],
+              additional_step_rules: [{"required_answer" => "Red", "question_identifiers" => ["123"]}],
               hidden: false)
             create(:radio_answer, step: first_step, response: "Changed from red")
 
@@ -228,7 +228,7 @@ RSpec.describe ToggleAdditionalSteps do
               :radio,
               journey: journey,
               contentful_id: "123",
-              additional_step_rules: [{"required_answer" => "Blue", "question_identifier" => ["456"]}],
+              additional_step_rules: [{"required_answer" => "Blue", "question_identifiers" => ["456"]}],
               hidden: false)
             create(:radio_answer, step: second_step, response: "Blue")
 
@@ -251,7 +251,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :checkbox_answers,
             journey: journey,
-            additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}])
+            additional_step_rules: [{"required_answer" => "Red", "question_identifiers" => ["123"]}])
           create(:checkbox_answers, step: step, response: ["Blue", "Red"])
 
           step_to_show = create(:step,

--- a/spec/services/toggle_additional_steps_spec.rb
+++ b/spec/services/toggle_additional_steps_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]})
+            additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}])
           create(:radio_answer, step: step, response: "Red")
 
           another_step_to_show = create(:step,
@@ -41,10 +41,10 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rules: {
+            additional_step_rules: [{
               "required_answer" => "Red",
               "question_identifier" => ["123", "456"]
-            })
+            }])
           create(:radio_answer, step: step, response: "Red")
 
           first_additional_step_to_show = create(:step,
@@ -76,7 +76,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]})
+              additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}])
             create(:radio_answer, step: step, response: "Red")
 
             step_to_show = create(:step,
@@ -96,7 +96,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: {"required_answer" => "RED", "question_identifier" => ["123"]})
+              additional_step_rules: [{"required_answer" => "RED", "question_identifier" => ["123"]}])
             create(:radio_answer, step: step, response: "red")
 
             step_to_show = create(:step,
@@ -116,7 +116,7 @@ RSpec.describe ToggleAdditionalSteps do
             first_step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]},
+              additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}],
               hidden: false)
             create(:radio_answer, step: first_step, response: "Red")
 
@@ -124,7 +124,7 @@ RSpec.describe ToggleAdditionalSteps do
               :radio,
               journey: journey,
               contentful_id: "123",
-              additional_step_rules: {"required_answer" => "Blue", "question_identifier" => ["456"]},
+              additional_step_rules: [{"required_answer" => "Blue", "question_identifier" => ["456"]}],
               hidden: true)
             create(:radio_answer, step: second_step, response: "Blue")
 
@@ -147,7 +147,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]})
+            additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}])
           create(:radio_answer, step: step, response: "Blue")
 
           step_to_show = create(:step,
@@ -165,10 +165,10 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rules: {
+            additional_step_rules: [{
               "required_answer" => "Red",
               "question_identifier" => ["123", "456"]
-            })
+            }])
           create(:radio_answer, step: step, response: "NOT Red")
 
           first_additional_step_to_hide = create(:step,
@@ -200,7 +200,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: {"required_answer" => "RED", "question_identifier" => ["123"]})
+              additional_step_rules: [{"required_answer" => "RED", "question_identifier" => ["123"]}])
             create(:radio_answer, step: step, response: "red")
 
             step_to_show = create(:step,
@@ -220,7 +220,7 @@ RSpec.describe ToggleAdditionalSteps do
             first_step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]},
+              additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}],
               hidden: false)
             create(:radio_answer, step: first_step, response: "Changed from red")
 
@@ -228,7 +228,7 @@ RSpec.describe ToggleAdditionalSteps do
               :radio,
               journey: journey,
               contentful_id: "123",
-              additional_step_rules: {"required_answer" => "Blue", "question_identifier" => ["456"]},
+              additional_step_rules: [{"required_answer" => "Blue", "question_identifier" => ["456"]}],
               hidden: false)
             create(:radio_answer, step: second_step, response: "Blue")
 
@@ -251,7 +251,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :checkbox_answers,
             journey: journey,
-            additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]})
+            additional_step_rules: [{"required_answer" => "Red", "question_identifier" => ["123"]}])
           create(:checkbox_answers, step: step, response: ["Blue", "Red"])
 
           step_to_show = create(:step,

--- a/spec/services/toggle_additional_steps_spec.rb
+++ b/spec/services/toggle_additional_steps_spec.rb
@@ -4,20 +4,20 @@ RSpec.describe ToggleAdditionalSteps do
   describe "#call" do
     let(:journey) { create(:journey) }
 
-    context "when the additional_step_rule field is nil" do
+    context "when the additional_step_rules field is nil" do
       it "returns nil" do
         step = build(:step)
         expect(described_class.new(step: step).call).to eq(nil)
       end
     end
 
-    context "when the additional_step_rule exists" do
+    context "when the additional_step_rules exists" do
       context "when the answers match" do
         it "only shows the additional steps within the same journey" do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]})
+            additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]})
           create(:radio_answer, step: step, response: "Red")
 
           another_step_to_show = create(:step,
@@ -41,7 +41,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rule: {
+            additional_step_rules: {
               "required_answer" => "Red",
               "question_identifier" => ["123", "456"]
             })
@@ -76,7 +76,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]})
+              additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]})
             create(:radio_answer, step: step, response: "Red")
 
             step_to_show = create(:step,
@@ -96,7 +96,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "RED", "question_identifier" => ["123"]})
+              additional_step_rules: {"required_answer" => "RED", "question_identifier" => ["123"]})
             create(:radio_answer, step: step, response: "red")
 
             step_to_show = create(:step,
@@ -111,12 +111,12 @@ RSpec.describe ToggleAdditionalSteps do
           end
         end
 
-        context "when the referenced step also has an additional_step_rule rule" do
+        context "when the referenced step also has an additional_step_rules rule" do
           it "shows both connected questions" do
             first_step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]},
+              additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]},
               hidden: false)
             create(:radio_answer, step: first_step, response: "Red")
 
@@ -124,7 +124,7 @@ RSpec.describe ToggleAdditionalSteps do
               :radio,
               journey: journey,
               contentful_id: "123",
-              additional_step_rule: {"required_answer" => "Blue", "question_identifier" => ["456"]},
+              additional_step_rules: {"required_answer" => "Blue", "question_identifier" => ["456"]},
               hidden: true)
             create(:radio_answer, step: second_step, response: "Blue")
 
@@ -147,7 +147,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]})
+            additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]})
           create(:radio_answer, step: step, response: "Blue")
 
           step_to_show = create(:step,
@@ -165,7 +165,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :radio,
             journey: journey,
-            additional_step_rule: {
+            additional_step_rules: {
               "required_answer" => "Red",
               "question_identifier" => ["123", "456"]
             })
@@ -200,7 +200,7 @@ RSpec.describe ToggleAdditionalSteps do
             step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "RED", "question_identifier" => ["123"]})
+              additional_step_rules: {"required_answer" => "RED", "question_identifier" => ["123"]})
             create(:radio_answer, step: step, response: "red")
 
             step_to_show = create(:step,
@@ -215,12 +215,12 @@ RSpec.describe ToggleAdditionalSteps do
           end
         end
 
-        context "when the referenced step also has an additional_step_rule rule" do
+        context "when the referenced step also has an additional_step_rules rule" do
           it "hides both connected questions" do
             first_step = create(:step,
               :radio,
               journey: journey,
-              additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]},
+              additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]},
               hidden: false)
             create(:radio_answer, step: first_step, response: "Changed from red")
 
@@ -228,7 +228,7 @@ RSpec.describe ToggleAdditionalSteps do
               :radio,
               journey: journey,
               contentful_id: "123",
-              additional_step_rule: {"required_answer" => "Blue", "question_identifier" => ["456"]},
+              additional_step_rules: {"required_answer" => "Blue", "question_identifier" => ["456"]},
               hidden: false)
             create(:radio_answer, step: second_step, response: "Blue")
 
@@ -251,7 +251,7 @@ RSpec.describe ToggleAdditionalSteps do
           step = create(:step,
             :checkbox_answers,
             journey: journey,
-            additional_step_rule: {"required_answer" => "Red", "question_identifier" => ["123"]})
+            additional_step_rules: {"required_answer" => "Red", "question_identifier" => ["123"]})
           create(:checkbox_answers, step: step, response: ["Blue", "Red"])
 
           step_to_show = create(:step,


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

Based on https://github.com/DFE-Digital/buy-for-your-school/pull/176

This is the final part of the work to allow the content team to specify proper branching questions. Instead of a palm tree (where we could only add or remove questions from the same trunk) we can now branch in different directions. Each branch can have an arbitrary length.

![external-content duckduckgo com](https://user-images.githubusercontent.com/912473/108837322-f8eba080-75c9-11eb-873d-f441e2ea341e.jpg)

## Changes in this PR

- The structure of the Contentful `Show additional question` field has changed. Instead of requiring only one rule object we now expect an array of rules. The names of these fields have been updated to better reflect the plurality of the contents:

```
[
    {
        "required_answer": "Breakfast",
        "question_identifiers": [
            "ZoOchclnfw6tPZ0xfYL0h",
	    "1DqhwF2XkJJ0Um6NSweWlZ"
        ]
    },
    {
        "required_answer": "Dinner",
        "question_identifiers": [
            "wSeEY4HlESoDJSUsE2wJQ"
        ]
    }
]
```

- When we evaluate whether to show or hide a question based on a given answer, we now iterate through every rule (rather than the single rule before). Theoretically 1,000 rules could be added, each with a 1,000 steps to show and hide. Should this scale of branch be needed then this approach would not be sufficient given the computational cost of iterating through rules and recursing down the tree. That said our user need is to show a single fork with 2 options that rejoins the trunk within 2/3 questions. 

## Screenshots of UI changes

This example uses the following Contentful tree structure:
![Screenshot 2021-02-23 at 11 21 46](https://user-images.githubusercontent.com/912473/108836892-57644f00-75c9-11eb-9d7d-6458ef946fe3.png)

![Screenshot_2021-02-23 Catering](https://user-images.githubusercontent.com/912473/108836500-ce4d1800-75c8-11eb-819c-8104f6e7a494.png)

When we answer the question with "Breakfast" we see the second hidden question appear:
![Screenshot_2021-02-23 Catering(1)](https://user-images.githubusercontent.com/912473/108836503-cf7e4500-75c8-11eb-95b2-29fe7de80729.png)

When we answer the question with "Dinner" we see the first hidden question appear:
![Screenshot_2021-02-23 Catering(2)](https://user-images.githubusercontent.com/912473/108836507-d0af7200-75c8-11eb-963e-11f2e14c65a4.png))

When we answer the question with "Lunch" we see both hidden questions are hidden again:
![Screenshot_2021-02-23 Catering(3)](https://user-images.githubusercontent.com/912473/108836510-d1480880-75c8-11eb-87ae-3e73bc0d47cf.png)

## Next steps

- [ ] Update all contentful entries on master and develop that use the `Show additional question` field and update the syntax to use the new structure
- [ ] Update Confluence documentation
- [ ] Communicate changes with the Content team