### PR TITLE
Fix cases where empty help text would cause errors

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -6,6 +6,7 @@ class AnswersController < ApplicationController
   def create
     @journey = Journey.find(journey_id)
     @step = Step.find(step_id)
+    @step_presenter = StepPresenter.new(@step)
 
     @answer = AnswerFactory.new(step: @step).call
     @answer.step = @step
@@ -24,6 +25,7 @@ class AnswersController < ApplicationController
   def update
     @journey = Journey.find(journey_id)
     @step = Step.find(step_id)
+    @step_presenter = StepPresenter.new(@step)
 
     result = SaveAnswer.new(answer: @step.answer)
       .call(checkbox_params: checkbox_params, answer_params: answer_params, date_params: date_params)

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -33,7 +33,7 @@ class JourneysController < ApplicationController
       :number_answer,
       :currency_answer
     ])
-    @steps = @visible_steps.map { |step| StepPresenter.new(step) }
+    @step_presenters = @visible_steps.map { |step| StepPresenter.new(step) }
 
     @specification_template = Liquid::Template.parse(
       @journey.liquid_template, error_mode: :strict

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -3,7 +3,10 @@
 class StepsController < ApplicationController
   def show
     @journey = Journey.find(journey_id)
+
     @step = Step.find(params[:id])
+    @step_presenter = StepPresenter.new(@step)
+
     @answer = AnswerFactory.new(step: @step).call
 
     render @step.contentful_type, locals: {layout: "steps/new_form_wrapper"}
@@ -11,7 +14,10 @@ class StepsController < ApplicationController
 
   def edit
     @journey = Journey.find(journey_id)
+
     @step = Step.find(params[:id])
+    @step_presenter = StepPresenter.new(@step)
+
     @answer = @step.answer
 
     render "steps/#{@step.contentful_type}", locals: {layout: "steps/edit_form_wrapper"}

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -27,9 +27,4 @@ class Step < ApplicationRecord
     return I18n.t("generic.button.next") unless super.present?
     super
   end
-
-  def help_text_html
-    return unless help_text.present?
-    Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(help_text).html_safe
-  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -29,6 +29,7 @@ class Step < ApplicationRecord
   end
 
   def help_text_html
-    Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(help_text)
+    return unless help_text.present?
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(help_text).html_safe
   end
 end

--- a/app/presenters/step_presenter.rb
+++ b/app/presenters/step_presenter.rb
@@ -2,4 +2,9 @@ class StepPresenter < SimpleDelegator
   def question?
     contentful_model == "question"
   end
+
+  def help_text_html
+    return unless help_text.present?
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(help_text).html_safe
+  end
 end

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -6,7 +6,7 @@
 
 <ol class="app-task-list">
 
-  <% section_group_with_steps(journey: @journey, steps: @steps).each do |grouping| %>
+  <% section_group_with_steps(journey: @journey, steps: @step_presenters).each do |grouping| %>
     <h2 class="app-task-list__section"><%= grouping["title"] %></h2>
     <li>
       <%= render "step_list", journey: @journey, steps: grouping["steps"] %>

--- a/app/views/steps/_edit_form_wrapper.html.erb
+++ b/app/views/steps/_edit_form_wrapper.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, @step.title %>
+<%= content_for :title, @step_presenter.title %>
 <%= form_for @answer, as: :answer, method: "put", url: journey_step_answer_path(@journey, @step, @answer) do |f| %>
   <%= yield f %>
   <%= f.submit I18n.t("generic.button.update"), class: "govuk-button" %>

--- a/app/views/steps/_new_form_wrapper.html.erb
+++ b/app/views/steps/_new_form_wrapper.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :title, @step.title %>
+<%= content_for :title, @step_presenter.title %>
 <%= form_for @answer, as: :answer, url: journey_step_answers_path(@journey, @step), method: "post" do |f| %>
   <%= yield f %>
-  <%= f.submit @step.primary_call_to_action_text, class: "govuk-button" %>
+  <%= f.submit @step_presenter.primary_call_to_action_text, class: "govuk-button" %>
 <% end %>

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -2,7 +2,7 @@
   <%= f.govuk_check_boxes_fieldset :response, legend: { text: @step.title, size: "l" } do %>
     <% if @step.help_text.present? %>
       <span class="govuk-hint">
-        <%= @step.help_text_html.html_safe %>
+        <%= @step.help_text_html %>
       </span>
     <% end %>
 

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -1,8 +1,8 @@
 <%= render layout: layout do |f| %>
-  <%= f.govuk_check_boxes_fieldset :response, legend: { text: @step.title, size: "l" } do %>
+  <%= f.govuk_check_boxes_fieldset :response, legend: { text: @step_presenter.title, size: "l" } do %>
     <% if @step.help_text.present? %>
       <span class="govuk-hint">
-        <%= @step.help_text_html %>
+        <%= @step_presenter.help_text_html %>
       </span>
     <% end %>
 

--- a/app/views/steps/currency.html.erb
+++ b/app/views/steps/currency.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_field :response,
-    label: { text: @step.title, size: "l" },
+    label: { text: @step_presenter.title, size: "l" },
     prefix_text: "£",
-    hint: -> { @step.help_text_html }
+    hint: -> { @step_presenter.help_text_html }
   %>
 <% end %>

--- a/app/views/steps/currency.html.erb
+++ b/app/views/steps/currency.html.erb
@@ -2,6 +2,6 @@
   <%= f.govuk_text_field :response,
     label: { text: @step.title, size: "l" },
     prefix_text: "£",
-    hint: -> { @step.help_text_html.html_safe }
+    hint: -> { @step.help_text_html }
   %>
 <% end %>

--- a/app/views/steps/long_text.html.erb
+++ b/app/views/steps/long_text.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_area :response,
     label: { text: @step.title, size: "l" },
-    hint: -> { @step.help_text_html.html_safe },
+    hint: -> { @step.help_text_html },
     width: "one-third",
     rows: 9
   %>

--- a/app/views/steps/long_text.html.erb
+++ b/app/views/steps/long_text.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_area :response,
-    label: { text: @step.title, size: "l" },
-    hint: -> { @step.help_text_html },
+    label: { text: @step_presenter.title, size: "l" },
+    hint: -> { @step_presenter.help_text_html },
     width: "one-third",
     rows: 9
   %>

--- a/app/views/steps/number.html.erb
+++ b/app/views/steps/number.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_field :response,
-    label: { text: @step.title, size: "l" },
-    hint: -> { @step.help_text_html }
+    label: { text: @step_presenter.title, size: "l" },
+    hint: -> { @step_presenter.help_text_html }
   %>
 <% end %>

--- a/app/views/steps/number.html.erb
+++ b/app/views/steps/number.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_field :response,
     label: { text: @step.title, size: "l" },
-    hint: -> { @step.help_text_html.html_safe }
+    hint: -> { @step.help_text_html }
   %>
 <% end %>

--- a/app/views/steps/paragraphs.html.erb
+++ b/app/views/steps/paragraphs.html.erb
@@ -1,7 +1,7 @@
-<%= content_for :title, @step.title %>
+<%= content_for :title, @step_presenter.title %>
 
-<h1 class="govuk-heading-xl"><%= @step.title %></h1>
+<h1 class="govuk-heading-xl"><%= @step_presenter.title %></h1>
 <div class="static-content">
-  <%= simple_format(@step.body, wrapper_tag: "p", class: "govuk-body") %>
+  <%= simple_format(@step_presenter.body, wrapper_tag: "p", class: "govuk-body") %>
 </div>
-<%= link_to @step.primary_call_to_action_text, journey_path(@journey), class: "govuk-button" %>
+<%= link_to @step_presenter.primary_call_to_action_text, journey_path(@journey), class: "govuk-button" %>

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -1,9 +1,9 @@
 <%= render layout: layout do |f| %>
   <%= f.hidden_field :response, value: nil %>
-  <%= f.govuk_radio_buttons_fieldset(:response, legend: { size: "l", text: @step.title }) do %>
+  <%= f.govuk_radio_buttons_fieldset(:response, legend: { size: "l", text: @step_presenter.title }) do %>
     <% if @step.help_text.present? %>
       <div class="govuk-hint">
-        <%= @step.help_text_html %>
+        <%= @step_presenter.help_text_html %>
       </div>
     <% end %>
 

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -3,7 +3,7 @@
   <%= f.govuk_radio_buttons_fieldset(:response, legend: { size: "l", text: @step.title }) do %>
     <% if @step.help_text.present? %>
       <div class="govuk-hint">
-        <%= @step.help_text_html.html_safe %>
+        <%= @step.help_text_html %>
       </div>
     <% end %>
 

--- a/app/views/steps/short_text.html.erb
+++ b/app/views/steps/short_text.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_field :response,
-    label: { text: @step.title, size: "l" },
-    hint: -> { @step.help_text_html },
+    label: { text: @step_presenter.title, size: "l" },
+    hint: -> { @step_presenter.help_text_html },
     width: "one-third"
   %>
 <% end %>

--- a/app/views/steps/short_text.html.erb
+++ b/app/views/steps/short_text.html.erb
@@ -1,7 +1,7 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_text_field :response,
     label: { text: @step.title, size: "l" },
-    hint: -> { @step.help_text_html.html_safe },
+    hint: -> { @step.help_text_html },
     width: "one-third"
   %>
 <% end %>

--- a/app/views/steps/single_date.html.erb
+++ b/app/views/steps/single_date.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_date_field :response,
     legend: { text: @step.title, size: "l" },
-    hint: -> { @step.help_text_html.html_safe }
+    hint: -> { @step.help_text_html }
   %>
 <% end %>

--- a/app/views/steps/single_date.html.erb
+++ b/app/views/steps/single_date.html.erb
@@ -1,6 +1,6 @@
 <%= render layout: layout do |f| %>
   <%= f.govuk_date_field :response,
-    legend: { text: @step.title, size: "l" },
-    hint: -> { @step.help_text_html }
+    legend: { text: @step_presenter.title, size: "l" },
+    hint: -> { @step_presenter.help_text_html }
   %>
 <% end %>

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -278,6 +278,12 @@ feature "Anyone can start a journey" do
 
       expect(page.html).to include("Which service do you need?")
     end
+
+    scenario "step page still renders when question is a short text" do
+      start_journey_from_category_and_go_to_question(category: "nil-help-text-short-text.json")
+
+      expect(page.html).to include("What email address did you use?")
+    end
   end
 
   context "when Contentful entry model wasn't an expected type" do

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -273,8 +273,8 @@ feature "Anyone can start a journey" do
   end
 
   context "when the help text is nil" do
-    scenario "paragraph breaks are parsed as expected" do
-      start_journey_from_category_and_go_to_question(category: "nil-help-text.json")
+    scenario "step page still renders when question is a radio" do
+      start_journey_from_category_and_go_to_question(category: "nil-help-text-radios.json")
 
       expect(page.html).to include("Which service do you need?")
     end

--- a/spec/fixtures/contentful/categories/nil-help-text-radios.json
+++ b/spec/fixtures/contentful/categories/nil-help-text-radios.json
@@ -35,7 +35,7 @@
             "sys": {
                 "type": "Link",
                 "linkType": "Entry",
-                "id": "nil-help-text-section"
+                "id": "nil-help-text-radios-section"
             }
           }
         ],

--- a/spec/fixtures/contentful/categories/nil-help-text-short-text.json
+++ b/spec/fixtures/contentful/categories/nil-help-text-short-text.json
@@ -1,0 +1,44 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "nil-help-text-short-text-section"
+            }
+          }
+        ],
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+    }
+}

--- a/spec/fixtures/contentful/sections/nil-help-text-radios-section.json
+++ b/spec/fixtures/contentful/sections/nil-help-text-radios-section.json
@@ -35,7 +35,7 @@
                 "sys": {
                     "type": "Link",
                     "linkType": "Entry",
-                    "id": "nil-help-text"
+                    "id": "nil-help-text-radios"
                 }
             }
         ]

--- a/spec/fixtures/contentful/sections/nil-help-text-short-text-section.json
+++ b/spec/fixtures/contentful/sections/nil-help-text-short-text-section.json
@@ -1,0 +1,43 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "nil-help-text-short-text-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section A",
+        "steps": [
+            {
+                "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "nil-help-text-short-text"
+                }
+            }
+        ]
+    }
+}

--- a/spec/fixtures/contentful/steps/nil-help-text-radios.json
+++ b/spec/fixtures/contentful/steps/nil-help-text-radios.json
@@ -7,7 +7,7 @@
                 "id": "jspwts36h1os"
             }
         },
-        "id": "nil-help-text",
+        "id": "nil-help-text-radios",
         "type": "Entry",
         "createdAt": "2020-09-07T10:56:40.585Z",
         "updatedAt": "2020-09-14T22:16:54.633Z",

--- a/spec/fixtures/contentful/steps/nil-help-text-short-text.json
+++ b/spec/fixtures/contentful/steps/nil-help-text-short-text.json
@@ -1,0 +1,36 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "nil-help-text-short-text",
+        "type": "Entry",
+        "createdAt": "2020-11-05T16:42:58.340Z",
+        "updatedAt": "2020-11-05T16:42:58.340Z",
+        "environment": {
+            "sys": {
+                "id": "master",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/what-email-address-did-you-use",
+        "title": "What email address did you use?",
+        "type": "short text"
+    }
+}


### PR DESCRIPTION
Since we weren't correctly guarding against empty `help_text` for some question types, when the `help_text` was empty we would try call methods on it that did not exist.

To make this easier to understand and cleaner for people in future, this also spends some time making sure the individual step views make use of `StepPresenter` instead of the `Step` object directly and moves the `help_text_html` into this presentation layer.