### PR TITLE
Checkbox info fields no longer try and create their own label

### DIFF
--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -13,7 +13,7 @@
         <% f.object = monkey_patch_form_object_with_further_information_field(form_object: f.object, associated_choice: machine_value) %>
         <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
           <%= f.govuk_text_field "#{machine_value}_further_information",
-            label: { text: option["further_information_help_text"] } %>
+            label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
         <% end %>
       <% else %>
         <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } %>

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -168,6 +168,10 @@ feature "Anyone can start a journey" do
           fill_in "answer[yes_further_information]", with: "The first piece of further information"
 
           check("No")
+          expect(page).not_to have_content("No_further_information") # It should not create a label which one isn't specified
+          within("span.govuk-visually-hidden") do
+            expect(page).to have_content("Optional further information") # Default the hidden label to something understandable for screen readers
+          end
           fill_in "answer[no_further_information]", with: "A second piece of further information"
 
           click_on(I18n.t("generic.button.next"))

--- a/spec/fixtures/contentful/steps/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/steps/extended-checkboxes-question.json
@@ -40,8 +40,7 @@
             },
             {
                 "value": "No",
-                "display_further_information": true,
-                "further_information_help_text": "You should tell us more"
+                "display_further_information": true
             }
         ],
         "alwaysShowTheUser": true


### PR DESCRIPTION

<!-- Do you need to update the changelog? -->

## Changes in this PR

..When one is not provided

We instead don't show a label at all.
## Screenshots of UI changes

### Before

![Screenshot 2021-02-23 at 15 11 34](https://user-images.githubusercontent.com/912473/108864456-1e88a200-75ea-11eb-81f7-c552bc192b11.png)


### After

![Screenshot 2021-02-23 at 15 11 48](https://user-images.githubusercontent.com/912473/108864466-20eafc00-75ea-11eb-80de-67fd7b95fb49.png)
