### PR TITLE
Fix inconsistent reference to Contentful attribute

### DIFF
--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -9,7 +9,7 @@
     <% @step.options.each do |option| %>
       <% machine_value = option["value"].tr(" ", "_").downcase %>
 
-      <% if option["further_information_required"] == true %>
+      <% if option["display_further_information"] == true %>
         <% f.object = monkey_patch_form_object_with_further_information_field(form_object: f.object, associated_choice: machine_value) %>
         <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
           <%= f.govuk_text_field "#{machine_value}_further_information",

--- a/spec/fixtures/contentful/steps/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/steps/extended-checkboxes-question.json
@@ -35,12 +35,12 @@
         "extendedOptions": [
             {
                 "value": "Yes",
-                "further_information_required": true,
+                "display_further_information": true,
                 "further_information_help_text": "You should tell us more"
             },
             {
                 "value": "No",
-                "further_information_required": true,
+                "display_further_information": true,
                 "further_information_help_text": "You should tell us more"
             }
         ],


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

\We already had `display_further_information` for radio questions and this has been used with our real questions. The addition of extended checkbox questions made an error with how it's fixture was produced. Switch this back to the original key name.

I've gone through Contentful `master` and `develop` and corrected all checkbox questions that had the wrong key and updated the help text on the Content Model.