### PR TITLE
Create an extended further information text box option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - markdown in help text fields is now parsed into HTML
 - show and hide more than one additional question at a time
 - users can be presenting with forking/branching question chains based on any one answer
+- create an extended further information text box option for radio answers
 
 ## [release-005] - 2021-1-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - show and hide more than one additional question at a time
 - users can be presenting with forking/branching question chains based on any one answer
 - create an extended further information text box option for radio answers
+- create extended further information text box option for checkbox answers
 
 ## [release-005] - 2021-1-19
 

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -9,15 +9,20 @@
     <% @step.options.each do |option| %>
       <% machine_value = option["value"].tr(" ", "_").downcase %>
 
-      <% if option["display_further_information"] == true %>
-        <% f.object = monkey_patch_form_object_with_further_information_field(form_object: f.object, associated_choice: machine_value) %>
-        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
-          <%= f.govuk_text_field "#{machine_value}_further_information",
-            label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
+      <% f.object = monkey_patch_form_object_with_further_information_field(form_object: f.object, associated_choice: machine_value) %>
+        <% if option["display_further_information"] == true || option["display_further_information"] == "single" %>
+          <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
+            <%= f.govuk_text_field "#{machine_value}_further_information",
+              label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
+          <% end %>
+        <% elsif option["display_further_information"] == "long" %>
+          <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
+            <%= f.govuk_text_area "#{machine_value}_further_information", rows: 6,
+              label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
+          <% end %>
+        <% else %>
+          <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } %>
         <% end %>
-      <% else %>
-        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } %>
-      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -8,13 +8,13 @@
     <% end %>
 
     <% @step.options.each do |option| %>
-      <% if option["display_further_information"] == true %>
         <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } do %>
-          <%= f.govuk_text_area :further_information, rows: 1, label: { text: option["further_information_help_text"] } %>
+          <% if option["display_further_information"] == "single" || option["display_further_information"] == true %>
+            <%= f.govuk_text_field :further_information, label: { text: option["further_information_help_text"] } %>
+          <% elsif option["display_further_information"] == "long" %>
+            <%= f.govuk_text_area :further_information, rows: 6, label: { text: option["further_information_help_text"] } %>
+          <% end %>
         <% end %>
-      <% else %>
-        <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } %>
-      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -187,6 +187,35 @@ feature "Anyone can start a journey" do
             .to eql("A second piece of further information")
         end
       end
+
+      context "when extended question is of type single" do
+        scenario "a single text field is displayed" do
+          start_journey_from_category_and_go_to_question(category: "extended-checkboxes-question.json")
+
+          check("Yes")
+
+          expect(page).to have_selector("input#answer-yes-further-information-field")
+        end
+      end
+
+      context "when extended question is of type long" do
+        scenario "a long text area is displayed" do
+          start_journey_from_category_and_go_to_question(category: "extended-long-answer-checkboxes-question.json")
+
+          check("Yes")
+
+          expect(page).to have_selector("textarea#answer-yes-further-information-field")
+        end
+      end
+
+      context "when there is no extended question" do
+        scenario "no extra text field is displayed" do
+          start_journey_from_category_and_go_to_question(category: "checkboxes-question.json")
+
+          expect(page).to_not have_selector("textarea#answer-yes-further-information-field")
+          expect(page).to_not have_selector("input#answer-yes-further-information-field")
+        end
+      end
     end
 
     context "when Contentful entry is of type radios" do

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -206,6 +206,35 @@ feature "Anyone can start a journey" do
             .to eql("The school needs the kitchen cleaned once a day")
         end
       end
+
+      context "when extended question is of type single" do
+        scenario "a single text field is displayed" do
+          start_journey_from_category_and_go_to_question(category: "extended-radio-question.json")
+
+          choose("Catering")
+
+          expect(page).to have_selector("input#answer-further-information-field")
+        end
+      end
+
+      context "when extended question is of type long" do
+        scenario "a long text area is displayed" do
+          start_journey_from_category_and_go_to_question(category: "extended-long-answer-radio-question.json")
+
+          choose("Catering")
+
+          expect(page).to have_selector("textarea#answer-further-information-field")
+        end
+      end
+
+      context "when there is no extended question" do
+        scenario "no extra text field is displayed" do
+          start_journey_from_category_and_go_to_question(category: "radio-question.json")
+
+          expect(page).to_not have_selector("textarea#answer-further-information-field")
+          expect(page).to_not have_selector("input#answer-further-information-field")
+        end
+      end
     end
 
     context "when Contentful entry includes a 'show additional question' rule" do

--- a/spec/fixtures/contentful/categories/extended-long-answer-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/extended-long-answer-checkboxes-question.json
@@ -1,0 +1,44 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "extended-long-answer-checkboxes-section"
+            }
+          }
+        ],
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+    }
+}

--- a/spec/fixtures/contentful/categories/extended-long-answer-radio-question.json
+++ b/spec/fixtures/contentful/categories/extended-long-answer-radio-question.json
@@ -1,0 +1,44 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "extended-long-answer-radio-section"
+            }
+          }
+        ],
+        "specification_template": "<article id='specification'><h1>{{answer_extended-radio-question}}</h1></article>"
+    }
+}

--- a/spec/fixtures/contentful/sections/extended-long-answer-checkboxes-section.json
+++ b/spec/fixtures/contentful/sections/extended-long-answer-checkboxes-section.json
@@ -1,0 +1,43 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "extended-long-answer-checkboxes-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section A",
+        "steps": [
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "extended-long-answer-checkboxes-question"
+              }
+            }
+        ]
+    }
+}

--- a/spec/fixtures/contentful/sections/extended-long-answer-radio-section.json
+++ b/spec/fixtures/contentful/sections/extended-long-answer-radio-section.json
@@ -1,0 +1,43 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "extended-long-answer-radio-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section A",
+        "steps": [
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "extended-long-answer-radio-question"
+              }
+            }
+        ]
+    }
+}

--- a/spec/fixtures/contentful/steps/extended-long-answer-checkboxes-question.json
+++ b/spec/fixtures/contentful/steps/extended-long-answer-checkboxes-question.json
@@ -1,0 +1,49 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "extended-long-answer-checkboxes-question",
+        "type": "Entry",
+        "createdAt": "2021-02-17T14:09:56.405Z",
+        "updatedAt": "2021-02-17T14:38:07.806Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/extended-checkboxes",
+        "type": "checkboxes",
+        "title": "Extended checkboxes",
+        "extendedOptions": [
+            {
+                "value": "Yes",
+                "display_further_information": "long",
+                "further_information_help_text": "You should tell us more"
+            },
+            {
+                "value": "No",
+                "display_further_information": "long",
+                "further_information_help_text": "You should tell us more"
+            }
+        ],
+        "alwaysShowTheUser": true
+    }
+}

--- a/spec/fixtures/contentful/steps/extended-long-answer-radio-question.json
+++ b/spec/fixtures/contentful/steps/extended-long-answer-radio-question.json
@@ -1,0 +1,51 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "jspwts36h1os"
+            }
+        },
+        "id": "extended-long-answer-radio-question",
+        "type": "Entry",
+        "createdAt": "2020-09-07T10:56:40.585Z",
+        "updatedAt": "2020-09-14T22:16:54.633Z",
+        "environment": {
+            "sys": {
+                "id": "master",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 7,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/which-service",
+        "title": "Which service do you need?",
+        "helpText": "Tell us which service you need.",
+        "type": "radios",
+        "extendedOptions": [
+          {
+              "value": "Catering",
+              "help_text": "",
+              "display_further_information": "long",
+              "further_information_help_text": "Briefly describe why you need catering"
+          },
+          {
+              "value": "Cleaning",
+              "help_text": "All interior areas of the school only",
+              "display_further_information": false,
+              "further_information_help_text": "Briefly describe why you need cleaning"
+          }
+        ]
+    }
+}


### PR DESCRIPTION
## Changes in this PR

Radio answers and checkbox answers now have the option to either display a `single` or `long` text box for their further information text box

## Screenshots of UI changes

This is the `single` option:

### Radio answer
![Screen Shot 2021-02-23 at 11 40 25](https://user-images.githubusercontent.com/59832893/108875987-aaec9200-75f5-11eb-8e14-96446342b982.png)

### Checkbox answer
![Screen Shot 2021-02-24 at 15 01 14](https://user-images.githubusercontent.com/59832893/109026579-cd46e400-76b7-11eb-96b1-7ffb1e5357b4.png)

This is the `long` option:

### Radio answer
![Screen Shot 2021-02-23 at 11 30 58](https://user-images.githubusercontent.com/59832893/108876028-b5a72700-75f5-11eb-9f7f-c4af12c3efc7.png)

### Checkbox answer
![Screen Shot 2021-02-24 at 15 49 40](https://user-images.githubusercontent.com/59832893/109026728-f5cede00-76b7-11eb-9244-30d1b24a57f4.png)

