### PR TITLE
Brakeman runs on CI again

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Build
         run: docker-compose -f docker-compose.ci.yml build
       - name: Test
-        run: docker-compose -f docker-compose.ci.yml run --rm test bundle exec rake
+        run: docker-compose -f docker-compose.ci.yml run --rm test script/test

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -45,7 +45,7 @@ class JourneysController < ApplicationController
     respond_to do |format|
       format.html
       format.docx do
-        render docx: "specification.docx", content: @specification_html, layout: "specficiation"
+        render docx: "specification.docx", content: @specification_html
       end
     end
   end

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -40,12 +40,12 @@ class JourneysController < ApplicationController
     )
 
     @answers = GetAnswersForSteps.new(visible_steps: @visible_steps).call
-    specification_html = @specification_template.render(@answers)
+    @specification_html = @specification_template.render(@answers)
 
     respond_to do |format|
       format.html
       format.docx do
-        render docx: "specification.docx", content: specification_html, layout: "specficiation"
+        render docx: "specification.docx", content: @specification_html, layout: "specficiation"
       end
     end
   end

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -25,4 +25,4 @@
   </div>
 <% end %>
 <%= link_to "Download (.docx)", journey_path(@journey, format: :docx), class: "govuk-button" %>
-<%= @specification_template.render(@answers).html_safe %>
+<%= @specification_html.html_safe %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,37 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "cf9010da503c2276ed17469cdc002d84afdc182b5e87adae78716ab10c2eb928",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/journeys/show.html.erb",
+      "line": 28,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Liquid::Template.parse(Journey.find(journey_id).liquid_template, :error_mode => :strict).render(GetAnswersForSteps.new(:visible_steps => Journey.find(journey_id).visible_steps.includes([:radio_answer, :short_text_answer, :long_text_answer, :single_date_answer, :checkbox_answers, :number_answer, :currency_answer])).call)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "JourneysController",
+          "method": "show",
+          "line": 46,
+          "file": "app/controllers/journeys_controller.rb",
+          "rendered": {
+            "name": "journeys/show",
+            "file": "app/views/journeys/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "journeys/show"
+      },
+      "user_input": "Journey.find(journey_id).liquid_template",
+      "confidence": "Weak",
+      "note": ""
+    }
+  ],
+  "updated": "2021-02-24 11:55:12 +0000",
+  "brakeman_version": "5.0.0"
+}

--- a/script/test
+++ b/script/test
@@ -6,3 +6,4 @@
 set -e
 
 bundle exec rake
+bundle exec brakeman -o /dev/stdout


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- add this as a testing steip to script/test in keeping with the 'One script to rule them all' pattern
- disregard the output so brakeman doesn't open an interactive prompt, we could add the report to a file but the container is ephemeral

We have an existing security warning to address as part of this work now as we had a period of time where we weren't running these checks.

CI will now explode (with a level 1 error and a fake level 3) ![Screenshot 2021-02-24 at 11 44 23](https://user-images.githubusercontent.com/912473/108995919-a8da1000-7695-11eb-8f9b-1f7b203bea32.png)