### PR TITLE
Optimise expensive database queries

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -14,13 +14,15 @@ class Step < ApplicationRecord
 
   def answer
     @answer ||=
-      radio_answer ||
-      short_text_answer ||
-      long_text_answer ||
-      single_date_answer ||
-      checkbox_answers ||
-      number_answer ||
-      currency_answer
+      case contentful_type
+      when "radios" then radio_answer
+      when "short_text" then short_text_answer
+      when "long_text" then long_text_answer
+      when "single_date" then single_date_answer
+      when "checkboxes" then checkbox_answers
+      when "number" then number_answer
+      when "currency" then currency_answer
+      end
   end
 
   def primary_call_to_action_text

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe GetAnswersForSteps do
       it "does not try to prepare that answer in the result" do
         journey = create(:journey)
         answerable_step = create(:step, :radio, journey: journey)
-        _answer = create(:short_text_answer, step: answerable_step)
+        _answer = create(:radio_answer, step: answerable_step)
         unanswerable_step = create(:step, :radio, journey: journey)
 
         result = described_class.new(visible_steps: [answerable_step]).call


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Refactor our implementation of `step.answer`.

Instead of trying each association in order we are selective about the query we expect to make. This changes the outcome of method, reducing the maximum of 7 database queries (if the step is currency) to always being at most 1 query. To do this we interogate the `contentful_type` field.

## Screenshots of UI changes

For example, this is the database output when asking a checkbox step for it's answer (and how I spotted this issue). You can see we make 4 redundant SELECT queries before checking for a checkbox answer: 

### Before

![Screenshot 2021-02-24 at 11 38 42](https://user-images.githubusercontent.com/912473/109000117-2ce2c680-769b-11eb-85a4-3916cbc6dab7.png)

### After

We now only make one query we always expect to retrieve something or raise a RecordNotFound:

![Screenshot 2021-02-24 at 12 17 42](https://user-images.githubusercontent.com/912473/109000055-19376000-769b-11eb-912e-4b21d0fe5454.png)

## Next steps
