### PR TITLE
Move specification rendering into a service object

### DIFF
--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -14,12 +14,12 @@ class SpecificationsController < ApplicationController
     ])
     @step_presenters = @visible_steps.map { |step| StepPresenter.new(step) }
 
-    @specification_template = Liquid::Template.parse(
-      @journey.liquid_template, error_mode: :strict
+    specification_renderer = SpecificationRenderer.new(
+      template: @journey.liquid_template,
+      answers: GetAnswersForSteps.new(visible_steps: @visible_steps).call
     )
 
-    @answers = GetAnswersForSteps.new(visible_steps: @visible_steps).call
-    @specification_html = @specification_template.render(@answers)
+    @specification_html = specification_renderer.to_html
 
     respond_to do |format|
       format.html

--- a/app/services/specification_renderer.rb
+++ b/app/services/specification_renderer.rb
@@ -1,0 +1,12 @@
+class SpecificationRenderer
+  def initialize(template:, answers:)
+    @template = Liquid::Template.parse(
+      template, error_mode: :strict
+    )
+    @answers = answers
+  end
+
+  def to_html
+    @template.render(@answers).html_safe
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "9e0249e5929623c7ab1fd850ad5e15b49356e4a7ab235bc0373e98998bd3b321",
+      "fingerprint": "3863b51add0146069c24410ec1bfc99015d680679d275ce49f27cc22b6dc8f9e",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/specifications/show.html.erb",
       "line": 15,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Liquid::Template.parse(Journey.find(journey_id).liquid_template, :error_mode => :strict).render(GetAnswersForSteps.new(:visible_steps => Journey.find(journey_id).visible_steps.includes([:radio_answer, :short_text_answer, :long_text_answer, :single_date_answer, :checkbox_answers, :number_answer, :currency_answer])).call)",
+      "code": "SpecificationRenderer.new(:template => Journey.find(journey_id).liquid_template, :answers => GetAnswersForSteps.new(:visible_steps => Journey.find(journey_id).visible_steps.includes([:radio_answer, :short_text_answer, :long_text_answer, :single_date_answer, :checkbox_answers, :number_answer, :currency_answer])).call).to_html",
       "render_path": [
         {
           "type": "controller",
@@ -32,6 +32,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-03-11 12:09:01 +0000",
+  "updated": "2021-03-15 12:25:24 +0000",
   "brakeman_version": "5.0.0"
 }

--- a/spec/services/specification_renderer_spec.rb
+++ b/spec/services/specification_renderer_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe SpecificationRenderer do
+  describe "#to_html" do
+    it "renders a HTML representation of a template given specific answers" do
+      renderer = described_class.new(
+        template: '<p>HTML paragraph rendering a variable: "{{ variable_name }}"</p>',
+        answers: {
+          "variable_name" => "variable value"
+        }
+      )
+      expect(renderer.to_html).to eql('<p>HTML paragraph rendering a variable: "variable value"</p>')
+    end
+  end
+end


### PR DESCRIPTION
Previously, all rendering work for the specification was done in the journey controller. This moves the job of combining the template and the answers into a rendered output into a new service object, which gives us a clearer separation of which bit of code is responsible for the rendering.

This was originally planned to be a first step in adding an 'incomplete spec' warning message to the .docx output, but that work has had its priorities changed and there's no point this (entirely functional) refactoring languishing around unmerged.