### PR TITLE
Checkbox answers are now human readable in a spec

### DIFF
--- a/app/presenters/checkboxes_answer_presenter.rb
+++ b/app/presenters/checkboxes_answer_presenter.rb
@@ -1,5 +1,8 @@
 class CheckboxesAnswerPresenter < SimpleDelegator
   def response
-    super.reject(&:blank?).map(&:capitalize).join(", ")
+    super.reject(&:blank?).map { |answer|
+      answer.tr!("_", " ")
+      answer.capitalize!
+    }.join(", ")
   end
 end

--- a/spec/presenters/checkboxes_answer_presenter_spec.rb
+++ b/spec/presenters/checkboxes_answer_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe CheckboxesAnswerPresenter do
   describe "#response" do
     it "returns all none nil values, capitalised as a comma separated string" do
-      step = build(:checkbox_answers, response: ["yes", "no", "morning break", ""])
+      step = build(:checkbox_answers, response: ["yes", "no", "morning_break", ""])
       presenter = described_class.new(step)
       expect(presenter.response).to eq("Yes, No, Morning break")
     end

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe GetAnswersForSteps do
     end
 
     context "when the answer is of type checkbox_answers" do
-      it_behaves_like "returns the answer in a hash", :checkbox_answers, CheckboxesAnswerPresenter, "Foo, Bar"
+      it_behaves_like "returns the answer in a hash", :checkbox_answers, CheckboxesAnswerPresenter, ["Foo", "Bar"]
     end
 
     context "when a step does not have an answer" do


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Our test didn't have an accurate case for how we are storing answers. We store a machine readable `morning_break` in  the `response` field (so we can reliably set field labels etc). Our test set the database value as "Morning break" which is close but let through this bug where all values are formatted in the machine readable format, rather than a human readable one.

We now strip the underscores from the value if it as multiple words during presentation.

## Screenshots of UI changes

### Before

![Screenshot 2021-02-24 at 16 55 30](https://user-images.githubusercontent.com/912473/109038930-287ed380-76c4-11eb-9fc0-f78cf19c54ef.png)

### After
![Screenshot 2021-02-24 at 17 10 19](https://user-images.githubusercontent.com/912473/109038927-274da680-76c4-11eb-8682-79bf329f380d.png)

