### PR TITLE
(373) Extended options for Radio and Checkbox answers are now available for use in the specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - create an extended further information text box option for radio answers
 - create extended further information text box option for checkbox answers
 - radio questions can be configured with an "or" separator
+- specification can show further information for radio answers
 
 ## [release-005] - 2021-1-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - create extended further information text box option for checkbox answers
 - radio questions can be configured with an "or" separator
 - specification can show further information for radio answers
+- specification can show further information for checkbox answers
 
 ## [release-005] - 2021-1-19
 

--- a/app/helpers/answer_helper.rb
+++ b/app/helpers/answer_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AnswerHelper
+  def human_readable_option(string:)
+    string.tr("_", " ").capitalize
+  end
+
+  def machine_readable_option(string:)
+    string.tr(" ", "_").downcase
+  end
+end

--- a/app/presenters/radio_answer_presenter.rb
+++ b/app/presenters/radio_answer_presenter.rb
@@ -1,5 +1,7 @@
 class RadioAnswerPresenter < SimpleDelegator
+  include AnswerHelper
+
   def response
-    super.capitalize
+    human_readable_option(string: super)
   end
 end

--- a/app/presenters/radio_answer_presenter.rb
+++ b/app/presenters/radio_answer_presenter.rb
@@ -1,7 +1,5 @@
 class RadioAnswerPresenter < SimpleDelegator
   def response
-    return super.capitalize if further_information.blank?
-
-    "#{super.capitalize} - #{further_information}"
+    super.capitalize
   end
 end

--- a/app/services/get_answers_for_steps.rb
+++ b/app/services/get_answers_for_steps.rb
@@ -22,12 +22,21 @@ class GetAnswersForSteps
       end
 
       if answer.respond_to?(:further_information)
-        hash["extended_answer_#{step.contentful_id}"] = [
-          {
-            "response" => answer.response,
-            "further_information" => answer.further_information
-          }
-        ]
+        hash["extended_answer_#{step.contentful_id}"] = if answer.further_information.is_a?(Hash)
+          answer.further_information.each_pair.each_with_object([]) do |(key, value), array|
+            array << {
+              "response" => key.gsub("_further_information", "").capitalize,
+              "further_information" => value
+            }
+          end
+        else
+          [
+            {
+              "response" => answer.response,
+              "further_information" => answer.further_information
+            }
+          ]
+        end
       end
 
       hash["answer_#{step.contentful_id}"] = answer.response.to_s

--- a/app/services/get_answers_for_steps.rb
+++ b/app/services/get_answers_for_steps.rb
@@ -21,6 +21,15 @@ class GetAnswersForSteps
       else raise UnexpectedAnswer.new("Trying to present an unknown type of answer: #{step.answer.class.name}")
       end
 
+      if answer.respond_to?(:further_information)
+        hash["extended_answer_#{step.contentful_id}"] = [
+          {
+            "response" => answer.response,
+            "further_information" => answer.further_information
+          }
+        ]
+      end
+
       hash["answer_#{step.contentful_id}"] = answer.response.to_s
     }
   end

--- a/app/services/get_answers_for_steps.rb
+++ b/app/services/get_answers_for_steps.rb
@@ -1,6 +1,8 @@
 class GetAnswersForSteps
   class UnexpectedAnswer < StandardError; end
 
+  include AnswerHelper
+
   attr_accessor :visible_steps
   def initialize(visible_steps:)
     self.visible_steps = visible_steps
@@ -24,8 +26,9 @@ class GetAnswersForSteps
       if answer.respond_to?(:further_information)
         hash["extended_answer_#{step.contentful_id}"] = if answer.further_information.is_a?(Hash)
           answer.further_information.each_pair.each_with_object([]) do |(key, value), array|
+            key_without_prefix = key.gsub("_further_information", "")
             array << {
-              "response" => key.gsub("_further_information", "").capitalize,
+              "response" => human_readable_option(string: key_without_prefix),
               "further_information" => value
             }
           end

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -7,7 +7,7 @@
     <% end %>
 
     <% @step.options.each do |option| %>
-      <% machine_value = option["value"].tr(" ", "_").downcase %>
+      <% machine_value = machine_readable_option(string: option["value"]) %>
       <% if option.fetch("separated_by_or", nil) == true %>
         <div class="govuk-radios__divider">or</div>
       <% end %>

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -30,6 +30,7 @@ feature "Users can see their catering specification" do
 
     within("article#specification") do
       expect(page).to have_content("Catering")
+      expect(page).to have_content("The school needs the kitchen cleaned once a day")
     end
   end
 

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -15,7 +15,7 @@ feature "Users can see their catering specification" do
     end
   end
 
-  scenario "renders responses that need extra formatting" do
+  scenario "renders radio responses that have futher information" do
     stub_contentful_category(fixture_filename: "extended-radio-question.json")
     visit root_path
     click_on(I18n.t("generic.button.start"))
@@ -29,7 +29,7 @@ feature "Users can see their catering specification" do
     expect(page).to have_content(I18n.t("journey.specification.header"))
 
     within("article#specification") do
-      expect(page).to have_content("Catering - The school needs the kitchen cleaned once a day")
+      expect(page).to have_content("Catering")
     end
   end
 

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -34,6 +34,30 @@ feature "Users can see their catering specification" do
     end
   end
 
+  scenario "renders checkbox responses that have further information" do
+    stub_contentful_category(fixture_filename: "extended-checkboxes-question.json")
+    visit root_path
+    click_on(I18n.t("generic.button.start"))
+
+    click_first_link_in_task_list
+
+    check("Yes")
+    fill_in "answer[yes_further_information]", with: "More info for yes"
+    check("No")
+    fill_in "answer[no_further_information]", with: "More info for no"
+
+    click_on(I18n.t("generic.button.next"))
+
+    expect(page).to have_content(I18n.t("journey.specification.header"))
+
+    within("article#specification") do
+      expect(page).to have_content("Yes")
+      expect(page).to have_content("More info for yes")
+      expect(page).to have_content("No")
+      expect(page).to have_content("More info for no")
+    end
+  end
+
   context "when the spec is incomplete" do
     it "warns the user that the contents are in a partially completed state" do
       stub_contentful_category(fixture_filename: "extended-radio-question.json")

--- a/spec/fixtures/contentful/categories/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/extended-checkboxes-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1><p>{{answer_extended-checkboxes-question}}</p><ul>{% for extended_answer in extended_answer_extended-checkboxes-question %}<li>{{ extended_answer['response'] }}</li><li>{{ extended_answer['further_information'] }}</li>{% endfor %}</ul></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/extended-radio-question.json
+++ b/spec/fixtures/contentful/categories/extended-radio-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>{{answer_extended-radio-question}}</h1></article>"
+        "specification_template": "<article id='specification'><h1>{{answer_extended-radio-question}}</h1><ul>{% for extended_answer in extended_answer_extended-radio-question %}<li>{{ extended_answer['response'] }}</li><li>{{ extended_answer['further_information'] }}</li>{% endfor %}</ul></article>"
     }
 }

--- a/spec/helpers/answer_helper_spec.rb
+++ b/spec/helpers/answer_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe AnswerHelper, type: :helper do
+  describe "#human_readable_option" do
+    it "replaces underscores with spaces and capitalises the string" do
+      result = helper.human_readable_option(string: "a_hash_key")
+      expect(result).to eql("A hash key")
+    end
+  end
+
+  describe "#machine_readable_option" do
+    it "replaces spaces with underscores and downcases the string" do
+      result = helper.machine_readable_option(string: "A LONG key with inconsistent casing")
+      expect(result).to eql("a_long_key_with_inconsistent_casing")
+    end
+  end
+end

--- a/spec/presenters/radio_answer_presenter_spec.rb
+++ b/spec/presenters/radio_answer_presenter_spec.rb
@@ -3,17 +3,9 @@ require "rails_helper"
 RSpec.describe RadioAnswerPresenter do
   describe "#response" do
     it "returns the option chosen" do
-      step = build(:radio_answer, response: "Yes", further_information: "")
+      step = build(:radio_answer, response: "Yes", further_information: "Extra info")
       presenter = described_class.new(step)
       expect(presenter.response).to eq("Yes")
-    end
-
-    context "when further information is provided" do
-      it "returns the option chosen and the further information" do
-        step = build(:radio_answer, response: "Yes", further_information: "This is really important")
-        presenter = described_class.new(step)
-        expect(presenter.response).to eq("Yes - This is really important")
-      end
     end
   end
 end

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -45,17 +45,17 @@ RSpec.describe GetAnswersForSteps do
       context "when the answer has further_information" do
         it "also includes an extended_answer hash in the response" do
           answer = create(:radio_answer,
-            response: "yes",
+            response: "yes please",
             further_information: "More yes info")
           result = described_class.new(visible_steps: [answer.step]).call
           expect(result).to include(
-            {"answer_#{answer.step.contentful_id}" => "Yes"}
+            {"answer_#{answer.step.contentful_id}" => "Yes please"}
           )
           expect(result).to include(
             {
               "extended_answer_#{answer.step.contentful_id}" => [
                 {
-                  "response" => "Yes",
+                  "response" => "Yes please",
                   "further_information" => "More yes info"
                 }
               ]
@@ -71,21 +71,21 @@ RSpec.describe GetAnswersForSteps do
       context "when the answer has further_information" do
         it "includes those values as distinct variables in the response" do
           answer = create(:checkbox_answers,
-            response: ["yes", "no"],
+            response: ["I would really like this", "I would hate this"],
             further_information: {
-              "yes_further_information" => "More yes info",
-              "no_further_information" => "More no info"
+              "i_would_really_like_this_further_information" => "More yes info",
+              "i_would_hate_this_further_information" => "More no info"
             })
           result = described_class.new(visible_steps: [answer.step]).call
           expect(result).to include(
             {
               "extended_answer_#{answer.step.contentful_id}" => [
                 {
-                  "response" => "Yes",
+                  "response" => "I would really like this",
                   "further_information" => "More yes info"
                 },
                 {
-                  "response" => "No",
+                  "response" => "I would hate this",
                   "further_information" => "More no info"
                 }
               ]

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -67,6 +67,32 @@ RSpec.describe GetAnswersForSteps do
 
     context "when the answer is of type checkbox_answers" do
       it_behaves_like "returns the answer in a hash", :checkbox_answers, CheckboxesAnswerPresenter, ["Foo", "Bar"]
+
+      context "when the answer has further_information" do
+        it "includes those values as distinct variables in the response" do
+          answer = create(:checkbox_answers,
+            response: ["yes", "no"],
+            further_information: {
+              "yes_further_information" => "More yes info",
+              "no_further_information" => "More no info"
+            })
+          result = described_class.new(visible_steps: [answer.step]).call
+          expect(result).to include(
+            {
+              "extended_answer_#{answer.step.contentful_id}" => [
+                {
+                  "response" => "Yes",
+                  "further_information" => "More yes info"
+                },
+                {
+                  "response" => "No",
+                  "further_information" => "More no info"
+                }
+              ]
+            }
+          )
+        end
+      end
     end
 
     context "when a step does not have an answer" do

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -41,6 +41,28 @@ RSpec.describe GetAnswersForSteps do
 
     context "when the answer is of type radio_answer" do
       it_behaves_like "returns the answer in a hash", :radio_answer, RadioAnswerPresenter, "Catering"
+
+      context "when the answer has further_information" do
+        it "also includes an extended_answer hash in the response" do
+          answer = create(:radio_answer,
+            response: "yes",
+            further_information: "More yes info")
+          result = described_class.new(visible_steps: [answer.step]).call
+          expect(result).to include(
+            {"answer_#{answer.step.contentful_id}" => "Yes"}
+          )
+          expect(result).to include(
+            {
+              "extended_answer_#{answer.step.contentful_id}" => [
+                {
+                  "response" => "Yes",
+                  "further_information" => "More yes info"
+                }
+              ]
+            }
+          )
+        end
+      end
     end
 
     context "when the answer is of type checkbox_answers" do


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
Based atop https://github.com/DFE-Digital/buy-for-your-school/pull/189

## Changes in this PR

The liquid template has a new variable available to it for every Radio and Checkbox answer, called `extended_answer_x`. This is _aswell as_ the previous `answer_x`.

```
# Radio
answer_x => "Yes"
extended_answer_x => [
  { 
    "response" => "Yes",
    "further_information" => "Some further information to tell you about" 
  }
]

# Checkboxes
answer_x => "Yes, no"
extended_answer_x => [
  { 
    "response" => "Yes",
    "further_information" => "Some further information to tell you about" 
  }
  { 
    "response" => "No",
    "further_information" => "" 
  }
]

```

The hope is that by making both available the content team will have the flexiblity to list the checklist answers only OR start to mixin the further information fields too, where relevant.

There is a small piece of breaking behaviour. Before `answer_x` for Radios would render an interpolation eg. "Yes - Further info". This change means that now only "Yes" will be rendered and the content team will need to reevaluate the template and add in this additional logic to access the further information.

This is an example of the interface to Liquid we can now support (which was used to generate the screenshot):

```
<!-- Get the response only as we could before (which will be a comma separated list for checkboxes) -->
{{ answer_7p7URWwZbkjqqzo3E0k1v4 }}

<!-- To get further_information we make a single new variable with a prefix -->
<ul>
  {% for extended_answer in extended_answer_7p7URWwZbkjqqzo3E0k1v4 %}
    <li>{{ extended_answer["response"] }}</li>
    {% if extended_answer["further_information"] != "" %}
      <li>{{ extended_answer["further_information"] }}</li>
    {% endif %}
  {% endfor %}
</ul>
</article>
```

We use new helper methods to centralise our logic for reading and writing the further_information keys to and from human readable.

## Screenshots of UI changes

![Screenshot 2021-02-25 at 12 39 28](https://user-images.githubusercontent.com/912473/109156836-3d617280-7769-11eb-84a2-3a7bcb9a006c.png)

