### PR TITLE
(354) Radio questions can be configured to show an OR separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can be presenting with forking/branching question chains based on any one answer
 - create an extended further information text box option for radio answers
 - create extended further information text box option for checkbox answers
+- radio questions can be configured with an "or" separator
 
 ## [release-005] - 2021-1-19
 

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -8,21 +8,25 @@
 
     <% @step.options.each do |option| %>
       <% machine_value = option["value"].tr(" ", "_").downcase %>
-
+      <% if option.fetch("separated_by_or", nil) == true %>
+        <div class="govuk-radios__divider">or</div>
+      <% end %>
+      
       <% f.object = monkey_patch_form_object_with_further_information_field(form_object: f.object, associated_choice: machine_value) %>
-        <% if option["display_further_information"] == true || option["display_further_information"] == "single" %>
-          <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
-            <%= f.govuk_text_field "#{machine_value}_further_information",
-              label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
-          <% end %>
-        <% elsif option["display_further_information"] == "long" %>
-          <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
-            <%= f.govuk_text_area "#{machine_value}_further_information", rows: 6,
-              label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
-          <% end %>
-        <% else %>
-          <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } %>
+
+      <% if option["display_further_information"] == true || option["display_further_information"] == "single" %>
+        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
+          <%= f.govuk_text_field "#{machine_value}_further_information",
+            label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
         <% end %>
+      <% elsif option["display_further_information"] == "long" %>
+        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
+          <%= f.govuk_text_area "#{machine_value}_further_information", rows: 6,
+            label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
+        <% end %>
+      <% else %>
+        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -8,6 +8,9 @@
     <% end %>
 
     <% @step.options.each do |option| %>
+      <% if option.fetch("separated_by_or", nil) == true %>
+        <div class="govuk-radios__divider">or</div>
+      <% end %>
         <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } do %>
           <% if option["display_further_information"] == "single" || option["display_further_information"] == true %>
             <%= f.govuk_text_field :further_information, label: { text: option["further_information_help_text"] } %>

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -264,6 +264,21 @@ feature "Anyone can start a journey" do
           expect(page).to_not have_selector("input#answer-further-information-field")
         end
       end
+
+      context "when an 'or separator' has been configured" do
+        scenario "shows an or separator" do
+          start_journey_from_category_and_go_to_question(category: "radio-question-with-separator.json")
+
+          expect(page).to have_selector("div.govuk-radios__divider")
+          within("div.govuk-radios__divider") do
+            expect(page).to have_content("or")
+          end
+
+          # Check that the "Or" separator appears in the correct position
+          expect(page.body.index("Catering") > page.body.index("or")).to eq(true)
+          expect(page.body.index("or") < page.body.index("Cleaning")).to eq(true)
+        end
+      end
     end
 
     context "when Contentful entry includes a 'show additional question' rule" do

--- a/spec/fixtures/contentful/categories/radio-question-with-separator.json
+++ b/spec/fixtures/contentful/categories/radio-question-with-separator.json
@@ -1,0 +1,44 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "radio-with-separator-section"
+            }
+          }
+        ],
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+    }
+}

--- a/spec/fixtures/contentful/sections/radio-with-separator-section.json
+++ b/spec/fixtures/contentful/sections/radio-with-separator-section.json
@@ -1,0 +1,43 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "radio-with-separator-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section A",
+        "steps": [
+            {
+                "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "radio-with-separator-question"
+                }
+            }
+        ]
+    }
+}

--- a/spec/fixtures/contentful/steps/radio-with-separator-question.json
+++ b/spec/fixtures/contentful/steps/radio-with-separator-question.json
@@ -1,0 +1,47 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "jspwts36h1os"
+            }
+        },
+        "id": "radio-with-separator-question",
+        "type": "Entry",
+        "createdAt": "2020-09-07T10:56:40.585Z",
+        "updatedAt": "2020-09-14T22:16:54.633Z",
+        "environment": {
+            "sys": {
+                "id": "master",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 7,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/which-service",
+        "title": "Which service do you need?",
+        "helpText": "Tell us which service you need.",
+        "type": "radios",
+        "extendedOptions": [
+          {
+              "value": "Catering"
+          },
+          {
+              "value": "Cleaning",
+              "separated_by_or": true
+          }
+        ],
+        "alwaysShowTheUser": true
+    }
+}


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

This change allows Radio questions within Contentful to specify a new attribute within it's existing `option` field called `separated_by_or`.

If omitted or set to false, no separator will be shown.

```
[
    {
        "value": "Yes"
    },
    {
        "value": "No",
        "separated_by_or": true
    }
]
```

## Screenshots of UI changes

### Before

![Screenshot 2021-02-25 at 16 42 28](https://user-images.githubusercontent.com/912473/109186625-0602be00-7789-11eb-958c-c8ee62f27d68.png)


### After

![Screenshot 2021-02-25 at 16 42 25](https://user-images.githubusercontent.com/912473/109186634-08fdae80-7789-11eb-92e3-f9e94b76c224.png)
