### PR TITLE
Fix page jump for radio questions without further info

### DIFF
--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -11,6 +11,7 @@
       <% if option.fetch("separated_by_or", nil) == true %>
         <div class="govuk-radios__divider">or</div>
       <% end %>
+      <% if option["display_further_information"] %>
         <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } do %>
           <% if option["display_further_information"] == "single" || option["display_further_information"] == true %>
             <%= f.govuk_text_field :further_information, label: { text: option["further_information_help_text"] } %>
@@ -18,6 +19,10 @@
             <%= f.govuk_text_area :further_information, rows: 6, label: { text: option["further_information_help_text"] } %>
           <% end %>
         <% end %>
+      <% else %>
+        <!-- We have to include this if there is no block given, selecting an option causes a page jump as a conditional element is toggled by the form builder -->
+        <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

When the radio question does NOT have a further_information of any sorts then when the user selects an option, the radio elements will jump slightly on the page.

This is caused by a new HTML element being added by the gem when `f.govuk_radio_button` is passed an empty block. In order to avoid this jump, we default back to the old (slightly repetitive) version of the code that has an else condition that uses this method without passing any block. This fixes the issue.

>  block (Block) — Any supplied HTML will be wrapped in a conditional container and only revealed when the radio button is picked [1]

[1] https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder/Builder#govuk_radio_button-instance_method

The same pattern is still used on checkboxes so there is no similar issue there.

## Screenshots of UI changes

### Before

Note the increase in pixels between both radio options.

![Screenshot 2021-02-25 at 16 57 32](https://user-images.githubusercontent.com/912473/109188766-27fd4000-778b-11eb-94c6-74b99f77f0f1.png)

Here we can see the new elements being added and shown and hidden as the user toggles their answer:
![Screenshot 2021-02-25 at 16 57 53](https://user-images.githubusercontent.com/912473/109188692-187df700-778b-11eb-940f-99ec152ef15b.png)

### After

![Screenshot 2021-02-25 at 17 04 13](https://user-images.githubusercontent.com/912473/109189062-81fe0580-778b-11eb-913b-f9ccf3d9fe9b.png)


