### PR TITLE
(419) Checkbox questions can be explicitly skipped/set as irrelevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - radio questions can be configured with an "or" separator
 - specification can show further information for radio answers
 - specification can show further information for checkbox answers
+- checkbox answers can be completed without choosing a given answer
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -53,6 +53,8 @@ class AnswersController < ApplicationController
   end
 
   def checkbox_params
+    return {skipped: true, response: nil, further_information: nil} if skip_answer?
+
     answer_params = params.require(:answer)
 
     if @step.options
@@ -73,5 +75,9 @@ class AnswersController < ApplicationController
     answer = params.require(:answer).permit(:response)
     date_hash = {day: answer["response(3i)"], month: answer["response(2i)"], year: answer["response(1i)"]}
     {response: format_date(date_hash)}
+  end
+
+  def skip_answer?
+    params.fetch("skip", false)
   end
 end

--- a/app/models/checkbox_answers.rb
+++ b/app/models/checkbox_answers.rb
@@ -2,7 +2,9 @@ class CheckboxAnswers < ActiveRecord::Base
   self.implicit_order_column = "created_at"
   belongs_to :step
 
-  validates :response, presence: true
+  validates :response,
+    presence: true,
+    unless: proc { |answer| answer.step.skippable? && answer.skipped }
 
   def response=(args)
     return if args.blank?

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -29,4 +29,8 @@ class Step < ApplicationRecord
     return I18n.t("generic.button.next") unless super.present?
     super
   end
+
+  def skippable?
+    skip_call_to_action_text.present?
+  end
 end

--- a/app/services/create_journey_step.rb
+++ b/app/services/create_journey_step.rb
@@ -41,6 +41,7 @@ class CreateJourneyStep
       contentful_type: step_type,
       options: options,
       primary_call_to_action_text: primary_call_to_action_text,
+      skip_call_to_action_text: skip_call_to_action_text,
       hidden: hidden,
       additional_step_rules: additional_step_rules,
       raw: raw,
@@ -100,6 +101,11 @@ class CreateJourneyStep
   def primary_call_to_action_text
     return nil unless contentful_entry.respond_to?(:primary_call_to_action)
     contentful_entry.primary_call_to_action
+  end
+
+  def skip_call_to_action_text
+    return nil unless contentful_entry.respond_to?(:skip_call_to_action)
+    contentful_entry.skip_call_to_action
   end
 
   def hidden

--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -29,4 +29,11 @@
       <% end %>
     <% end %>
   <% end %>
+
+  <% if @step_presenter.skippable? %>
+    <div class="govuk-radios__divider">or</div>
+    <div class="govuk-form-group">
+      <%= f.button @step_presenter.skip_call_to_action_text, type: "submit", name: "skip", value: "true", class: "govuk-button govuk-button--secondary" %>
+    </div>
+  <% end %>
 <% end %>

--- a/db/migrate/20210301151653_add_skippable_to_step.rb
+++ b/db/migrate/20210301151653_add_skippable_to_step.rb
@@ -1,0 +1,5 @@
+class AddSkippableToStep < ActiveRecord::Migration[6.1]
+  def change
+    add_column :steps, :skip_call_to_action_text, :string, default: nil
+  end
+end

--- a/db/migrate/20210302110746_add_skipped_to_checkbox_answers.rb
+++ b/db/migrate/20210302110746_add_skipped_to_checkbox_answers.rb
@@ -1,0 +1,5 @@
+class AddSkippedToCheckboxAnswers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :checkbox_answers, :skipped, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_01_151653) do
+ActiveRecord::Schema.define(version: 2021_03_02_110746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2021_03_01_151653) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "further_information"
+    t.boolean "skipped", default: false
     t.index ["step_id"], name: "index_checkbox_answers_on_step_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_102716) do
+ActiveRecord::Schema.define(version: 2021_03_01_151653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 2021_02_23_102716) do
     t.jsonb "options"
     t.boolean "hidden", default: false
     t.jsonb "additional_step_rules"
+    t.string "skip_call_to_action_text"
     t.index ["journey_id"], name: "index_steps_on_journey_id"
   end
 

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
     association :step, factory: :step, options: [{"value" => "Breakfast"}, {"value" => "Lunch"}], contentful_type: "checkboxes", contentful_model: "question"
 
     response { ["breakfast", "lunch", ""] }
+    skipped { false }
   end
 
   factory :number_answer do

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     hidden { false }
     additional_step_rules { nil }
     primary_call_to_action_text { nil }
+    skip_call_to_action_text { nil }
 
     association :journey, factory: :journey
 

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     raw { |attrs| {"sys": {"id" => attrs["contentful_id"]}} }
     hidden { false }
     additional_step_rules { nil }
+    primary_call_to_action_text { nil }
 
     association :journey, factory: :journey
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -302,6 +302,23 @@ feature "Anyone can start a journey" do
     end
   end
 
+  context "when the question is skippable" do
+    scenario "allows the user to not select an answer" do
+      start_journey_from_category_and_go_to_question(category: "skippable-checkboxes-question.json")
+
+      check("Lunch")
+      click_on("None of the above")
+
+      within(".app-task-list") do
+        expect(page).to have_content("Complete")
+      end
+
+      click_first_link_in_task_list
+
+      expect(page).not_to have_checked_field("Lunch")
+    end
+  end
+
   context "when the Contentful model is of type staticContent" do
     context "when Contentful entry is of type paragraphs" do
       scenario "the content is not displayed in the task list" do

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -306,6 +306,9 @@ feature "Anyone can start a journey" do
     scenario "allows the user to not select an answer" do
       start_journey_from_category_and_go_to_question(category: "skippable-checkboxes-question.json")
 
+      click_on(I18n.t("generic.button.next"))
+      expect(page).to have_content("can't be blank")
+
       check("Lunch")
       click_on("None of the above")
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -316,6 +316,8 @@ feature "Anyone can start a journey" do
       click_first_link_in_task_list
 
       expect(page).not_to have_checked_field("Lunch")
+
+      expect(CheckboxAnswers.last.skipped).to be true
     end
   end
 

--- a/spec/fixtures/contentful/categories/skippable-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/skippable-checkboxes-question.json
@@ -1,0 +1,44 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+          {
+            "sys": {
+                "type": "Link",
+                "linkType": "Entry",
+                "id": "skippable-checkboxes-section"
+            }
+          }
+        ],
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+    }
+}

--- a/spec/fixtures/contentful/sections/skippable-checkboxes-section.json
+++ b/spec/fixtures/contentful/sections/skippable-checkboxes-section.json
@@ -1,0 +1,43 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "skippable-checkboxes-section",
+        "type": "Entry",
+        "createdAt": "2021-02-01T10:47:10.257Z",
+        "updatedAt": "2021-02-01T10:47:10.257Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "section"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Section A",
+        "steps": [
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "skippable-checkboxes-question"
+              }
+            }
+        ]
+    }
+}

--- a/spec/fixtures/contentful/steps/skippable-checkboxes-question.json
+++ b/spec/fixtures/contentful/steps/skippable-checkboxes-question.json
@@ -1,0 +1,43 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "skippable-checkboxes-question",
+        "type": "Entry",
+        "createdAt": "2020-12-09T11:53:52.744Z",
+        "updatedAt": "2020-12-09T11:53:52.744Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 1,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "question"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "slug": "/everyday-services",
+        "type": "checkboxes",
+        "title": "Everyday services that are required and need to be considered",
+        "extendedOptions": [
+          { "value": "Breakfast" },
+          { "value": "Morning break" },
+          { "value": "Lunch" },
+          { "value": "Dinner" }
+        ],
+        "skipCallToAction": "None of the above"
+    }
+}

--- a/spec/models/checkbox_answers_spec.rb
+++ b/spec/models/checkbox_answers_spec.rb
@@ -1,7 +1,10 @@
 require "rails_helper"
 
 RSpec.describe CheckboxAnswers, type: :model do
-  it { should belong_to(:step) }
+  it "should belong_to a step" do
+    association = described_class.reflect_on_association(:step)
+    expect(association.macro).to eq(:belongs_to)
+  end
 
   describe "#response" do
     it "returns an array of strings" do
@@ -11,7 +14,21 @@ RSpec.describe CheckboxAnswers, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:response) }
+    it "is not valid if there is no response" do
+      answer = build(:checkbox_answers, response: [])
+      expect(answer).not_to be_valid
+    end
+
+    context "when the step is skippable" do
+      it "does not validate the presence of the response" do
+        skippable_step = create(:step, :checkbox_answers, skip_call_to_action_text: "None of the above")
+        answer = build(:checkbox_answers, step: skippable_step, response: "")
+
+        answer.save
+
+        expect(answer.persisted?).to be true
+      end
+    end
   end
 
   describe "#response=" do

--- a/spec/models/checkbox_answers_spec.rb
+++ b/spec/models/checkbox_answers_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CheckboxAnswers, type: :model do
     context "when the step is skippable" do
       it "does not validate the presence of the response" do
         skippable_step = create(:step, :checkbox_answers, skip_call_to_action_text: "None of the above")
-        answer = build(:checkbox_answers, step: skippable_step, response: "")
+        answer = build(:checkbox_answers, step: skippable_step, response: "", skipped: true)
 
         answer.save
 

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -77,6 +77,20 @@ RSpec.describe Step, type: :model do
     end
   end
 
+  describe "#skippable?" do
+    it "returns true if there is skip_call_to_action_text" do
+      step = build(:step, skip_call_to_action_text: "None of the above")
+      result = step.skippable?
+      expect(result).to eq(true)
+    end
+
+    it "returns false if there is NOT skip_call_to_action_text" do
+      step = build(:step, skip_call_to_action_text: nil)
+      result = step.skippable?
+      expect(result).to eq(false)
+    end
+  end
+
   describe "#options" do
     # TODO: This will need updating when options are set on the step with the new format
     it "returns a hash of options" do

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -133,6 +133,21 @@ process around March.")
       end
     end
 
+    context "when no 'skipCallToAction' is provided" do
+      it "default copy is used for the button" do
+        journey = create(:journey, :catering)
+        fake_entry = fake_contentful_step(
+          contentful_fixture_filename: "steps/skippable-checkboxes-question.json"
+        )
+
+        step, _answer = described_class.new(
+          journey: journey, contentful_entry: fake_entry
+        ).call
+
+        expect(step.skip_call_to_action_text).to eq("None of the above")
+      end
+    end
+
     context "when no 'alwaysShowTheUser' is provided" do
       it "default hidden to true" do
         journey = create(:journey, :catering)

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -147,6 +147,7 @@ module ContentfulHelpers
       type: hash_response.dig("fields", "type"),
       next: double(id: hash_response.dig("fields", "next", "sys", "id")),
       primary_call_to_action: hash_response.dig("fields", "primaryCallToAction"),
+      skip_call_to_action: hash_response.dig("fields", "skipCallToAction"),
       always_show_the_user: hash_response.dig("fields", "alwaysShowTheUser"),
       show_additional_question: hash_response.dig("fields", "showAdditionalQuestion"),
       raw: hash_response,


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

The user need here is for a user to "complete" a step where no provided options are relevant to them. We need to be able to distinguish a user who has not yet answered and one who has chosen none are relevant. This allows us to mark the spec builder journey as complete and stop prompting the user to complete a step by showing an "complete" label in the task list.

There is no pattern for this checkbox form in the Design system.

[We had found one in DfE Claim](https://trello.com/c/Tdrjhtde/419-none-of-the-above-radio-option-on-checkbox-lists) but it doesn't appear to work properly. Crucially you cannot deselect the radio option once selected. Label clicks for the radio input also toggle checks to the check box selections too. We decided that it was too much work to try and salvage the pattern now, and a risk to maintaining it in future along with probably needing to use Javascript.

Pete suggested we use a link instead of a button here. I was unable to force a link to send a POST request and got into the muddy territory of creating new controller actions to support it. On future reflection I think a link is conventionally for navigation purposes and buttons are more transactional. Buttons feel correct and were the cleaner implementation 🤞 

## Changes in this PR

- a new `skipCallToAction` field exists for all Contentful questions and sits alongside `PrimaryCallToAction`, both provide copy for buttons
- If this option is present we will store it on the `Step`. We are then able to determine if any `Step` is should be skippable or not via the presence or omission of the button text (this is a bit mysterious but saves us having 2 fields to control this behaviour?)
- checkboxes are the only questions we know of where a skip option is necessary so we hard code this in as an option that is (currently) only something that will affect a checkbox question
- we have to do a little more work to turn validations on for the case where no checkbox or the skip button is used

## Screenshots of UI changes

We introduce a new secondary button, configured with copy from Contentful. We can use the OR separator to provide some vertical grouping of the 2 relevant parts of the form step:
![Screenshot 2021-03-02 at 11 05 38](https://user-images.githubusercontent.com/912473/109645205-6b222f00-7b4e-11eb-9bb3-6a96acb9628b.png)

We continue to validate that _either_ one or more options are checked *or* the skip button is used. (sadly I couldn't see how to easily make the form errors wrap both form groups)
![Screenshot 2021-03-02 at 11 51 39](https://user-images.githubusercontent.com/912473/109645221-6eb5b600-7b4e-11eb-85f5-3aab7c4be2fb.png)

Once an answer is created (either by skipping or by a normal choice) the question appears as "Completed" in the task list:
![Screenshot 2021-03-02 at 12 01 06](https://user-images.githubusercontent.com/912473/109645648-0d421700-7b4f-11eb-82cb-d8acb954bd5e.png)

If the user decides to initially store some answers we want to check that a later skip resets this:
![Screenshot 2021-03-02 at 11 51 51](https://user-images.githubusercontent.com/912473/109645225-707f7980-7b4e-11eb-9caf-949bd2afba3b.png)

After pressing the skip button, we go back in and see that it has been reset.
![Screenshot 2021-03-02 at 11 51 58](https://user-images.githubusercontent.com/912473/109645232-72493d00-7b4e-11eb-8701-557c4ed919b2.png)

## Next steps

- [ ] Update the Confluence documentation
- [ ] Let the Content team know of the changes when available