### PR TITLE
(426) Fix bug where radio questions with multiple expanded options only saves response to last in sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - further information for options that include special characters is now available to the specification
 - incomplete specification documents include a warning within the document as well as the file name
 - users return to the same place in the task list after answering a question
+- fix extended radio questions so that further_information can be remembered when it can be provided through multiple fields
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -74,7 +74,7 @@ class AnswersController < ApplicationController
     further_information_params = answer_params.permit(*allowed_further_information_keys)
     further_information = further_information_params.to_hash
 
-    all_params = answer_params.permit(response: [])
+    all_params = answer_params.permit(:response, response: [])
     all_params[:further_information] = further_information
     all_params
   end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -12,8 +12,11 @@ class AnswersController < ApplicationController
     @answer = AnswerFactory.new(step: @step).call
     @answer.step = @step
 
-    result = SaveAnswer.new(answer: @answer)
-      .call(checkbox_params: checkbox_params, answer_params: answer_params, date_params: date_params)
+    result = SaveAnswer.new(answer: @answer).call(
+      further_information_params: further_information_params,
+      answer_params: answer_params,
+      date_params: date_params
+    )
     @answer = result.object
 
     if result.success?
@@ -28,8 +31,11 @@ class AnswersController < ApplicationController
     @step = Step.find(step_id)
     @step_presenter = StepPresenter.new(@step)
 
-    result = SaveAnswer.new(answer: @step.answer)
-      .call(checkbox_params: checkbox_params, answer_params: answer_params, date_params: date_params)
+    result = SaveAnswer.new(answer: @step.answer).call(
+      further_information_params: further_information_params,
+      answer_params: answer_params,
+      date_params: date_params
+    )
     @answer = result.object
 
     if result.success?
@@ -53,7 +59,7 @@ class AnswersController < ApplicationController
     params.require(:answer).permit(:response, :further_information)
   end
 
-  def checkbox_params
+  def further_information_params
     return {skipped: true, response: [""], further_information: nil} if skip_answer?
 
     answer_params = params.require(:answer)

--- a/app/presenters/radio_answer_presenter.rb
+++ b/app/presenters/radio_answer_presenter.rb
@@ -11,4 +11,9 @@ class RadioAnswerPresenter < SimpleDelegator
       further_information: further_information
     }
   end
+
+  def further_information
+    return unless super
+    super["#{machine_readable_option(string: response)}_further_information"]
+  end
 end

--- a/app/services/save_answer.rb
+++ b/app/services/save_answer.rb
@@ -9,7 +9,7 @@ class SaveAnswer
     result = Result.new(false, answer)
 
     case step.contentful_type
-    when "checkboxes", "radio"
+    when "checkboxes", "radios"
       answer.assign_attributes(further_information_params)
     when "single_date"
       answer.assign_attributes(date_params)

--- a/app/services/save_answer.rb
+++ b/app/services/save_answer.rb
@@ -5,12 +5,12 @@ class SaveAnswer
     self.step = answer.step
   end
 
-  def call(answer_params: {}, checkbox_params: {}, date_params: {})
+  def call(answer_params: {}, further_information_params: {}, date_params: {})
     result = Result.new(false, answer)
 
     case step.contentful_type
-    when "checkboxes"
-      answer.assign_attributes(checkbox_params)
+    when "checkboxes", "radio"
+      answer.assign_attributes(further_information_params)
     when "single_date"
       answer.assign_attributes(date_params)
     else

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -8,15 +8,19 @@
     <% end %>
 
     <% @step.options.each do |option| %>
+      <% machine_value = machine_readable_option(string: option["value"]) %>
+
+      <% f.object = monkey_patch_form_object_with_further_information_field(form_object: f.object, associated_choice: machine_value) %>
+
       <% if option.fetch("separated_by_or", nil) == true %>
         <div class="govuk-radios__divider">or</div>
       <% end %>
       <% if option["display_further_information"] %>
         <%= f.govuk_radio_button :response, option["value"], label: { text: option["value"] }, hint: { text: option["help_text"] } do %>
           <% if option["display_further_information"] == "single" || option["display_further_information"] == true %>
-            <%= f.govuk_text_field :further_information, label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
+            <%= f.govuk_text_field "#{machine_value}_further_information", label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
           <% elsif option["display_further_information"] == "long" %>
-            <%= f.govuk_text_area :further_information, rows: 6, label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
+            <%= f.govuk_text_area "#{machine_value}_further_information", rows: 6, label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
           <% end %>
         <% end %>
       <% else %>

--- a/db/migrate/20210316114040_change_further_information_to_json_for_radio_answers.rb
+++ b/db/migrate/20210316114040_change_further_information_to_json_for_radio_answers.rb
@@ -1,0 +1,27 @@
+class ChangeFurtherInformationToJsonForRadioAnswers < ActiveRecord::Migration[6.1]
+  def up
+    add_column :radio_answers, :further_information_jsonb, :jsonb
+    ActiveRecord::Base.transaction do
+      RadioAnswer.all.map do |radio|
+        machine_value = radio.response.parameterize(separator: "_")
+        hash = {machine_value => radio.further_information}
+        radio.update(further_information_jsonb: hash)
+      end
+    end
+    remove_column :radio_answers, :further_information
+    rename_column :radio_answers, :further_information_jsonb, :further_information
+  end
+
+  def down
+    add_column :radio_answers, :further_information_string, :string
+    ActiveRecord::Base.transaction do
+      RadioAnswer.all.map do |radio|
+        machine_value = radio.response.parameterize(separator: "_")
+        matching_further_information = radio.further_information[machine_value]
+        radio.update(further_information_string: matching_further_information)
+      end
+    end
+    remove_column :radio_answers, :further_information
+    rename_column :radio_answers, :further_information_string, :further_information
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_02_110746) do
+ActiveRecord::Schema.define(version: 2021_03_16_114040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2021_03_02_110746) do
     t.string "response", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "further_information"
+    t.jsonb "further_information"
     t.index ["step_id"], name: "index_radio_answers_on_step_id"
   end
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -232,20 +232,19 @@ feature "Anyone can start a journey" do
           start_journey_from_category_and_go_to_question(category: "extended-radio-question.json")
 
           choose("Catering")
-
           expect(page).not_to have_content("No_further_information") # It should not create a label when one isn't specified
           within("span.govuk-visually-hidden") do
             expect(page).to have_content("Optional further information") # Default the hidden label to something understandable for screen readers
           end
 
-          fill_in "answer[further_information]", with: "The school needs the kitchen cleaned once a day"
+          fill_in "answer[catering_further_information]", with: "The school needs the kitchen cleaned once a day"
 
           click_on(I18n.t("generic.button.next"))
 
           click_first_link_in_task_list
 
           expect(page).to have_checked_field("Catering")
-          expect(find_field("answer-further-information-field").value)
+          expect(find_field("answer-catering-further-information-field").value)
             .to eql("The school needs the kitchen cleaned once a day")
         end
       end
@@ -256,7 +255,7 @@ feature "Anyone can start a journey" do
 
           choose("Catering")
 
-          expect(page).to have_selector("input#answer-further-information-field")
+          expect(page).to have_selector("input#answer-catering-further-information-field")
         end
       end
 
@@ -266,7 +265,7 @@ feature "Anyone can start a journey" do
 
           choose("Catering")
 
-          expect(page).to have_selector("textarea#answer-further-information-field")
+          expect(page).to have_selector("textarea#answer-catering-further-information-field")
         end
       end
 
@@ -274,8 +273,8 @@ feature "Anyone can start a journey" do
         scenario "no extra text field is displayed" do
           start_journey_from_category_and_go_to_question(category: "radio-question.json")
 
-          expect(page).to_not have_selector("textarea#answer-further-information-field")
-          expect(page).to_not have_selector("input#answer-further-information-field")
+          expect(page).to_not have_selector("textarea#answer-catering-further-information-field")
+          expect(page).to_not have_selector("input#answer-catering-further-information-field")
         end
       end
 

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -35,7 +35,7 @@ feature "Users can see their catering specification" do
     click_first_link_in_task_list
 
     choose("Catering")
-    fill_in "answer[further_information]", with: "The school needs the kitchen cleaned once a day"
+    fill_in "answer[catering_further_information]", with: "The school needs the kitchen cleaned once a day"
     click_on(I18n.t("generic.button.next"))
     click_on(I18n.t("journey.specification.button"))
 

--- a/spec/presenters/radio_answer_presenter_spec.rb
+++ b/spec/presenters/radio_answer_presenter_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe RadioAnswerPresenter do
   describe "#response" do
     it "returns the option chosen" do
-      step = build(:radio_answer, response: "Yes", further_information: "Extra info")
+      step = build(:radio_answer,
+        response: "Yes",
+        further_information: {yes_further_information: "More yes info"})
       presenter = described_class.new(step)
       expect(presenter.response).to eq("Yes")
     end
@@ -13,7 +15,7 @@ RSpec.describe RadioAnswerPresenter do
     it "returns a hash of radio_answer" do
       step = build(:radio_answer,
         response: "Yes",
-        further_information: "More yes info")
+        further_information: {yes_further_information: "More yes info"})
 
       presenter = described_class.new(step)
 

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe GetAnswersForSteps do
       it "returns the answer information in a hash" do
         answer = create(:radio_answer,
           response: "Yes please",
-          further_information: "More yes info")
+          further_information: {yes_please_further_information: "More yes info"})
 
         result = described_class.new(visible_steps: [answer.step]).call
         assertion = {

--- a/spec/services/save_answer_spec.rb
+++ b/spec/services/save_answer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SaveAnswer do
         answer = create(:checkbox_answers)
         params = ActionController::Parameters.new(response: ["A", "B"]).permit!
 
-        result = described_class.new(answer: answer).call(checkbox_params: params)
+        result = described_class.new(answer: answer).call(further_information_params: params)
 
         expect(result.success?).to eql(true)
         expect(result.object.response).to eql(["A", "B"])


### PR DESCRIPTION
## Changes

If there are multiple options within a radio question where expanded information is switched on, only the value from the last option is saved. This is the case even if the input is hidden, which means that unless the user chooses the last option in the list it will appear as their input has not been saved.

We fix this for presenting questions to the user by treating extended radio options like checkboxes and storing a hash of `further_information`. This also means that if a user changes their radio selection at a later date, their original response to further information will also be stored should they change back in future.

For rendering the result in the specification, as we prepare variables for the liquid template we only use the `further_information` value for the key which matches the selected option.

## Screenshots

We check that we can provide answers to both options:
![Screenshot 2021-03-16 at 12 33 46](https://user-images.githubusercontent.com/912473/111309838-3e910b80-8654-11eb-8ef8-25676bbaf7dc.png)
![Screenshot 2021-03-16 at 12 33 53](https://user-images.githubusercontent.com/912473/111309961-65e7d880-8654-11eb-8e3f-e654d56893e4.png)

We go back tot he question and check that we open it with the right selected answer _and_ that when we click between the top 2 options, both bits further information are there:
![Screenshot 2021-03-16 at 12 35 55](https://user-images.githubusercontent.com/912473/111309891-4f418180-8654-11eb-9548-ef8c04adeb0f.png)
![Screenshot 2021-03-16 at 12 34 05](https://user-images.githubusercontent.com/912473/111310084-9596e080-8654-11eb-9ce1-4d268b006771.png)

We open the spec and make sure that the variable is available with only the chosen answer in the `further_information` key.
![Screenshot 2021-03-16 at 12 35 47](https://user-images.githubusercontent.com/912473/111309878-4b156400-8654-11eb-8656-8f11356e2172.png)

