### PR TITLE
Pull request template includes Confluence prompt

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,5 @@
 ### After
 
 ## Next steps
+
+<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->


### PR DESCRIPTION
In an effort to help us keep our documentation in Confluence up to date for how content is managed, include a prompt in our Pull request template.

The majority of changes do not require documentation changes so the prompt can be commented in if applicable.