### PR TITLE
Planning page links back to the start page correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - specification can show further information for radio answers
 - specification can show further information for checkbox answers
 - checkbox answers can be completed without choosing a given answer
+- fix planning page link back to the service
 
 ## [release-005] - 2021-1-19
 

--- a/app/views/pages/planning_start_page.html.erb
+++ b/app/views/pages/planning_start_page.html.erb
@@ -209,7 +209,7 @@
       <p class="govuk-body"><a href="https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools/writing-a-specification" class="govuk-link">Read about how to write a specification</a></p>
 
 
-      <p class="govuk-body">Below are some of the things that you should include. You can also <a href="../start">use our tool to create a specification</a>.</p>
+      <p class="govuk-body">Below are some of the things that you should include. You can also <%= link_to "use our tool to create a specification", root_path, class: "govuk-link" %>.</p>
 
 
       <h3 class="govuk-heading-m">Objectives</h3>

--- a/spec/features/visitors/anyone_can_see_a_planning_start_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_a_planning_start_page_spec.rb
@@ -32,6 +32,7 @@ feature "Users can see a start page for planning their purchase" do
     expect(page).to have_content("Writing your requirements")
     page.find(:xpath, "//*[contains(text(),'Writing your requirements')]").click
     expect(page).to have_content("This is the document that you give to suppliers explaining what you want to buy, sometimes called a specification.")
+    expect(page).to have_link("use our tool to create a specification", href: root_path)
 
     expect(page).to have_content("What to do next")
     page.find(:xpath, "//*[contains(text(),'What to do next')]").click


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

The link included the prototype link of /start which doesn't exist. In this change we add a test for the link which was missed, the correct link and ensure it has the correct class for styling.

## Screenshots of UI changes

![Screenshot 2021-03-08 at 10 25 17](https://user-images.githubusercontent.com/912473/110308981-b332cd00-7ff8-11eb-8d1a-390d3a45630a.png)