### PR TITLE
(452) Part 1 - Checkbox answers are not automatically joined by commas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - specification can show further information for checkbox answers
 - checkbox answers can be completed without choosing a given answer
 - fix planning page link back to the service
+- checkbox answers are not automatically joined by commas for the specification
 
 ## [release-005] - 2021-1-19
 

--- a/app/presenters/checkboxes_answer_presenter.rb
+++ b/app/presenters/checkboxes_answer_presenter.rb
@@ -1,8 +1,5 @@
 class CheckboxesAnswerPresenter < SimpleDelegator
   def response
-    super.reject(&:blank?).map { |answer|
-      answer.tr!("_", " ")
-      answer.capitalize!
-    }.join(", ")
+    super.reject(&:blank?)
   end
 end

--- a/app/services/get_answers_for_steps.rb
+++ b/app/services/get_answers_for_steps.rb
@@ -42,7 +42,7 @@ class GetAnswersForSteps
         end
       end
 
-      hash["answer_#{step.contentful_id}"] = answer.response.to_s
+      hash["answer_#{step.contentful_id}"] = answer.response
     }
   end
 end

--- a/spec/presenters/checkboxes_answer_presenter_spec.rb
+++ b/spec/presenters/checkboxes_answer_presenter_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe CheckboxesAnswerPresenter do
   describe "#response" do
-    it "returns all none nil values, capitalised as a comma separated string" do
-      step = build(:checkbox_answers, response: ["yes", "no", "morning_break", ""])
+    it "returns all none nil values as an array" do
+      step = build(:checkbox_answers, response: ["Yes", "No", "Morning break", ""])
       presenter = described_class.new(step)
-      expect(presenter.response).to eq("Yes, No, Morning break")
+      expect(presenter.response).to eq(["Yes", "No", "Morning break"])
     end
   end
 end


### PR DESCRIPTION

<!-- Do you need to update the changelog? -->

## Changes in this PR

Instead of performing this operation in Rails, we leave the presentational logic to Contentful.

The same logic can be achieved by defining the following in the `specification_template`:

```
{{ options | join: ", " }}
```

This enables the user to present the options in different ways. Not only as a single paragraph but as a list of options.

## Next steps

- [] Migrate 13 existing checkbox answers to using the new join syntax in Contentful to replicate the previous intention
- [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS)
