### PR TITLE
(452) Part 1 - Change how information about all answers is shared with the specification builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - specification can show further information for checkbox answers
 - checkbox answers can be completed without choosing a given answer
 - fix planning page link back to the service
+- checkbox answers are not automatically joined by commas for the specification
 
 ## [release-005] - 2021-1-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - checkbox answers can be completed without choosing a given answer
 - fix planning page link back to the service
 - checkbox answers are not automatically joined by commas for the specification
+- answer data is all available through the single `answer_x` convention, this has replaced `extended_answer_x` which has now been removed
 
 ## [release-005] - 2021-1-19
 

--- a/app/presenters/checkboxes_answer_presenter.rb
+++ b/app/presenters/checkboxes_answer_presenter.rb
@@ -2,4 +2,33 @@ class CheckboxesAnswerPresenter < SimpleDelegator
   def response
     super.reject(&:blank?)
   end
+
+  def to_param
+    {
+      response: response,
+      skipped: skipped,
+      selected_answers: selected_answers
+    }
+  end
+
+  private def concatenated_response
+    return nil if response.empty?
+
+    response.join(", ")
+  end
+
+  private def selected_answers
+    return [] if response.empty?
+
+    response.each_with_object([]) do |human_readable_choice, array|
+      machine_readable_key = human_readable_choice.parameterize.to_sym
+      matching_further_information = further_information&.fetch("#{machine_readable_key}_further_information", nil)
+
+      array << {
+        machine_value: machine_readable_key,
+        human_value: human_readable_choice,
+        further_information: matching_further_information
+      }
+    end
+  end
 end

--- a/app/presenters/checkboxes_answer_presenter.rb
+++ b/app/presenters/checkboxes_answer_presenter.rb
@@ -6,6 +6,7 @@ class CheckboxesAnswerPresenter < SimpleDelegator
   def to_param
     {
       response: response,
+      concatenated_response: concatenated_response,
       skipped: skipped,
       selected_answers: selected_answers
     }

--- a/app/presenters/checkboxes_answer_presenter.rb
+++ b/app/presenters/checkboxes_answer_presenter.rb
@@ -1,8 +1,5 @@
 class CheckboxesAnswerPresenter < SimpleDelegator
   def response
-    super.reject(&:blank?).map { |answer|
-      answer.tr!("_", " ")
-      answer.capitalize!
-    }.join(", ")
+    super.reject(&:blank?)
   end
 end

--- a/app/presenters/currency_answer_presenter.rb
+++ b/app/presenters/currency_answer_presenter.rb
@@ -4,4 +4,8 @@ class CurrencyAnswerPresenter < SimpleDelegator
   def response
     number_to_currency(super, unit: "£", precision: 2)
   end
+
+  def to_param
+    response
+  end
 end

--- a/app/presenters/currency_answer_presenter.rb
+++ b/app/presenters/currency_answer_presenter.rb
@@ -6,6 +6,8 @@ class CurrencyAnswerPresenter < SimpleDelegator
   end
 
   def to_param
-    response
+    {
+      response: response
+    }
   end
 end

--- a/app/presenters/long_text_answer_presenter.rb
+++ b/app/presenters/long_text_answer_presenter.rb
@@ -6,6 +6,8 @@ class LongTextAnswerPresenter < SimpleDelegator
   end
 
   def to_param
-    response
+    {
+      response: response
+    }
   end
 end

--- a/app/presenters/long_text_answer_presenter.rb
+++ b/app/presenters/long_text_answer_presenter.rb
@@ -4,4 +4,8 @@ class LongTextAnswerPresenter < SimpleDelegator
   def response
     simple_format(super)
   end
+
+  def to_param
+    response
+  end
 end

--- a/app/presenters/number_answer_presenter.rb
+++ b/app/presenters/number_answer_presenter.rb
@@ -1,4 +1,8 @@
 class NumberAnswerPresenter < SimpleDelegator
+  def response
+    super.to_s
+  end
+  
   def to_param
     response
   end

--- a/app/presenters/number_answer_presenter.rb
+++ b/app/presenters/number_answer_presenter.rb
@@ -2,8 +2,10 @@ class NumberAnswerPresenter < SimpleDelegator
   def response
     super.to_s
   end
-  
+
   def to_param
-    response
+    {
+      response: response
+    }
   end
 end

--- a/app/presenters/number_answer_presenter.rb
+++ b/app/presenters/number_answer_presenter.rb
@@ -1,2 +1,5 @@
 class NumberAnswerPresenter < SimpleDelegator
+  def to_param
+    response
+  end
 end

--- a/app/presenters/radio_answer_presenter.rb
+++ b/app/presenters/radio_answer_presenter.rb
@@ -4,4 +4,8 @@ class RadioAnswerPresenter < SimpleDelegator
   def response
     human_readable_option(string: super)
   end
+
+  def to_param
+    response
+  end
 end

--- a/app/presenters/radio_answer_presenter.rb
+++ b/app/presenters/radio_answer_presenter.rb
@@ -6,6 +6,9 @@ class RadioAnswerPresenter < SimpleDelegator
   end
 
   def to_param
-    response
+    {
+      response: response,
+      further_information: further_information
+    }
   end
 end

--- a/app/presenters/short_text_answer_presenter.rb
+++ b/app/presenters/short_text_answer_presenter.rb
@@ -1,2 +1,5 @@
 class ShortTextAnswerPresenter < SimpleDelegator
+  def to_param
+    response
+  end
 end

--- a/app/presenters/short_text_answer_presenter.rb
+++ b/app/presenters/short_text_answer_presenter.rb
@@ -1,5 +1,7 @@
 class ShortTextAnswerPresenter < SimpleDelegator
   def to_param
-    response
+    {
+      response: response
+    }
   end
 end

--- a/app/presenters/single_date_answer_presenter.rb
+++ b/app/presenters/single_date_answer_presenter.rb
@@ -4,6 +4,8 @@ class SingleDateAnswerPresenter < SimpleDelegator
   end
 
   def to_param
-    response
+    {
+      response: response
+    }
   end
 end

--- a/app/presenters/single_date_answer_presenter.rb
+++ b/app/presenters/single_date_answer_presenter.rb
@@ -2,4 +2,8 @@ class SingleDateAnswerPresenter < SimpleDelegator
   def response
     I18n.l(super)
   end
+
+  def to_param
+    response
+  end
 end

--- a/app/services/get_answers_for_steps.rb
+++ b/app/services/get_answers_for_steps.rb
@@ -23,26 +23,7 @@ class GetAnswersForSteps
       else raise UnexpectedAnswer.new("Trying to present an unknown type of answer: #{step.answer.class.name}")
       end
 
-      if answer.respond_to?(:further_information)
-        hash["extended_answer_#{step.contentful_id}"] = if answer.further_information.is_a?(Hash)
-          answer.further_information.each_pair.each_with_object([]) do |(key, value), array|
-            key_without_prefix = key.gsub("_further_information", "")
-            array << {
-              "response" => human_readable_option(string: key_without_prefix),
-              "further_information" => value
-            }
-          end
-        else
-          [
-            {
-              "response" => answer.response,
-              "further_information" => answer.further_information
-            }
-          ]
-        end
-      end
-
-      hash["answer_#{step.contentful_id}"] = answer.to_param
+      hash["answer_#{step.contentful_id}"] = answer.to_param.with_indifferent_access
     }
   end
 end

--- a/app/services/get_answers_for_steps.rb
+++ b/app/services/get_answers_for_steps.rb
@@ -42,7 +42,7 @@ class GetAnswersForSteps
         end
       end
 
-      hash["answer_#{step.contentful_id}"] = answer.response.to_s
+      hash["answer_#{step.contentful_id}"] = answer.to_param
     }
   end
 end

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -51,9 +51,9 @@ feature "Users can see their catering specification" do
     expect(page).to have_content(I18n.t("journey.specification.header"))
 
     within("article#specification") do
-      expect(page).to have_content("Yes")
+      expect(page).to have_content("yes")
       expect(page).to have_content("More info for yes")
-      expect(page).to have_content("No")
+      expect(page).to have_content("no")
       expect(page).to have_content("More info for no")
     end
   end

--- a/spec/fixtures/contentful/categories/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/extended-checkboxes-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1><p>{{answer_extended-checkboxes-question}}</p><ul>{% for extended_answer in extended_answer_extended-checkboxes-question %}<li>{{ extended_answer['response'] }}</li><li>{{ extended_answer['further_information'] }}</li>{% endfor %}</ul></article>"
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1><ul>{% for checkbox_answer in answer_extended-checkboxes-question['selected_answers'] %}<li>{{ checkbox_answer['human_value'] }}</li><li>{{ checkbox_answer.further_information }}</li>{% endfor %}</ul></article>"
     }
 }

--- a/spec/presenters/checkboxes_answer_presenter_spec.rb
+++ b/spec/presenters/checkboxes_answer_presenter_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe CheckboxesAnswerPresenter do
   describe "#response" do
-    it "returns all none nil values, capitalised as a comma separated string" do
-      step = build(:checkbox_answers, response: ["yes", "no", "morning_break", ""])
+    it "returns all none nil values as an array" do
+      step = build(:checkbox_answers, response: ["Yes", "No", "Morning break", ""])
       presenter = described_class.new(step)
-      expect(presenter.response).to eq("Yes, No, Morning break")
+      expect(presenter.response).to eq(["Yes", "No", "Morning break"])
     end
   end
 end

--- a/spec/presenters/checkboxes_answer_presenter_spec.rb
+++ b/spec/presenters/checkboxes_answer_presenter_spec.rb
@@ -8,4 +8,64 @@ RSpec.describe CheckboxesAnswerPresenter do
       expect(presenter.response).to eq(["Yes", "No", "Morning break"])
     end
   end
+
+  describe "#to_param" do
+    it "returns a hash of options" do
+      step = build(:checkbox_answers,
+        response: ["Yes", "No"],
+        skipped: false,
+        further_information: {
+          yes_further_information: "More yes info",
+          no_further_information: "More no info"
+        })
+
+      presenter = described_class.new(step)
+
+      expect(presenter.to_param).to eql({
+        response: ["Yes", "No"],
+        skipped: false,
+        concatenated_response: "Yes, No",
+        selected_answers: [
+          {
+            machine_value: :yes,
+            human_value: "Yes",
+            further_information: "More yes info"
+          },
+          {
+            machine_value: :no,
+            human_value: "No",
+            further_information: "More no info"
+          }
+        ]
+      })
+    end
+
+    context "when there is no response" do
+      it "sets the response to an empty array" do
+        step = build(:checkbox_answers, response: [])
+        presenter = described_class.new(step)
+        expect(presenter.to_param).to include({response: []})
+      end
+
+      it "sets the concatenated_response to an array with an empty hash" do
+        step = build(:checkbox_answers, response: [])
+        presenter = described_class.new(step)
+        expect(presenter.to_param).to include({selected_answers: []})
+      end
+
+      it "sets the concatenated_response to a nil" do
+        step = build(:checkbox_answers, response: [])
+        presenter = described_class.new(step)
+        expect(presenter.to_param).to include({concatenated_response: nil})
+      end
+    end
+
+    context "when the answer is skipped" do
+      it "sets the skipped value to true" do
+        step = build(:checkbox_answers, skipped: true)
+        presenter = described_class.new(step)
+        expect(presenter.to_param).to include({skipped: true})
+      end
+    end
+  end
 end

--- a/spec/presenters/currency_answer_presenter_spec.rb
+++ b/spec/presenters/currency_answer_presenter_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe CurrencyAnswerPresenter do
       expect(presenter.response).to eq("£1,000.01")
     end
   end
+
+  describe "#to_param" do
+    it "returns a hash of currency_answer" do
+      step = build(:currency_answer, response: 100.00)
+      presenter = described_class.new(step)
+      expect(presenter.to_param).to eql({response: "£100.00"})
+    end
+  end
 end

--- a/spec/presenters/long_text_answer_presenter_spec.rb
+++ b/spec/presenters/long_text_answer_presenter_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe LongTextAnswerPresenter do
       end
     end
   end
+
+  describe "#to_param" do
+    it "returns a hash of long_text_answer" do
+      step = build(:long_text_answer, response: "First line\r\nSecond line")
+      presenter = described_class.new(step)
+      expect(presenter.to_param).to eql({response: "<p>First line\n<br />Second line</p>"})
+    end
+  end
 end

--- a/spec/presenters/number_answer_presenter_spec.rb
+++ b/spec/presenters/number_answer_presenter_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe NumberAnswerPresenter do
       expect(presenter.response).to eq("100")
     end
   end
+
+  describe "#to_param" do
+    it "returns a hash of number_answer" do
+      step = build(:number_answer, response: 1)
+      presenter = described_class.new(step)
+      expect(presenter.to_param).to eql({response: "1"})
     end
   end
 end

--- a/spec/presenters/number_answer_presenter_spec.rb
+++ b/spec/presenters/number_answer_presenter_spec.rb
@@ -2,10 +2,12 @@ require "rails_helper"
 
 RSpec.describe NumberAnswerPresenter do
   describe "#response" do
-    it "returns the response" do
+    it "returns the response as a string" do
       step = build(:number_answer, response: 100)
       presenter = described_class.new(step)
-      expect(presenter.response).to eq(100)
+      expect(presenter.response).to eq("100")
+    end
+  end
     end
   end
 end

--- a/spec/presenters/radio_answer_presenter_spec.rb
+++ b/spec/presenters/radio_answer_presenter_spec.rb
@@ -8,4 +8,19 @@ RSpec.describe RadioAnswerPresenter do
       expect(presenter.response).to eq("Yes")
     end
   end
+
+  describe "#to_param" do
+    it "returns a hash of radio_answer" do
+      step = build(:radio_answer,
+        response: "Yes",
+        further_information: "More yes info")
+
+      presenter = described_class.new(step)
+
+      expect(presenter.to_param).to eql({
+        response: "Yes",
+        further_information: "More yes info"
+      })
+    end
+  end
 end

--- a/spec/presenters/short_text_answer_presenter_spec.rb
+++ b/spec/presenters/short_text_answer_presenter_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe ShortTextAnswerPresenter do
       expect(presenter.response).to eq("A little of text")
     end
   end
+
+  describe "#to_param" do
+    it "returns a hash of short_text_answer" do
+      step = build(:short_text_answer, response: "Red")
+      presenter = described_class.new(step)
+      expect(presenter.to_param).to eql({response: "Red"})
+    end
+  end
 end

--- a/spec/presenters/single_date_answer_presenter_spec.rb
+++ b/spec/presenters/single_date_answer_presenter_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe SingleDateAnswerPresenter do
       expect(presenter.response).to eq("30 Dec 2000")
     end
   end
+
+  describe "#to_param" do
+    it "returns a hash of single_date_answer" do
+      step = build(:single_date_answer, response: Date.new(2000, 12, 30))
+      presenter = described_class.new(step)
+      expect(presenter.to_param).to eql({response: "30 Dec 2000"})
+    end
+  end
 end

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -1,17 +1,5 @@
 require "rails_helper"
 
-RSpec.shared_examples "returns the answer in a hash" do |factory_name, presenter, response|
-  it "returns the response for a #{factory_name} in the result" do
-    answer = create(factory_name, response: response)
-    result = described_class.new(visible_steps: [answer.step]).call
-    expect(result).to include(
-      {
-        "answer_#{answer.step.contentful_id}" => presenter.new(answer).to_param
-      }
-    )
-  end
-end
-
 RSpec.describe GetAnswersForSteps do
   describe "#call" do
     it "only returns answers for the given journey" do
@@ -22,15 +10,25 @@ RSpec.describe GetAnswersForSteps do
 
       expect(result).to be_a(Hash)
       expect(result).to include(
-        {"answer_#{relevant_answer.step.contentful_id}" => "Red"}
+        {"answer_#{relevant_answer.step.contentful_id}" => {response: "Red"}}
       )
       expect(result).not_to include(
-        {"answer_#{irrelevant_answer.step.contentful_id}" => "Blue"}
+        {"answer_#{irrelevant_answer.step.contentful_id}" => {response: "Blue"}}
       )
     end
 
     context "when the answer is of type short_text_answer" do
-      it_behaves_like "returns the answer in a hash", :short_text_answer, ShortTextAnswerPresenter, "Red"
+      it "returns the answer information in a hash" do
+        answer = create(:short_text_answer, response: "Red")
+        result = described_class.new(visible_steps: [answer.step]).call
+        assertion = {
+          "answer_#{answer.step.contentful_id}" => {
+            response: "Red"
+          }
+        }
+
+        expect(result).to match(a_hash_including(assertion))
+      end
     end
 
     context "when the answer is of type long_text_answer" do

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -38,7 +38,18 @@ RSpec.describe GetAnswersForSteps do
     end
 
     context "when the answer is of type single_date_answer" do
-      it_behaves_like "returns the answer in a hash", :single_date_answer, SingleDateAnswerPresenter, "12 Jan 2020"
+      it "returns the answer information in a hash" do
+        answer = create(:single_date_answer, response: Date.new(2000, 12, 30))
+
+        result = described_class.new(visible_steps: [answer.step]).call
+        assertion = {
+          "answer_#{answer.step.contentful_id}" => {
+            response: "30 Dec 2000"
+          }
+        }
+
+        expect(result).to match(a_hash_including(assertion))
+      end
     end
 
     context "when the answer is of type radio_answer" do

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -112,6 +112,21 @@ RSpec.describe GetAnswersForSteps do
       end
     end
 
+    context "when the answer is of type number_answer" do
+      it "returns the answer information in a hash" do
+        answer = create(:number_answer, response: 2)
+
+        result = described_class.new(visible_steps: [answer.step]).call
+        assertion = {
+          "answer_#{answer.step.contentful_id}" => {
+            response: "2"
+          }
+        }
+
+        expect(result).to match(a_hash_including(assertion))
+      end
+    end
+
     context "when the answer is of type checkbox_answers" do
       it "returns the answer information in a hash" do
         answer = create(:checkbox_answers,

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe GetAnswersForSteps do
       )
     end
 
+    it "returns a hash with_indifferent_access so Liquid can use the string syntax for access" do
+      answer = create(:short_text_answer, response: "Red")
+      result = described_class.new(visible_steps: [answer.step]).call
+      expect(result).to include({"answer_#{answer.step.contentful_id}" => {"response" => "Red"}})
+    end
+
     context "when the answer is of type short_text_answer" do
       it "returns the answer information in a hash" do
         answer = create(:short_text_answer, response: "Red")
@@ -64,36 +70,17 @@ RSpec.describe GetAnswersForSteps do
       it "returns the answer information in a hash" do
         answer = create(:radio_answer,
           response: "Yes please",
-          further_information: nil)
+          further_information: "More yes info")
 
         result = described_class.new(visible_steps: [answer.step]).call
         assertion = {
           "answer_#{answer.step.contentful_id}" => {
             response: "Yes please",
-            further_information: nil
+            further_information: "More yes info"
           }
         }
 
         expect(result).to match(a_hash_including(assertion))
-      end
-
-      context "when the answer has further_information" do
-        it "also includes an extended_answer hash in the response" do
-          answer = create(:radio_answer,
-            response: "yes please",
-            further_information: "More yes info")
-          result = described_class.new(visible_steps: [answer.step]).call
-          expect(result).to include(
-            {
-              "extended_answer_#{answer.step.contentful_id}" => [
-                {
-                  "response" => "Yes please",
-                  "further_information" => "More yes info"
-                }
-              ]
-            }
-          )
-        end
       end
     end
 

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -42,7 +42,21 @@ RSpec.describe GetAnswersForSteps do
     end
 
     context "when the answer is of type radio_answer" do
-      it_behaves_like "returns the answer in a hash", :radio_answer, RadioAnswerPresenter, "Catering"
+      it "returns the answer information in a hash" do
+        answer = create(:radio_answer,
+          response: "Yes please",
+          further_information: nil)
+
+        result = described_class.new(visible_steps: [answer.step]).call
+        assertion = {
+          "answer_#{answer.step.contentful_id}" => {
+            response: "Yes please",
+            further_information: nil
+          }
+        }
+
+        expect(result).to match(a_hash_including(assertion))
+      end
 
       context "when the answer has further_information" do
         it "also includes an extended_answer hash in the response" do
@@ -50,9 +64,6 @@ RSpec.describe GetAnswersForSteps do
             response: "yes please",
             further_information: "More yes info")
           result = described_class.new(visible_steps: [answer.step]).call
-          expect(result).to include(
-            {"answer_#{answer.step.contentful_id}" => "Yes please"}
-          )
           expect(result).to include(
             {
               "extended_answer_#{answer.step.contentful_id}" => [

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -34,7 +34,17 @@ RSpec.describe GetAnswersForSteps do
     end
 
     context "when the answer is of type long_text_answer" do
-      it_behaves_like "returns the answer in a hash", :long_text_answer, LongTextAnswerPresenter, "<p>Red Blue Yellow</p>"
+      it "returns the answer information in a hash" do
+        answer = create(:long_text_answer, response: "Red\r\n\r\n\r\nBlue")
+        result = described_class.new(visible_steps: [answer.step]).call
+        assertion = {
+          "answer_#{answer.step.contentful_id}" => {
+            response: "<p>Red</p>\n\n<p>Blue</p>"
+          }
+        }
+
+        expect(result).to match(a_hash_including(assertion))
+      end
     end
 
     context "when the answer is of type single_date_answer" do

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -97,6 +97,21 @@ RSpec.describe GetAnswersForSteps do
       end
     end
 
+    context "when the answer is of type currency_answer" do
+      it "returns the answer information in a hash" do
+        answer = create(:currency_answer, response: 100.01)
+
+        result = described_class.new(visible_steps: [answer.step]).call
+        assertion = {
+          "answer_#{answer.step.contentful_id}" => {
+            response: "£100.01"
+          }
+        }
+
+        expect(result).to match(a_hash_including(assertion))
+      end
+    end
+
     context "when the answer is of type checkbox_answers" do
       it "returns the answer information in a hash" do
         answer = create(:checkbox_answers,

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe GetAnswersForSteps do
         assertion = {
           "answer_#{answer.step.contentful_id}" => {
             response: ["Foo", "Bar"],
+            concatenated_response: "Foo, Bar",
             skipped: false,
             selected_answers: [
               {
@@ -108,6 +109,7 @@ RSpec.describe GetAnswersForSteps do
           assertion = {
             "answer_#{answer.step.contentful_id}" => {
               response: ["Foo"],
+              concatenated_response: "Foo",
               skipped: false,
               selected_answers: [
                 {


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

The variables and their data structure that we make available to the specification through the template has breaking changes.

We remove the concept of `extended_answer` by merging all of its responsibility into `answer` by changing it from a `string` to a `hash`.

We go from:
```
answer_123 => "The option the user picked"
extended_answer_123["response"] => "the_option_the_user_picked"
extended_answer_123["further_information"] => "extra information"
```

To:
```
answer_123 => {
  response: ["Foo", "Bar"],
  concatenated_response: "Foo, Bar",
  skipped: false,
  selected_answers: [
    {
      machine_value: :foo,
      human_value: "Foo",
      further_information: "More yes info"
    },
    {
      machine_value: :bar,
      human_value: "Bar",
      further_information: nil
    }
  ]
}
```

This addresses several issues:

1. the distinction between the human readable text (that the user sees in the browser and selects) and the machine version (used for mapping the `further_information` fields) is clear
2. when no further_information is provided we return `nil` rather than a missing object in the `furhter_information` field
3. provide a structure that allows us to add more configuration that Liquid templating can use, such as `answer["skipped"] == true`

Whilst the `CheckboxAnswerPresenter` class receives the bulk of the changes, every `AnswerPresenter` is also changed with similar (but simpler) changes to return a hash of only the `response`. Offering the same interface for all question types should make it simpler for users in Liquid and provides us an easier way to extend again in future.

There are 32 references to `extended` in the specification template right now. Merging this change will break the spec until they are all converted over.

## Next steps

- [ ] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS)
- [ ] Convert all spec references of old @extended_ variables across to the new format