### PR TITLE
(452) Part 2 - Content team can identify skipped questions in the specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix planning page link back to the service
 - checkbox answers are not automatically joined by commas for the specification
 - answer data is all available through the single `answer_x` convention, this has replaced `extended_answer_x` which has now been removed
+- checkbox answers that are skipped can be identified in the specification
 
 ## [release-005] - 2021-1-19
 

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -58,6 +58,18 @@ feature "Users can see their catering specification" do
     end
   end
 
+  scenario "questions that are skipped can be identified" do
+    stub_contentful_category(fixture_filename: "skippable-checkboxes-question.json")
+    visit root_path
+    click_on(I18n.t("generic.button.start"))
+
+    click_first_link_in_task_list
+
+    click_on("None of the above")
+
+    expect(page).to have_content("Skipped question detected")
+  end
+
   context "when the spec is incomplete" do
     it "warns the user that the contents are in a partially completed state" do
       stub_contentful_category(fixture_filename: "extended-radio-question.json")

--- a/spec/fixtures/contentful/categories/skippable-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/skippable-checkboxes-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1>{% if answer_skippable-checkboxes-question['skipped'] == true %}Skipped question detected{% endif %}</article>"
     }
 }


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
Based on https://github.com/DFE-Digital/buy-for-your-school/pull/210

## Changes in this PR

Checkbox answers that are skipped by the user, are now able to be explicitly identified in the specification.

Before this we could and were inferring this state by checking for an answer variable that exists (since only answered questions have `answer` records) with an empty response.

## Next steps

- [ ] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) 
