### PR TITLE
Checkbox and radio answers store the human readable choice

### DIFF
--- a/app/views/steps/checkboxes.html.erb
+++ b/app/views/steps/checkboxes.html.erb
@@ -11,21 +11,21 @@
       <% if option.fetch("separated_by_or", nil) == true %>
         <div class="govuk-radios__divider">or</div>
       <% end %>
-      
+
       <% f.object = monkey_patch_form_object_with_further_information_field(form_object: f.object, associated_choice: machine_value) %>
 
       <% if option["display_further_information"] == true || option["display_further_information"] == "single" %>
-        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
+        <%= f.govuk_check_box :response, option["value"], label: { text: option["value"] } do %>
           <%= f.govuk_text_field "#{machine_value}_further_information",
             label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
         <% end %>
       <% elsif option["display_further_information"] == "long" %>
-        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } do %>
+        <%= f.govuk_check_box :response, option["value"], label: { text: option["value"] } do %>
           <%= f.govuk_text_area "#{machine_value}_further_information", rows: 6,
             label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
         <% end %>
       <% else %>
-        <%= f.govuk_check_box :response, machine_value, label: { text: option["value"] } %>
+        <%= f.govuk_check_box :response, option["value"], label: { text: option["value"] } %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -12,7 +12,7 @@
         <div class="govuk-radios__divider">or</div>
       <% end %>
       <% if option["display_further_information"] %>
-        <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } do %>
+        <%= f.govuk_radio_button :response, option["value"], label: { text: option["value"] }, hint: { text: option["help_text"] } do %>
           <% if option["display_further_information"] == "single" || option["display_further_information"] == true %>
             <%= f.govuk_text_field :further_information, label: { text: option["further_information_help_text"] } %>
           <% elsif option["display_further_information"] == "long" %>
@@ -21,7 +21,7 @@
         <% end %>
       <% else %>
         <!-- We have to include this if there is no block given, selecting an option causes a page jump as a conditional element is toggled by the form builder -->
-        <%= f.govuk_radio_button :response, option["value"].downcase, label: { text: option["value"] }, hint: { text: option["help_text"] } %>
+        <%= f.govuk_radio_button :response, option["value"], label: { text: option["value"] }, hint: { text: option["help_text"] } %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/factories/answer.rb
+++ b/spec/factories/answer.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
   factory :checkbox_answers do
     association :step, factory: :step, options: [{"value" => "Breakfast"}, {"value" => "Lunch"}], contentful_type: "checkboxes", contentful_model: "question"
 
-    response { ["breakfast", "lunch", ""] }
+    response { ["Breakfast", "Lunch", ""] }
     skipped { false }
   end
 

--- a/spec/features/visitors/anyone_can_edit_their_answers_spec.rb
+++ b/spec/features/visitors/anyone_can_edit_their_answers_spec.rb
@@ -59,7 +59,7 @@ feature "Users can edit their answers" do
   end
 
   context "when the question is checkbox_answers" do
-    let(:answer) { create(:checkbox_answers, response: ["breakfast", "lunch", ""]) }
+    let(:answer) { create(:checkbox_answers, response: ["Breakfast", "Lunch", ""]) }
 
     scenario "The edited answer is saved" do
       visit journey_path(answer.step.journey)


### PR DESCRIPTION
## Changes in this PR

When a user selects the human readable `Pots, plans or cooking utensils` as a checkbox or radio answer we persist `pots,_pans_or_cooking_utensils` in the database instead of `Pots, plans or cooking utensils`.

`f.govuk_check_box :response` is now set to `option["value"]`, which saves the human readble value, `Pots, plans or cooking utensils`.

This fixes a problem where branching required the content user to pass in a machine readable value, often requiring the content user to have to guess the formatting of this value.