### PR TITLE
(425) Multiple answers can unlock the same branching question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - checkbox answers are not automatically joined by commas for the specification
 - answer data is all available through the single `answer_x` convention, this has replaced `extended_answer_x` which has now been removed
 - checkbox answers that are skipped can be identified in the specification
+- fix branching so multiple rules can show the same question
 
 ## [release-005] - 2021-1-19
 

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -8,8 +8,8 @@ class ToggleAdditionalSteps
   def call
     return unless additional_step_rules
 
-    recursively_show_additional_steps!(current_step: step, next_steps: additional_steps_to_show(step: step))
     recursively_hide_additional_steps!(next_steps: additional_steps_to_hide)
+    recursively_show_additional_steps!(current_step: step, next_steps: additional_steps_to_show(step: step))
   end
 
   private

--- a/spec/services/toggle_additional_steps_spec.rb
+++ b/spec/services/toggle_additional_steps_spec.rb
@@ -142,6 +142,29 @@ RSpec.describe ToggleAdditionalSteps do
         end
       end
 
+      context "when a branching question is shown based on more than on matching answer" do
+        it "continues to show the next step (rather than hiding it again when it doesn't match the second rule)" do
+          step = create(:step,
+            :radio,
+            journey: journey,
+            additional_step_rules: [
+              {"required_answer" => "red", "question_identifiers" => ["123"]},
+              {"required_answer" => "blue", "question_identifiers" => ["123"]}
+            ])
+          create(:radio_answer, step: step, response: "red")
+
+          step_to_show = create(:step,
+            :radio,
+            journey: journey,
+            contentful_id: "123",
+            hidden: true)
+
+          described_class.new(step: step).call
+
+          expect(step_to_show.reload.hidden).to eq(false)
+        end
+      end
+
       context "when the answers DO NOT match" do
         it "updates the referenced step's hidden field to true" do
           step = create(:step,


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

This change fixes a bug where one question with branching logic could not unlock the same question baed on more than one required answer.

For example, if question A should show question B if the answer was "Blue" **or** question B if the answer was "Red". The rules would be iterated through one at a time, the first rule would correctly unlock the first question, but the second rule would incorrectly hide it again (straight away). The behaviour we want is: if any rule matches we show it and it stays shown until updated again.

We can achieve this by simply switching the order in which we go through the show and hide rules. If we go through all the hides first we avoid the case where we can ever re hide a question that was shown in the same toggle action.
