### PR TITLE
Radio further information fields no longer auto-generates it's own label

### DIFF
--- a/app/views/steps/radios.html.erb
+++ b/app/views/steps/radios.html.erb
@@ -14,9 +14,9 @@
       <% if option["display_further_information"] %>
         <%= f.govuk_radio_button :response, option["value"], label: { text: option["value"] }, hint: { text: option["help_text"] } do %>
           <% if option["display_further_information"] == "single" || option["display_further_information"] == true %>
-            <%= f.govuk_text_field :further_information, label: { text: option["further_information_help_text"] } %>
+            <%= f.govuk_text_field :further_information, label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
           <% elsif option["display_further_information"] == "long" %>
-            <%= f.govuk_text_area :further_information, rows: 6, label: { text: option["further_information_help_text"] } %>
+            <%= f.govuk_text_area :further_information, rows: 6, label: { text: option.fetch("further_information_help_text", "Optional further information"), hidden: !option.keys.include?("further_information_help_text") } %>
           <% end %>
         <% end %>
       <% else %>

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -224,6 +224,12 @@ feature "Anyone can start a journey" do
           start_journey_from_category_and_go_to_question(category: "extended-radio-question.json")
 
           choose("Catering")
+
+          expect(page).not_to have_content("No_further_information") # It should not create a label when one isn't specified
+          within("span.govuk-visually-hidden") do
+            expect(page).to have_content("Optional further information") # Default the hidden label to something understandable for screen readers
+          end
+
           fill_in "answer[further_information]", with: "The school needs the kitchen cleaned once a day"
 
           click_on(I18n.t("generic.button.next"))

--- a/spec/fixtures/contentful/steps/extended-radio-question.json
+++ b/spec/fixtures/contentful/steps/extended-radio-question.json
@@ -37,8 +37,7 @@
           {
               "value": "Catering",
               "help_text": "",
-              "display_further_information": true,
-              "further_information_help_text": "Briefly describe why you need catering"
+              "display_further_information": true
           },
           {
               "value": "Cleaning",


### PR DESCRIPTION
## Changes in this PR

When `further_information_help_text` isn't provided, it now no longer auto-generates it's own label. 
Instead it doesn't show a label at all.

## Screenshots of UI changes

### Before

![Screen Shot 2021-03-10 at 12 40 56](https://user-images.githubusercontent.com/59832893/110631456-70aaf500-819e-11eb-902a-214aff064ad9.png)


### After

![Screen Shot 2021-03-10 at 12 43 40](https://user-images.githubusercontent.com/59832893/110631374-5a9d3480-819e-11eb-84aa-081a31db212b.png)
