### PR TITLE
(457) Fix skipping answers so that previous choices are removed

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -53,7 +53,7 @@ class AnswersController < ApplicationController
   end
 
   def checkbox_params
-    return {skipped: true, response: nil, further_information: nil} if skip_answer?
+    return {skipped: true, response: [""], further_information: nil} if skip_answer?
 
     answer_params = params.require(:answer)
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -310,6 +310,11 @@ feature "Anyone can start a journey" do
       expect(page).to have_content("can't be blank")
 
       check("Lunch")
+      check("Dinner")
+      click_on(I18n.t("generic.button.next"))
+
+      click_first_link_in_task_list
+
       click_on("None of the above")
 
       within(".app-task-list") do
@@ -319,7 +324,6 @@ feature "Anyone can start a journey" do
       click_first_link_in_task_list
 
       expect(page).not_to have_checked_field("Lunch")
-
       expect(CheckboxAnswers.last.skipped).to be true
     end
   end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

The previous version of this code `answer.assign_attributes({:response=>nil})` did not change the response column. Probably because at a database level a column with the type Array cannot be set to nil so the update request was silently ignored.

Setting this to an empty array `[]` has the same result, nothing changes.

The only way I found to remove the old choices is to set an empty string in the array.

