### PR TITLE
Machine_readable_option filters out special characters using parameterize

### DIFF
--- a/app/helpers/answer_helper.rb
+++ b/app/helpers/answer_helper.rb
@@ -6,6 +6,6 @@ module AnswerHelper
   end
 
   def machine_readable_option(string:)
-    string.tr(" ", "_").downcase
+    string.parameterize(separator: "_")
   end
 end

--- a/spec/helpers/answer_helper_spec.rb
+++ b/spec/helpers/answer_helper_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe AnswerHelper, type: :helper do
   end
 
   describe "#machine_readable_option" do
-    it "replaces spaces with underscores and downcases the string" do
-      result = helper.machine_readable_option(string: "A LONG key with inconsistent casing")
+    it "replaces spaces with underscores, removes special characters and downcases the string" do
+      result = helper.machine_readable_option(string: "A LONG key with inconsistent casing &*()%$")
       expect(result).to eql("a_long_key_with_inconsistent_casing")
     end
   end


### PR DESCRIPTION
### Changes in this PR

`machine_readable_option` now uses the parameterize method to filter out special characters and replace spaces with an underscore
