### PR TITLE
(434) Specification is shown on its own page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - answer data is all available through the single `answer_x` convention, this has replaced `extended_answer_x` which has now been removed
 - checkbox answers that are skipped can be identified in the specification
 - fix branching so multiple rules can show the same question
+- the specification lives on it's own page, separate to the task list
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -34,20 +34,6 @@ class JourneysController < ApplicationController
       :currency_answer
     ])
     @step_presenters = @visible_steps.map { |step| StepPresenter.new(step) }
-
-    @specification_template = Liquid::Template.parse(
-      @journey.liquid_template, error_mode: :strict
-    )
-
-    @answers = GetAnswersForSteps.new(visible_steps: @visible_steps).call
-    @specification_html = @specification_template.render(@answers)
-
-    respond_to do |format|
-      format.html
-      format.docx do
-        render docx: "specification.docx", content: @specification_html
-      end
-    end
   end
 
   private

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class SpecificationsController < ApplicationController
+  def show
+    @journey = Journey.find(journey_id)
+    @visible_steps = @journey.visible_steps.includes([
+      :radio_answer,
+      :short_text_answer,
+      :long_text_answer,
+      :single_date_answer,
+      :checkbox_answers,
+      :number_answer,
+      :currency_answer
+    ])
+    @step_presenters = @visible_steps.map { |step| StepPresenter.new(step) }
+
+    @specification_template = Liquid::Template.parse(
+      @journey.liquid_template, error_mode: :strict
+    )
+
+    @answers = GetAnswersForSteps.new(visible_steps: @visible_steps).call
+    @specification_html = @specification_template.render(@answers)
+
+    respond_to do |format|
+      format.html
+      format.docx do
+        render docx: "specification.docx", content: @specification_html
+      end
+    end
+  end
+
+  private
+
+  def journey_id
+    params[:journey_id]
+  end
+end

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -5,7 +5,6 @@
 <%= render "resume_journey_notice" %>
 
 <ol class="app-task-list">
-
   <% section_group_with_steps(journey: @journey, steps: @step_presenters).each do |grouping| %>
     <h2 class="app-task-list__section"><%= grouping["title"] %></h2>
     <li>
@@ -14,15 +13,4 @@
   <% end %>
 </ol>
 
-<h1 class="govuk-heading-l"><%= I18n.t("journey.specification.header") %></h1>
-<% unless @journey.all_steps_completed? %>
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-warning-text__assistive">Warning</span>
-      <%= I18n.t("journey.specification.warning") %>
-    </strong>
-  </div>
-<% end %>
-<%= link_to "Download (.docx)", journey_path(@journey, format: :docx), class: "govuk-button" %>
-<%= @specification_html.html_safe %>
+<%= link_to I18n.t("journey.specification.button"), journey_specification_path(@journey), class: "govuk-button" %>

--- a/app/views/pages/planning_start_page.html.erb
+++ b/app/views/pages/planning_start_page.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :title, I18n.t("planning.start_page.page_title") %>
-<%= link_to "Back", root_path, class: "govuk-back-link" %>
+<%= link_to I18n.t("generic.button.back"), root_path, class: "govuk-back-link" %>
 
 <h1 class="govuk-heading-xl"><%= I18n.t("planning.start_page.page_title") %></h1>
 

--- a/app/views/specifications/show.html.erb
+++ b/app/views/specifications/show.html.erb
@@ -1,0 +1,14 @@
+<%= content_for :title, @journey.category.capitalize %>
+
+<h1 class="govuk-heading-xl"><%= I18n.t("journey.specification.header") %></h1>
+<% unless @journey.all_steps_completed? %>
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      <%= I18n.t("journey.specification.warning") %>
+    </strong>
+  </div>
+<% end %>
+<%= link_to "Download (.docx)", journey_specification_path(@journey, format: :docx), class: "govuk-button" %>
+<%= @specification_html.html_safe %>

--- a/app/views/specifications/show.html.erb
+++ b/app/views/specifications/show.html.erb
@@ -1,4 +1,5 @@
 <%= content_for :title, @journey.category.capitalize %>
+<%= link_to I18n.t("generic.button.back"), journey_path(@journey), class: "govuk-back-link" %>
 
 <h1 class="govuk-heading-xl"><%= I18n.t("journey.specification.header") %></h1>
 <% unless @journey.all_steps_completed? %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,35 +3,35 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "cf9010da503c2276ed17469cdc002d84afdc182b5e87adae78716ab10c2eb928",
+      "fingerprint": "9e0249e5929623c7ab1fd850ad5e15b49356e4a7ab235bc0373e98998bd3b321",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
-      "file": "app/views/journeys/show.html.erb",
-      "line": 28,
+      "file": "app/views/specifications/show.html.erb",
+      "line": 15,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Liquid::Template.parse(Journey.find(journey_id).liquid_template, :error_mode => :strict).render(GetAnswersForSteps.new(:visible_steps => Journey.find(journey_id).visible_steps.includes([:radio_answer, :short_text_answer, :long_text_answer, :single_date_answer, :checkbox_answers, :number_answer, :currency_answer])).call)",
       "render_path": [
         {
           "type": "controller",
-          "class": "JourneysController",
+          "class": "SpecificationsController",
           "method": "show",
-          "line": 46,
-          "file": "app/controllers/journeys_controller.rb",
+          "line": 25,
+          "file": "app/controllers/specifications_controller.rb",
           "rendered": {
-            "name": "journeys/show",
-            "file": "app/views/journeys/show.html.erb"
+            "name": "specifications/show",
+            "file": "app/views/specifications/show.html.erb"
           }
         }
       ],
       "location": {
         "type": "template",
-        "template": "journeys/show"
+        "template": "specifications/show"
       },
       "user_input": "Journey.find(journey_id).liquid_template",
       "confidence": "Weak",
       "note": ""
     }
   ],
-  "updated": "2021-02-24 11:55:12 +0000",
+  "updated": "2021-03-11 12:09:01 +0000",
   "brakeman_version": "5.0.0"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
     specification:
       header: "Your specification"
       warning: "You have not completed all the tasks. There may be information missing from your specification."
+      button: "View your specification"
   task_list:
     status:
       not_started: Not started

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
       default: "%-d %b %Y"
   generic:
     button:
+      back: "Back"
       start: "Start"
       next: "Continue"
       change_answer: "Change"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   resource :journey_map, only: [:new]
   resources :journeys, only: [:new, :show] do
+    resource :specification, only: [:show]
     resources :steps, only: [:new, :show, :edit] do
       resources :answers, only: [:create, :update]
     end

--- a/spec/features/visitors/anyone_can_download_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_download_their_catering_specification_spec.rb
@@ -5,6 +5,7 @@ feature "Users can see their catering specification" do
     choose("Catering")
 
     click_on(I18n.t("generic.button.next"))
+    click_on(I18n.t("journey.specification.button"))
 
     expect(page).to have_content(I18n.t("journey.specification.header"))
 

--- a/spec/features/visitors/anyone_can_see_a_planning_start_page_spec.rb
+++ b/spec/features/visitors/anyone_can_see_a_planning_start_page_spec.rb
@@ -50,7 +50,7 @@ feature "Users can see a start page for planning their purchase" do
 
     expect(page).to have_content(I18n.t("planning.start_page.page_title"))
 
-    click_on("Back")
+    click_on(I18n.t("generic.button.back"))
 
     expect(page).to have_content(I18n.t("specifying.start_page.page_title"))
   end

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -16,6 +16,17 @@ feature "Users can see their catering specification" do
     end
   end
 
+  scenario "navigates back to the task list" do
+    stub_contentful_category(fixture_filename: "extended-radio-question.json")
+    visit root_path
+    click_on(I18n.t("generic.button.start"))
+
+    click_on(I18n.t("journey.specification.button"))
+
+    click_on(I18n.t("generic.button.back"))
+    expect(page).to have_content(I18n.t("specifying.start_page.page_title"))
+  end
+
   scenario "renders radio responses that have futher information" do
     stub_contentful_category(fixture_filename: "extended-radio-question.json")
     visit root_path

--- a/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_see_their_catering_specification_spec.rb
@@ -4,6 +4,7 @@ feature "Users can see their catering specification" do
 
     choose("Catering")
     click_on(I18n.t("generic.button.next"))
+    click_on(I18n.t("journey.specification.button"))
 
     expect(page).to have_content(I18n.t("journey.specification.header"))
 
@@ -25,6 +26,7 @@ feature "Users can see their catering specification" do
     choose("Catering")
     fill_in "answer[further_information]", with: "The school needs the kitchen cleaned once a day"
     click_on(I18n.t("generic.button.next"))
+    click_on(I18n.t("journey.specification.button"))
 
     expect(page).to have_content(I18n.t("journey.specification.header"))
 
@@ -47,6 +49,7 @@ feature "Users can see their catering specification" do
     fill_in "answer[no_further_information]", with: "More info for no"
 
     click_on(I18n.t("generic.button.next"))
+    click_on(I18n.t("journey.specification.button"))
 
     expect(page).to have_content(I18n.t("journey.specification.header"))
 
@@ -66,6 +69,7 @@ feature "Users can see their catering specification" do
     click_first_link_in_task_list
 
     click_on("None of the above")
+    click_on(I18n.t("journey.specification.button"))
 
     expect(page).to have_content("Skipped question detected")
   end
@@ -78,6 +82,7 @@ feature "Users can see their catering specification" do
 
       # Don't answer any questions to create a in progress spec
 
+      click_on(I18n.t("journey.specification.button"))
       expect(page).to have_content("You have not completed all the tasks. There may be information missing from your specification.")
     end
   end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Move the specification, the warning and the download button away from the task list and onto its own page.

Include a back link so the user can return to the task list, using the pattern we added for the planning start page.

## Screenshots of UI changes

![Screenshot_2021-03-10 Catering](https://user-images.githubusercontent.com/912473/110671258-37867b00-81c6-11eb-8997-5ada97450de5.png)
![Screenshot_2021-03-10 Catering(1)](https://user-images.githubusercontent.com/912473/110671284-3d7c5c00-81c6-11eb-8a17-f8543abee7ce.png)

