### PR TITLE
(465) Further information is now saved for options with commas (or other special characters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - checkbox answers that are skipped can be identified in the specification
 - fix branching so multiple rules can show the same question
 - the specification lives on it's own page, separate to the task list
+- fix checkbox questions where further information couldn't be saved for an option that included a special character
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -2,6 +2,7 @@
 
 class AnswersController < ApplicationController
   include DateHelper
+  include AnswerHelper
 
   def create
     @journey = Journey.find(journey_id)
@@ -59,7 +60,8 @@ class AnswersController < ApplicationController
 
     if @step.options
       allowed_further_information_keys = @step.options.map { |option|
-        "#{option["value"].tr(" ", "_").downcase}_further_information".to_sym
+        key = machine_readable_option(string: option["value"])
+        "#{key}_further_information".to_sym
       }
     end
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -168,11 +168,15 @@ feature "Anyone can start a journey" do
           fill_in "answer[yes_further_information]", with: "The first piece of further information"
 
           check("No")
-          expect(page).not_to have_content("No_further_information") # It should not create a label which one isn't specified
+          expect(page).not_to have_content("No_further_information") # It should not create a label when text for one isn't provided
           within("span.govuk-visually-hidden") do
             expect(page).to have_content("Optional further information") # Default the hidden label to something understandable for screen readers
           end
           fill_in "answer[no_further_information]", with: "A second piece of further information"
+
+          # We are testing a value that includes a comma
+          check("Other, please specify")
+          fill_in "answer[other_please_specify_further_information]", with: "Other information"
 
           click_on(I18n.t("generic.button.next"))
 
@@ -185,6 +189,10 @@ feature "Anyone can start a journey" do
           expect(page).to have_checked_field("No")
           expect(find_field("answer-no-further-information-field").value)
             .to eql("A second piece of further information")
+
+          expect(page).to have_checked_field("Other, please specify")
+          expect(find_field("answer-other-please-specify-further-information-field").value)
+            .to eql("Other information")
         end
       end
 

--- a/spec/fixtures/contentful/steps/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/steps/extended-checkboxes-question.json
@@ -41,6 +41,11 @@
             {
                 "value": "No",
                 "display_further_information": true
+            },
+            {
+                "value": "Other, please specify",
+                "further_information_help_text": "Tell us all about it",
+                "display_further_information": true
             }
         ],
         "alwaysShowTheUser": true


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

We were accidentally blocking further information `params` as the key didn't match an expected pattern. This caused them not to be saved on the record and the choice appeared to be ignored because we don't raise when an unexpected param was found (maybe we should?).

Flesh out the feature test to cover this regression with the "Other, please specify" option that's used a lot on live.

## Screenshots of UI changes

This value is now being persisted and is visible when returning to the question:

![Screenshot 2021-03-11 at 11 56 15](https://user-images.githubusercontent.com/912473/110783806-d19b0180-8260-11eb-9c1a-2d1474673798.png)
![Screenshot 2021-03-11 at 11 56 22](https://user-images.githubusercontent.com/912473/110783808-d19b0180-8260-11eb-918b-a5ec8b9c4b2f.png)
