### PR TITLE
Prevent sensitive files that may be comitted by accident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ crash.log
 *.tfvars
 .terraformrc
 terraform.rc
+
+# Data dumps (might lead to accidental data breach)
+*.dump
+*.sql
+*.csv
+*.xls


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

This was a recent learning from a dxw incident review to protect contributors from accidentally committing files that include sensitive information to GitHub.