### PR TITLE
(467) Fix Branching so that questions can still be hidden when any child node includes **multiple** rules

### DIFF
--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -61,7 +61,7 @@ class ToggleAdditionalSteps
 
         all_next_step_ids = next_step.additional_step_rules.map { |rule|
           rule.fetch("question_identifiers", nil)
-        }
+        }.flatten
         all_next_steps = journey_steps.where(contentful_id: all_next_step_ids)
 
         recursively_hide_additional_steps!(

--- a/spec/services/toggle_additional_steps_spec.rb
+++ b/spec/services/toggle_additional_steps_spec.rb
@@ -142,6 +142,51 @@ RSpec.describe ToggleAdditionalSteps do
         end
       end
 
+      context "when a branching question has multiple branches itself" do
+        it "should hide itself and all connected branches" do
+          step = create(:step,
+            :radio,
+            journey: journey,
+            additional_step_rules: [
+              {"required_answer" => "Red", "question_identifiers" => ["123"]},
+              {"required_answer" => "Blue", "question_identifiers" => ["456"]}
+            ],
+            hidden: false)
+
+          create(:radio_answer, step: step, response: "Blue")
+
+          first_step_to_hide = create(:step,
+            :radio,
+            journey: journey,
+            contentful_id: "123",
+            additional_step_rules: [
+              {"required_answer" => "Yellow", "question_identifiers" => ["8"]},
+              {"required_answer" => "Green", "question_identifiers" => ["9"]}
+            ],
+            hidden: false)
+
+          second_step_to_hide = create(:step,
+            :radio,
+            journey: journey,
+            contentful_id: "8",
+            additional_step_rules: [],
+            hidden: false)
+
+          third_step_to_hide = create(:step,
+            :radio,
+            journey: journey,
+            contentful_id: "9",
+            additional_step_rules: [],
+            hidden: false)
+
+          described_class.new(step: step).call
+
+          expect(first_step_to_hide.reload.hidden).to eq(true)
+          expect(second_step_to_hide.reload.hidden).to eq(true)
+          expect(third_step_to_hide.reload.hidden).to eq(true)
+        end
+      end
+
       context "when a branching question is shown based on more than on matching answer" do
         it "continues to show the next step (rather than hiding it again when it doesn't match the second rule)" do
           step = create(:step,


### PR DESCRIPTION
Before this change any branches that had child nodes with had a _single_ rule worked fine.

When any child node had _more than one_ rule then we got a `TypeError: can't cast Array` [1].

This was happening because `journey_steps.where(contentful_id: [["8"]])` returns an object called `Step::ActiveRecord_AssociationRelation` which is automatically presented as an array of objects.

The problem comes when a second ID is passed and `flatten` isn't used: `journey_steps.where(contentful_id: [["8"], ["9"]])`. This code only returns a `Step::ActiveRecord_AssociationRelation` object and doesn't present itself as an array of steps. This fails to query for steps but doesn't explode. We see the problem when we then call `.update` upon it.

[1] https://rollbar.com/dxw/dfe-buy-for-your-school/items/91/?item_page=0&item_count=100&#traceback
