### PR TITLE
(398) Specification document includes incomplete warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - the specification lives on it's own page, separate to the task list
 - fix checkbox questions where further information couldn't be saved for an option that included a special character
 - further information for options that include special characters is now available to the specification
+- incomplete specification documents include a warning within the document as well as the file name
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -24,9 +24,10 @@ class SpecificationsController < ApplicationController
     respond_to do |format|
       format.html
       format.docx do
+        file_name = @journey.all_steps_completed? ? "specification.docx" : "specification-incomplete.docx"
         document_html = specification_renderer.to_document_html(journey_complete: @journey.all_steps_completed?)
 
-        render docx: "specification.docx", content: document_html
+        render docx: file_name, content: document_html
       end
     end
   end

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -24,7 +24,9 @@ class SpecificationsController < ApplicationController
     respond_to do |format|
       format.html
       format.docx do
-        render docx: "specification.docx", content: @specification_html
+        document_html = specification_renderer.to_document_html(journey_complete: @journey.all_steps_completed?)
+
+        render docx: "specification.docx", content: document_html
       end
     end
   end

--- a/app/services/specification_renderer.rb
+++ b/app/services/specification_renderer.rb
@@ -9,4 +9,12 @@ class SpecificationRenderer
   def to_html
     @template.render(@answers).html_safe
   end
+
+  def to_document_html(journey_complete:)
+    document_html = @template.render(@answers)
+    unless journey_complete
+      document_html.prepend(I18n.t("journey.specification.download.warning.incomplete"))
+    end
+    document_html
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,10 @@ en:
       header: "Your specification"
       warning: "You have not completed all the tasks. There may be information missing from your specification."
       button: "View your specification"
+      download:
+        warning:
+          incomplete: "<article id='warning'><p></b>You have not completed all the tasks in Create a specification. There may be information missing from your specification.</b></p></article>"
+  specification:
   task_list:
     status:
       not_started: Not started

--- a/spec/features/visitors/anyone_can_download_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_download_their_catering_specification_spec.rb
@@ -48,6 +48,8 @@ feature "Users can see their catering specification" do
         .and_call_original
 
       click_on("Download (.docx)")
+
+      expect(page.response_headers["Content-Disposition"]).to match(/filename="specification-incomplete.docx"/)
     end
   end
 end

--- a/spec/features/visitors/anyone_can_download_their_catering_specification_spec.rb
+++ b/spec/features/visitors/anyone_can_download_their_catering_specification_spec.rb
@@ -1,19 +1,53 @@
 feature "Users can see their catering specification" do
-  scenario "HTML" do
-    start_journey_from_category_and_go_to_question(category: "category-with-liquid-template.json")
+  context "when the journey has been completed" do
+    scenario "HTML" do
+      start_journey_from_category_and_go_to_question(category: "category-with-liquid-template.json")
 
-    choose("Catering")
+      common_specification_html = "<article id='specification'><h1>Liquid </h1></article>"
+      expect(Htmltoword::Document)
+        .to receive(:create)
+        .with(common_specification_html, nil, false)
+        .and_call_original
 
-    click_on(I18n.t("generic.button.next"))
-    click_on(I18n.t("journey.specification.button"))
+      choose("Catering")
 
-    expect(page).to have_content(I18n.t("journey.specification.header"))
+      click_on(I18n.t("generic.button.next"))
 
-    click_on("Download (.docx)")
+      click_on(I18n.t("journey.specification.button"))
 
-    expect(page.response_headers["Content-Type"]).to eql("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
-    header = page.response_headers["Content-Disposition"]
-    expect(header).to match(/^attachment/)
-    expect(header).to match(/filename="specification.docx"/)
+      expect(page).to have_content(I18n.t("journey.specification.header"))
+
+      click_on("Download (.docx)")
+
+      expect(page.response_headers["Content-Type"]).to eql("application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+      header = page.response_headers["Content-Disposition"]
+      expect(header).to match(/^attachment/)
+      expect(header).to match(/filename="specification.docx"/)
+    end
+  end
+
+  context "when the journey has not yet been completed" do
+    scenario "includes an incomple warning" do
+      stub_contentful_category(
+        fixture_filename: "category-with-liquid-template.json"
+      )
+
+      visit root_path
+      click_on(I18n.t("generic.button.start"))
+
+      # Omit answering a question to simulate an incomplete spec
+
+      click_on(I18n.t("journey.specification.button"))
+
+      warning_html = I18n.t("journey.specification.download.warning.incomplete")
+      common_specification_html = "<article id='specification'><h1>Liquid </h1></article>"
+      expect(page).not_to have_content(Nokogiri::HTML(warning_html).text)
+      expect(Htmltoword::Document)
+        .to receive(:create)
+        .with(common_specification_html.prepend(warning_html), nil, false)
+        .and_call_original
+
+      click_on("Download (.docx)")
+    end
   end
 end

--- a/spec/services/specification_renderer_spec.rb
+++ b/spec/services/specification_renderer_spec.rb
@@ -12,4 +12,34 @@ RSpec.describe SpecificationRenderer do
       expect(renderer.to_html).to eql('<p>HTML paragraph rendering a variable: "variable value"</p>')
     end
   end
+
+  describe "#to_document_html" do
+    context "when the journey is complete" do
+      it "renders HTML for use in rendering a docx file" do
+        renderer = described_class.new(
+          template: '<p>HTML paragraph rendering a variable: "{{ variable_name }}"</p>',
+          answers: {
+            "variable_name" => "variable value"
+          }
+        )
+        expect(renderer.to_document_html(journey_complete: true))
+          .to eql('<p>HTML paragraph rendering a variable: "variable value"</p>')
+      end
+    end
+
+    context "when the journey is NOT complete" do
+      it "renders HTML with an extra warning for use in rendering a docx file" do
+        renderer = described_class.new(
+          template: '<p>HTML paragraph rendering a variable: "{{ variable_name }}"</p>',
+          answers: {
+            "variable_name" => "variable value"
+          }
+        )
+        warning_html = I18n.t("journey.specification.download.warning.incomplete")
+        common_html = '<p>HTML paragraph rendering a variable: "variable value"</p>'
+        expect(renderer.to_document_html(journey_complete: false))
+          .to eql(warning_html + common_html)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

We change the filename and include a simple paragraph at the top of the document which cannot intentionally or accidentally  reordered by the `specification_template`.

[The language used is taken from this document that the content team prepared](https://docs.google.com/document/d/11BOARCY9u6p846oS_NGq0hm3RE2EOOcBzFUyjarejt0/edit).

I'm unhappy with the feature test and the subsequant lack of complete coverage we have. [I've explained the different options I went through on the commit](https://github.com/DFE-Digital/buy-for-your-school/pull/227/commits/d4bab9cef9c8df183afb7e7756f3a9467c023e78). If there's a way anyone can think to improve this without changing the testing stack to include a non headless config I'd love to hear it!

## Screenshots of UI changes

### Before

Note the filename doesn't include "incomplete":

![Screenshot 2021-03-15 at 15 36 14](https://user-images.githubusercontent.com/912473/111179725-41ccbe80-85a4-11eb-9281-1b26605a63fe.png)

No warning at the top of the file:

![Screenshot 2021-03-15 at 15 36 22](https://user-images.githubusercontent.com/912473/111179722-41342800-85a4-11eb-89c9-78b7c3927ceb.png)

### After


![Screenshot 2021-03-15 at 15 02 44](https://user-images.githubusercontent.com/912473/111179738-44c7af00-85a4-11eb-88d2-fd6dd9a3d50c.png)

![Screenshot 2021-03-15 at 15 13 27](https://user-images.githubusercontent.com/912473/111179737-442f1880-85a4-11eb-99d3-9050754f48fd.png)
