### PR TITLE
Further info for variables with special chars is available to the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix branching so multiple rules can show the same question
 - the specification lives on it's own page, separate to the task list
 - fix checkbox questions where further information couldn't be saved for an option that included a special character
+- further information for options that include special characters is now available to the specification
 
 ## [release-005] - 2021-1-19
 

--- a/app/presenters/checkboxes_answer_presenter.rb
+++ b/app/presenters/checkboxes_answer_presenter.rb
@@ -1,4 +1,6 @@
 class CheckboxesAnswerPresenter < SimpleDelegator
+  include AnswerHelper
+
   def response
     super.reject(&:blank?)
   end
@@ -22,7 +24,7 @@ class CheckboxesAnswerPresenter < SimpleDelegator
     return [] if response.empty?
 
     response.each_with_object([]) do |human_readable_choice, array|
-      machine_readable_key = human_readable_choice.parameterize.to_sym
+      machine_readable_key = machine_readable_option(string: human_readable_choice).to_sym
       matching_further_information = further_information&.fetch("#{machine_readable_key}_further_information", nil)
 
       array << {

--- a/spec/presenters/checkboxes_answer_presenter_spec.rb
+++ b/spec/presenters/checkboxes_answer_presenter_spec.rb
@@ -67,5 +67,26 @@ RSpec.describe CheckboxesAnswerPresenter do
         expect(presenter.to_param).to include({skipped: true})
       end
     end
+
+    context "when the option includes special characters" do
+      it "the further_information is correctly returned" do
+        step = build(:checkbox_answers,
+          response: ["Other, please specify"],
+          further_information: {"other_please_specify_further_information": "Sinks and stuff"})
+        presenter = described_class.new(step)
+        expect(presenter.to_param).to eql({
+          response: ["Other, please specify"],
+          skipped: false,
+          concatenated_response: "Other, please specify",
+          selected_answers: [
+            {
+              machine_value: :other_please_specify,
+              human_value: "Other, please specify",
+              further_information: "Sinks and stuff"
+            }
+          ]
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Looks like the application of the `parameterize` method with it's parameters were not applied everywhere and our test suite had holes in it for keys that had special characters! 

`other-please-specify_further_information` did not equal the expected pattern of `other_please_specify_further_information` so no value was added to the variables given to Liquid. 

We reuse the `AnswerHelper` and this time check that `parameterize` is no longer defined in the rest of the code base. The test case covers an exact case from live.
