### PR TITLE
Flash messages can be shown as notification banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - incomplete specification documents include a warning within the document as well as the file name
 - users return to the same place in the task list after answering a question
 - fix extended radio questions so that further_information can be remembered when it can be provided through multiple fields
+- flash messages can be shown in notification banners
 
 ## [release-005] - 2021-1-19
 

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -1,9 +1,16 @@
-<% # Rails flash messages styled for Bootstrap 4.0 %>
 <% flash.each do |name, msg| %>
   <% if msg.is_a?(String) %>
-    <div class="alert alert-<%= name.to_s == "notice" ? "success" : "danger" %>" role="alert">
-      <button aria-hidden="true" class="close" data-dismiss="alert" type="button">&times;</button>
-      <%= content_tag :div, msg, id: "flash_#{name}" %>
+    <div class="govuk-notification-banner govuk-notification-banner--<%= name %>" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          <%= name.capitalize %>
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <h3 class="govuk-notification-banner__heading">
+          <%= content_tag :div, msg, id: "flash_#{name}" %>
+        </h3>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,6 +67,7 @@
         </p>
       </div>
       <main class="govuk-main-wrapper " id="main-content" role="main">
+        <%= render partial: "layouts/messages" %>
         <%= yield %>
       </main>
     </div>


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- We add the existing (but unused) messages partial into the layout
- Flash messages can now be set by controllers that will appear as an undissmisable notification banner
- Use design system styling for the notificaiton component

![Screenshot 2021-03-17 at 16 38 24](https://user-images.githubusercontent.com/912473/111504484-9e181580-873f-11eb-92f3-ae7c7803398f.png)
