### PR TITLE
Fix checkbox answer to save choices after previously skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users return to the same place in the task list after answering a question
 - fix extended radio questions so that further_information can be remembered when it can be provided through multiple fields
 - flash messages can be shown in notification banners
+- fix checkbox answer to save choices after previously skipping
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -76,6 +76,11 @@ class AnswersController < ApplicationController
 
     all_params = answer_params.permit(:response, response: [])
     all_params[:further_information] = further_information
+
+    if @step.contentful_type == "checkboxes"
+      all_params[:skipped] = false
+    end
+
     all_params
   end
 

--- a/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
+++ b/spec/features/visitors/anyone_can_complete_a_journey_spec.rb
@@ -339,6 +339,26 @@ feature "Anyone can start a journey" do
       expect(page).not_to have_checked_field("Lunch")
       expect(CheckboxAnswers.last.skipped).to be true
     end
+
+    context "when the question has already been skipped" do
+      scenario "selecting an answer marks the question as not being skipped" do
+        start_journey_from_category_and_go_to_question(category: "skippable-checkboxes-question.json")
+
+        click_on("None of the above")
+
+        within(".app-task-list") do
+          expect(page).to have_content("Complete")
+        end
+
+        click_first_link_in_task_list
+
+        check("Lunch")
+        check("Dinner")
+        click_on(I18n.t("generic.button.update"))
+
+        expect(CheckboxAnswers.last.skipped).to be false
+      end
+    end
   end
 
   context "when the Contentful model is of type staticContent" do


### PR DESCRIPTION
## Changes in this PR

When a checkbox answer was skipped, any later updates to this answer were not saving. `further_information_params` was only setting the skipped value to true. It now reassigns the skipped value to false when any checkbox choices are later selected.

