### PR TITLE
Add a new dashboard page with ability to create new specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix checkbox answer to save choices after previously skipping
 - users can sign in using DfE Sign-in
 - users can sign out using DfE Sign-in
+- add new dashboard page with the ability to create new specifications
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,4 @@
+class DashboardController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,7 +13,7 @@ class SessionsController < ApplicationController
     UserSession.new(session: session)
       .persist_successful_dfe_sign_in_claim!(omniauth_hash: auth_hash)
 
-    redirect_to new_journey_path
+    redirect_to dashboard_path
   end
   alias_method :bypass_callback, :create
 

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,0 +1,10 @@
+<%= content_for :title, I18n.t("dashboard.header") %>
+<%= link_to I18n.t("generic.button.back"), root_path, class: "govuk-back-link" %>
+
+<h1 class="govuk-heading-xl"><%= I18n.t("dashboard.header") %></h1>
+
+<h2 class="govuk-heading-m"><%= I18n.t("dashboard.create.header") %></h2>
+
+<p class="govuk-body"><%= I18n.t("dashboard.create.body") %></p>
+
+<%= link_to I18n.t("dashboard.create.link"), new_journey_path, class: "govuk-link" %>

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -1,5 +1,6 @@
 <%= content_for :title, @journey.category.capitalize %>
 
+<%= link_to I18n.t("generic.button.back"), dashboard_path, class: "govuk-back-link" %>
 <h1 class="govuk-heading-xl"><%= I18n.t("specifying.start_page.page_title") %></h1>
 
 <%= render "resume_journey_notice" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,12 @@ en:
         warning:
           incomplete: "<article id='warning'><p></b>You have not completed all the tasks in Create a specification. There may be information missing from your specification.</b></p></article>"
   specification:
+  dashboard:
+    header: "Specifications dashboard"
+    create:
+      header: "Create a new specification"
+      body: "Create a new specification for a catering procurement."
+      link: "Create a new specification"
   task_list:
     status:
       not_started: Not started

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,4 +29,6 @@ Rails.application.routes.draw do
   namespace :preview do
     resources :entries, only: [:show]
   end
+
+  get "dashboard", to: "dashboard#show"
 end

--- a/spec/features/school_buying_professionals/complete_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/complete_a_journey_spec.rb
@@ -11,9 +11,7 @@ feature "Anyone can start a journey" do
   end
 
   scenario "Start page includes a call to action" do
-    stub_contentful_category(fixture_filename: "radio-question.json")
-
-    user_starts_the_journey
+    start_journey_from_category(category: "radio-question.json")
 
     expect(page).to have_content(I18n.t("specifying.start_page.page_title"))
     expect(page).to have_content("Which service do you need?")
@@ -363,11 +361,7 @@ feature "Anyone can start a journey" do
   context "when the Contentful model is of type staticContent" do
     context "when Contentful entry is of type paragraphs" do
       scenario "the content is not displayed in the task list" do
-        stub_contentful_category(fixture_filename: "static-content.json")
-
-        visit root_path
-
-        click_on(I18n.t("generic.button.start"))
+        start_journey_from_category(category: "static-content.json")
 
         # We should really remove static content entirely, since it doesn't
         # appear in the task list pattern.
@@ -454,11 +448,7 @@ feature "Anyone can start a journey" do
 
   context "when the Liquid template was invalid" do
     it "raises an error" do
-      stub_contentful_category(fixture_filename: "category-with-invalid-liquid-template.json")
-
-      visit root_path
-
-      click_on(I18n.t("generic.button.start"))
+      start_journey_from_category(category: "category-with-invalid-liquid-template.json")
 
       expect(page).to have_content(I18n.t("errors.specification_template_invalid.page_title"))
       expect(page).to have_content(I18n.t("errors.specification_template_invalid.page_body"))

--- a/spec/features/school_buying_professionals/download_their_catering_specification_spec.rb
+++ b/spec/features/school_buying_professionals/download_their_catering_specification_spec.rb
@@ -30,11 +30,9 @@ feature "Users can see their catering specification" do
 
   context "when the journey has not yet been completed" do
     scenario "includes an incomple warning" do
-      stub_contentful_category(
-        fixture_filename: "category-with-liquid-template.json"
+      start_journey_from_category(
+        category: "category-with-liquid-template.json"
       )
-
-      user_starts_the_journey
 
       # Omit answering a question to simulate an incomplete spec
 

--- a/spec/features/school_buying_professionals/see_their_catering_specification_spec.rb
+++ b/spec/features/school_buying_professionals/see_their_catering_specification_spec.rb
@@ -19,8 +19,7 @@ feature "Users can see their catering specification" do
   end
 
   scenario "navigates back to the task list" do
-    stub_contentful_category(fixture_filename: "extended-radio-question.json")
-    user_starts_the_journey
+    start_journey_from_category(category: "extended-radio-question.json")
 
     click_on(I18n.t("journey.specification.button"))
 
@@ -29,9 +28,7 @@ feature "Users can see their catering specification" do
   end
 
   scenario "renders radio responses that have futher information" do
-    stub_contentful_category(fixture_filename: "extended-radio-question.json")
-    user_starts_the_journey
-    click_first_link_in_task_list
+    start_journey_from_category_and_go_to_question(category: "extended-radio-question.json")
 
     choose("Catering")
     fill_in "answer[catering_further_information]", with: "The school needs the kitchen cleaned once a day"
@@ -47,9 +44,7 @@ feature "Users can see their catering specification" do
   end
 
   scenario "renders checkbox responses that have further information" do
-    stub_contentful_category(fixture_filename: "extended-checkboxes-question.json")
-    user_starts_the_journey
-    click_first_link_in_task_list
+    start_journey_from_category_and_go_to_question(category: "extended-checkboxes-question.json")
 
     check("Yes")
     fill_in "answer[yes_further_information]", with: "More info for yes"
@@ -70,9 +65,7 @@ feature "Users can see their catering specification" do
   end
 
   scenario "questions that are skipped can be identified" do
-    stub_contentful_category(fixture_filename: "skippable-checkboxes-question.json")
-    user_starts_the_journey
-    click_first_link_in_task_list
+    start_journey_from_category_and_go_to_question(category: "skippable-checkboxes-question.json")
 
     click_on("None of the above")
     click_on(I18n.t("journey.specification.button"))
@@ -82,8 +75,7 @@ feature "Users can see their catering specification" do
 
   context "when the spec is incomplete" do
     it "warns the user that the contents are in a partially completed state" do
-      stub_contentful_category(fixture_filename: "extended-radio-question.json")
-      user_starts_the_journey
+      start_journey_from_category(category: "extended-radio-question.json")
 
       # Don't answer any questions to create a in progress spec
 

--- a/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 feature "Anyone can view a dashboard" do
+  before { user_is_signed_in }
+
   around do |example|
     ClimateControl.modify(
       CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID: "contentful-category-entry"

--- a/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
@@ -4,9 +4,7 @@ feature "Users can view the task list" do
   before { user_is_signed_in }
 
   it "tasks are grouped by their section" do
-    stub_contentful_category(fixture_filename: "multiple-sections.json")
-
-    user_starts_the_journey
+    start_journey_from_category(category: "multiple-sections.json")
 
     within(".app-task-list") do
       expect(page).to have_content("Section A")
@@ -52,9 +50,7 @@ feature "Users can view the task list" do
 
   context "When a question has been hidden" do
     it "should not appear in the task list" do
-      stub_contentful_category(fixture_filename: "hidden-field.json")
-
-      user_starts_the_journey
+      start_journey_from_category(category: "hidden-field.json")
 
       expect(page).not_to have_content("You should NOT be able to see this question")
       expect(page).to have_content("You should be able to see this question")

--- a/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
@@ -22,6 +22,14 @@ feature "Users can view the task list" do
     end
   end
 
+  scenario "user can navigate back to the dashboard" do
+    start_journey_from_category(category: "extended-radio-question.json")
+
+    click_on(I18n.t("generic.button.back"))
+
+    expect(page).to have_content(I18n.t("dashboard.header"))
+  end
+
   context "When a question has been answered" do
     scenario "The task is marked as completed" do
       stub_contentful_category(fixture_filename: "multiple-sections.json")

--- a/spec/features/visitors/anyone_can_sign_in_with_dfe_sign_in_spec.rb
+++ b/spec/features/visitors/anyone_can_sign_in_with_dfe_sign_in_spec.rb
@@ -60,7 +60,7 @@ feature "Anyone can sign in with DfE Sign-in" do
       .with("Sign in failed unexpectedly")
       .and_call_original
 
-    user_starts_the_journey
+    visit dashboard_path
 
     expect(page).to have_content(I18n.t("errors.sign_in.unexpected_failure.page_title"))
     expect(page).to have_content(I18n.t("errors.sign_in.unexpected_failure.page_body"))

--- a/spec/features/visitors/anyone_can_view_a_dashboard_spec.rb
+++ b/spec/features/visitors/anyone_can_view_a_dashboard_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+feature "Anyone can view a dashboard" do
+  around do |example|
+    ClimateControl.modify(
+      CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID: "contentful-category-entry"
+    ) do
+      example.run
+    end
+  end
+
+  scenario "Dashboard displays the title" do
+    visit dashboard_path
+
+    expect(page).to have_content(I18n.t("dashboard.header"))
+  end
+
+  scenario "Dashboard prompts user to start a new journey" do
+    stub_contentful_category(fixture_filename: "radio-question.json")
+
+    visit dashboard_path
+
+    expect(page).to have_content(I18n.t("dashboard.create.header"))
+    expect(page).to have_content(I18n.t("dashboard.create.body"))
+
+    click_on(I18n.t("dashboard.create.link"))
+
+    expect(page).to have_content(I18n.t("specifying.start_page.page_title"))
+    expect(page).to have_content("Which service do you need?")
+    expect(page).to have_content("Not started")
+  end
+end

--- a/spec/features/visitors/see_a_specification_start_page_spec.rb
+++ b/spec/features/visitors/see_a_specification_start_page_spec.rb
@@ -35,4 +35,12 @@ feature "Users can see a start page for specifying their purchase" do
 
     expect(page).to have_content(I18n.t("specifying.start_page.pause_and_resume_body"))
   end
+
+  scenario "The start button takes the user to the dashboard" do
+    visit root_path
+
+    click_on(I18n.t("generic.button.start"))
+
+    expect(page).to have_content(I18n.t("dashboard.header"))
+  end
 end

--- a/spec/support/journey_helpers.rb
+++ b/spec/support/journey_helpers.rb
@@ -5,12 +5,16 @@ module JourneyHelpers
     end
   end
 
-  def start_journey_from_category_and_go_to_question(category:)
+  def start_journey_from_category(category:)
     stub_contentful_category(
       fixture_filename: category
     )
 
     user_signs_in_and_starts_the_journey
+  end
+
+  def start_journey_from_category_and_go_to_question(category:)
+    start_journey_from_category(category: category)
 
     click_first_link_in_task_list
   end

--- a/spec/support/sign_in_helpers.rb
+++ b/spec/support/sign_in_helpers.rb
@@ -13,8 +13,8 @@ module SignInHelpers
   end
 
   def user_starts_the_journey
-    visit root_path
-    click_link I18n.t("generic.button.start")
+    visit dashboard_path
+    click_link I18n.t("dashboard.create.link")
   end
 
   def user_signs_in_and_starts_the_journey


### PR DESCRIPTION
## Changes in this PR

After sign in, users are now sent to the Specification Dashboard (instead of starting a new spec), from where they can choose to create a new specification.

A subsequent PR will add the ability to view existing specifications.

## Screenshots of new UI

![localhost_3000_dashboard (1)](https://user-images.githubusercontent.com/619082/112013757-33415280-8b22-11eb-8888-00e4bf1b16f7.png)
