### PR TITLE
Existing specifications can be viewed from the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - users can sign in using DfE Sign-in
 - users can sign out using DfE Sign-in
 - add new dashboard page with the ability to create new specifications
+- users can only see their past journeys from the dashboard
 
 ## [release-005] - 2021-1-19
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AnswersController < ApplicationController
+  before_action :check_user_belongs_to_journey?
+
   include DateHelper
   include AnswerHelper
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -7,7 +7,7 @@ class AnswersController < ApplicationController
   include AnswerHelper
 
   def create
-    @journey = Journey.find(journey_id)
+    @journey = current_journey
     @step = Step.find(step_id)
     @step_presenter = StepPresenter.new(@step)
 
@@ -29,7 +29,7 @@ class AnswersController < ApplicationController
   end
 
   def update
-    @journey = Journey.find(journey_id)
+    @journey = current_journey
     @step = Step.find(step_id)
     @step_presenter = StepPresenter.new(@step)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,4 +29,14 @@ class ApplicationController < ActionController::Base
     session.delete(:dfe_sign_in_uid)
     redirect_to new_dfe_path
   end
+
+  def current_journey
+    journey_id = params[:journey_id].present? ? params[:journey_id] : params[:id]
+    @current_journey ||= Journey.find(journey_id)
+  end
+
+  def check_user_belongs_to_journey?
+    return true if current_journey.user == current_user
+    render file: "public/404.html", status: :not_found, layout: false
+  end
 end

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -17,6 +17,10 @@ class JourneysController < ApplicationController
     render "errors/contentful_entry_not_found", status: 500
   end
 
+  def index
+    @journeys = Journey.all
+  end
+
   def new
     journey = CreateJourney.new(category_name: "catering").call
     redirect_to journey_path(journey)

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -29,7 +29,7 @@ class JourneysController < ApplicationController
   end
 
   def show
-    @journey = Journey.find(journey_id)
+    @journey = current_journey
     @visible_steps = @journey.visible_steps.includes([
       :radio_answer,
       :short_text_answer,

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -22,7 +22,7 @@ class JourneysController < ApplicationController
   end
 
   def new
-    journey = CreateJourney.new(category_name: "catering").call
+    journey = CreateJourney.new(category_name: "catering", user: current_user).call
     redirect_to journey_path(journey)
   end
 

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class JourneysController < ApplicationController
+  before_action :check_user_belongs_to_journey?, only: %w[show]
+
   rescue_from GetCategory::InvalidLiquidSyntax do |exception|
     render "errors/specification_template_invalid", status: 500, locals: {error: exception}
   end

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -18,7 +18,7 @@ class JourneysController < ApplicationController
   end
 
   def index
-    @journeys = Journey.all
+    @journeys = current_user.journeys
   end
 
   def new

--- a/app/controllers/preview/entries_controller.rb
+++ b/app/controllers/preview/entries_controller.rb
@@ -1,6 +1,11 @@
 class Preview::EntriesController < ApplicationController
   def show
-    @journey = Journey.create(category: "catering", liquid_template: "<p>N/A</p>")
+    @journey = Journey.create(
+      category: "catering",
+      user: current_user,
+      liquid_template: "<p>N/A</p>"
+    )
+
     contentful_entry = GetEntry.new(entry_id: entry_id).call
     @step = CreateJourneyStep.new(
       journey: @journey, contentful_entry: contentful_entry

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SpecificationsController < ApplicationController
+  before_action :check_user_belongs_to_journey?
+
   def show
     @journey = Journey.find(journey_id)
     @visible_steps = @journey.visible_steps.includes([

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -4,7 +4,7 @@ class SpecificationsController < ApplicationController
   before_action :check_user_belongs_to_journey?
 
   def show
-    @journey = Journey.find(journey_id)
+    @journey = current_journey
     @visible_steps = @journey.visible_steps.includes([
       :radio_answer,
       :short_text_answer,

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class StepsController < ApplicationController
+  before_action :check_user_belongs_to_journey?
+
   def show
     @journey = Journey.find(journey_id)
 

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -4,7 +4,7 @@ class StepsController < ApplicationController
   before_action :check_user_belongs_to_journey?
 
   def show
-    @journey = Journey.find(journey_id)
+    @journey = current_journey
 
     @step = Step.find(params[:id])
     @step_presenter = StepPresenter.new(@step)
@@ -15,7 +15,7 @@ class StepsController < ApplicationController
   end
 
   def edit
-    @journey = Journey.find(journey_id)
+    @journey = current_journey
 
     @step = Step.find(params[:id])
     @step_presenter = StepPresenter.new(@step)

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -3,7 +3,7 @@ class Journey < ApplicationRecord
   has_many :steps
   has_many :visible_steps, -> { where(steps: {hidden: false}) }, class_name: "Step"
 
-  validates :liquid_template, presence: true
+  validates :category, :liquid_template, presence: true
 
   def all_steps_completed?
     visible_steps.all? { |step| step.answer.present? }

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -2,6 +2,7 @@ class Journey < ApplicationRecord
   self.implicit_order_column = "created_at"
   has_many :steps
   has_many :visible_steps, -> { where(steps: {hidden: false}) }, class_name: "Step"
+  belongs_to :user
 
   validates :category, :liquid_template, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ApplicationRecord
   self.implicit_order_column = "created_at"
+
+  has_many :journeys
 end

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -1,8 +1,9 @@
 class CreateJourney
-  attr_accessor :category_name
+  attr_accessor :category_name, :user
 
-  def initialize(category_name:)
+  def initialize(category_name:, user:)
     self.category_name = category_name
+    self.user = user
   end
 
   def call
@@ -10,7 +11,8 @@ class CreateJourney
     sections = GetSectionsFromCategory.new(category: category).call
     journey = Journey.new(
       category: category_name,
-      liquid_template: category.specification_template
+      liquid_template: category.specification_template,
+      user: user
     )
 
     journey.section_groups = build_section_groupings(sections: sections)

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -14,7 +14,7 @@ class CreateJourney
     )
 
     journey.section_groups = build_section_groupings(sections: sections)
-    journey.save
+    journey.save!
 
     sections.each do |section|
       question_entries = GetStepsFromSection.new(section: section).call

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,10 +1,26 @@
 <%= content_for :title, I18n.t("dashboard.header") %>
 <%= link_to I18n.t("generic.button.back"), root_path, class: "govuk-back-link" %>
 
-<h1 class="govuk-heading-xl"><%= I18n.t("dashboard.header") %></h1>
+<div class="govuk-grid-row">
 
-<h2 class="govuk-heading-m"><%= I18n.t("dashboard.create.header") %></h2>
+  <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl"><%= I18n.t("dashboard.header") %></h1>
+  </div>
 
-<p class="govuk-body"><%= I18n.t("dashboard.create.body") %></p>
+  <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-m"><%= I18n.t("dashboard.existing.header") %></h2>
+      <p class="govuk-body"><%= I18n.t("dashboard.existing.body") %></p>
+      <ul class="govuk-list">
+        <li><%= link_to I18n.t("dashboard.existing.link"), journeys_path, class: "govuk-link" %></li>
+      </ul>
+  </div>
 
-<%= link_to I18n.t("dashboard.create.link"), new_journey_path, class: "govuk-link" %>
+  <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-m"><%= I18n.t("dashboard.create.header") %></h2>
+      <p class="govuk-body"><%= I18n.t("dashboard.create.body") %></p>
+      <ul class="govuk-list">
+        <li><a href="start_new-specification" class="govuk-link"><%= link_to I18n.t("dashboard.create.link"), new_journey_path, class: "govuk-link" %></a></li>
+      </ul>
+  </div>
+
+  </div>

--- a/app/views/journeys/index.html.erb
+++ b/app/views/journeys/index.html.erb
@@ -1,0 +1,21 @@
+<%= content_for :title, I18n.t("journey.index.existing.header") %>
+<%= link_to I18n.t("generic.button.back"), dashboard_path, class: "govuk-back-link" %>
+
+<h1 class="govuk-heading-xl"><%= I18n.t("journey.index.existing.header") %></h1>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Date started</th>
+      <th scope="col" class="govuk-table__header govuk-table__cell--numeric"> </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @journeys.each do |journey| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= journey.created_at.strftime("%e %B %Y") %></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric"><a href="<%= journey_path(journey) %>" class="govuk-link">Review and edit</a></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,10 @@ en:
       header: "Create a new specification"
       body: "Create a new specification for a catering procurement."
       link: "Create a new specification"
+    existing:
+      header: "Existing specifications"
+      body: "Continue with a draft specification, and review completed specifications."
+      link: "Existing specifications"
   task_list:
     status:
       not_started: Not started

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,9 @@ en:
     errors:
       contentful_entry_not_found: "An unexpected error occurred. The starting step has been revoked by the content team."
   journey:
+    index:
+      existing:
+        header: "Existing specifications"
     specification:
       header: "Your specification"
       warning: "You have not completed all the tasks. There may be information missing from your specification."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   post "/auth/developer/callback" => "sessions#bypass_callback" if Rails.env.development?
 
   resource :journey_map, only: [:new]
-  resources :journeys, only: [:new, :show] do
+  resources :journeys, only: [:index, :new, :show] do
     resource :specification, only: [:show]
     resources :steps, only: [:new, :show, :edit] do
       resources :answers, only: [:create, :update]

--- a/db/migrate/20210325145645_set_up_user_journey_association.rb
+++ b/db/migrate/20210325145645_set_up_user_journey_association.rb
@@ -1,0 +1,7 @@
+class SetUpUserJourneyAssociation < ActiveRecord::Migration[6.1]
+  def change
+    change_table :journeys do |t|
+      t.belongs_to :user, type: :uuid
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_18_105104) do
+ActiveRecord::Schema.define(version: 2021_03_25_145645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -41,6 +41,8 @@ ActiveRecord::Schema.define(version: 2021_03_18_105104) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "liquid_template", null: false
     t.jsonb "section_groups"
+    t.uuid "user_id"
+    t.index ["user_id"], name: "index_journeys_on_user_id"
   end
 
   create_table "long_text_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/journey.rb
+++ b/spec/factories/journey.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
     liquid_template { "Your answer was {{ answer_47EI2X2T5EDTpJX9WjRR9p }}" }
     section_groups { [] }
 
+    association :user, factory: :user
+
     trait :catering do
       category { "catering" }
     end

--- a/spec/features/school_buying_professionals/edit_their_answers_spec.rb
+++ b/spec/features/school_buying_professionals/edit_their_answers_spec.rb
@@ -1,22 +1,26 @@
 require "rails_helper"
 
 feature "Users can edit their answers" do
-  before { user_is_signed_in }
+  let(:user) { create(:user) }
+  before { user_is_signed_in(user: user) }
 
   before do
     journey = answer.step.journey
-    journey.update(section_groups: [
-      {
-        "order" => 0,
-        "title" => "Section A",
-        "steps" => [
-          {
-            "contentful_id" => answer.step.contentful_id,
-            "order" => 0
-          }
-        ]
-      }
-    ])
+    journey.update(
+      user: user,
+      section_groups: [
+        {
+          "order" => 0,
+          "title" => "Section A",
+          "steps" => [
+            {
+              "contentful_id" => answer.step.contentful_id,
+              "order" => 0
+            }
+          ]
+        }
+      ]
+    )
   end
   let(:answer) { create(:short_text_answer, response: "answer") }
 

--- a/spec/features/school_buying_professionals/resume_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/resume_a_journey_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 feature "Users can see how to resume a journey" do
-  before { user_is_signed_in }
+  let(:user) { create(:user) }
+  before { user_is_signed_in(user: user) }
 
   context "on the task list" do
-    let(:journey) { create(:journey) }
+    let(:journey) { create(:journey, user: user) }
 
     scenario "displays the notification banner" do
       visit journey_path(journey)

--- a/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
@@ -17,7 +17,21 @@ feature "Anyone can view a dashboard" do
     expect(page).to have_content(I18n.t("dashboard.header"))
   end
 
-  scenario "Dashboard prompts user to start a new journey" do
+  scenario "user can view existing specifications" do
+    create(:journey, created_at: Time.local(2021, 2, 15, 12, 0, 0))
+
+    visit dashboard_path
+
+    expect(page).to have_content(I18n.t("dashboard.existing.header"))
+    expect(page).to have_content(I18n.t("dashboard.existing.body"))
+
+    click_on(I18n.t("dashboard.existing.link"))
+
+    expect(page).to have_content(I18n.t("journey.index.existing.header"))
+    expect(page).to have_content("15 February 2021")
+  end
+
+  scenario "user can start a new specification" do
     stub_contentful_category(fixture_filename: "radio-question.json")
 
     visit dashboard_path

--- a/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
@@ -18,7 +18,9 @@ feature "Anyone can view a dashboard" do
   end
 
   scenario "user can view existing specifications" do
-    create(:journey, created_at: Time.local(2021, 2, 15, 12, 0, 0))
+    user = create(:user)
+    user_is_signed_in(user: user)
+    create(:journey, user: user, created_at: Time.local(2021, 2, 15, 12, 0, 0))
 
     visit dashboard_path
 

--- a/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 feature "Users can view the task list" do
-  before { user_is_signed_in }
+  let(:user) { create(:user) }
+  before { user_is_signed_in(user: user) }
 
   it "tasks are grouped by their section" do
     start_journey_from_category(category: "multiple-sections.json")
@@ -35,18 +36,21 @@ feature "Users can view the task list" do
       stub_contentful_category(fixture_filename: "multiple-sections.json")
 
       answer = create(:short_text_answer, response: "answer")
-      answer.step.journey.update(section_groups: [
-        {
-          "order" => 0,
-          "title" => "Section A",
-          "steps" => [
-            {
-              "contentful_id" => answer.step.contentful_id,
-              "order" => 0
-            }
-          ]
-        }
-      ])
+      answer.step.journey.update(
+        user: user,
+        section_groups: [
+          {
+            "order" => 0,
+            "title" => "Section A",
+            "steps" => [
+              {
+                "contentful_id" => answer.step.contentful_id,
+                "order" => 0
+              }
+            ]
+          }
+        ]
+      )
 
       user_starts_the_journey
 

--- a/spec/features/school_buying_professionals/view_existing_journeys_spec.rb
+++ b/spec/features/school_buying_professionals/view_existing_journeys_spec.rb
@@ -9,12 +9,37 @@ feature "Users can view their existing journeys" do
   end
 
   it "lists existing journeys" do
-    create(:journey, created_at: Time.local(2021, 2, 15, 12, 0, 0))
-    create(:journey, created_at: Time.local(2021, 3, 20, 12, 0, 0))
+    user = create(:user)
+    user_is_signed_in(user: user)
+    create(:journey, user: user, created_at: Time.local(2021, 2, 15, 12, 0, 0))
+    create(:journey, user: user, created_at: Time.local(2021, 3, 20, 12, 0, 0))
 
     visit journeys_path
 
     expect(page).to have_content("15 February 2021")
     expect(page).to have_content("20 March 2021")
+  end
+
+  context "when the journey does not belong to the user" do
+    scenario "that journey is not shown" do
+      travel_to Time.zone.local(2021, 2, 15, 12, 0, 0)
+
+      another_user = create(:user)
+      _another_users_journey = create(:journey,
+        user: another_user,
+        created_at: Time.local(2021, 3, 20, 12, 0, 0))
+
+      signed_in_user = create(:user)
+      user_is_signed_in(user: signed_in_user)
+
+      # Start the journey which creates a journey record
+      start_journey_from_category(category: "radio-question.json")
+
+      click_on(I18n.t("generic.button.back"))
+      click_on(I18n.t("dashboard.existing.link"))
+
+      expect(page).to have_content("15 February 2021")
+      expect(page).not_to have_content("20 March 2021")
+    end
   end
 end

--- a/spec/features/school_buying_professionals/view_existing_journeys_spec.rb
+++ b/spec/features/school_buying_professionals/view_existing_journeys_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+feature "Users can view their existing journeys" do
+  before { user_is_signed_in }
+
+  it "displays the page header" do
+    visit journeys_path
+    expect(page).to have_content(I18n.t("journey.index.existing.header"))
+  end
+
+  it "lists existing journeys" do
+    create(:journey, created_at: Time.local(2021, 2, 15, 12, 0, 0))
+    create(:journey, created_at: Time.local(2021, 3, 20, 12, 0, 0))
+
+    visit journeys_path
+
+    expect(page).to have_content("15 February 2021")
+    expect(page).to have_content("20 March 2021")
+  end
+end

--- a/spec/features/visitors/anyone_can_sign_in_with_dfe_sign_in_spec.rb
+++ b/spec/features/visitors/anyone_can_sign_in_with_dfe_sign_in_spec.rb
@@ -22,17 +22,15 @@ feature "Anyone can sign in with DfE Sign-in" do
 
       user_exists_in_dfe_sign_in(dsi_uid: user.dfe_sign_in_uid)
       user_starts_the_journey
-
       expect(page).to have_content(I18n.t("specifying.start_page.page_title"))
-
-      visit root_path
 
       # Undo the OmniAuth stub to check we don't require it again
       OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(foo: :bar)
 
-      answer = create(:short_text_answer)
-      visit edit_journey_step_path(answer.step.journey, answer.step)
-      expect(page).to have_content(answer.step.title)
+      journey = create(:journey, user: user)
+      step = create(:step, :radio, journey: journey)
+      visit journey_step_path(journey, step)
+      expect(page).to have_content(step.title)
     end
   end
 

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Journey, type: :model do
   it { should have_many(:steps) }
 
   describe "validations" do
+    it { is_expected.to validate_presence_of(:category) }
     it { is_expected.to validate_presence_of(:liquid_template) }
   end
 

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Authorisation", type: :request do
+  describe "Users can only see journeys they belong to" do
+    context "when the journey IS theirs" do
+      it "returns 200" do
+        journey = create(:journey)
+        user_is_signed_in(user: journey.user)
+
+        get journey_path(journey)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when the journey is NOT theirs" do
+      it "returns 404" do
+        another_user = build(:user)
+        journey = create(:journey)
+        user_is_signed_in(user: another_user)
+
+        get journey_path(journey)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/entry_preview_spec.rb
+++ b/spec/requests/entry_preview_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Entry previews", type: :request do
     entry_id = "123"
     fake_journey = create(:journey)
     expect(Journey).to receive(:create)
-      .with(category: anything, liquid_template: anything)
+      .with(category: anything, user: anything, liquid_template: anything)
       .and_return(fake_journey)
 
     fake_get_contentful_entry = instance_double(Contentful::Entry)

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -59,5 +59,19 @@ RSpec.describe CreateJourney do
         }
       ])
     end
+
+    context "when the journey cannot be saved" do
+      it "raises an error" do
+        stub_contentful_category(
+          fixture_filename: "category-with-liquid-template.json",
+          stub_sections: true,
+          stub_steps: false
+        )
+
+        # Force a validation error by not providing a category_name
+        expect { described_class.new(category_name: nil).call }
+          .to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
   end
 end

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -15,9 +15,21 @@ RSpec.describe CreateJourney do
         fixture_filename: "category-with-no-steps.json",
         stub_steps: false
       )
-      expect { described_class.new(category_name: "catering").call }
+      expect { described_class.new(category_name: "catering", user: build(:user)).call }
         .to change { Journey.count }.by(1)
       expect(Journey.last.category).to eql("catering")
+    end
+
+    it "associates the new journey with the given user" do
+      stub_contentful_category(
+        fixture_filename: "category-with-no-steps.json",
+        stub_steps: false
+      )
+      user = create(:user)
+
+      described_class.new(category_name: "catering", user: user).call
+
+      expect(Journey.last.user).to eq(user)
     end
 
     it "stores a copy of the Liquid template" do
@@ -25,7 +37,7 @@ RSpec.describe CreateJourney do
         fixture_filename: "category-with-liquid-template.json"
       )
 
-      described_class.new(category_name: "catering").call
+      described_class.new(category_name: "catering", user: build(:user)).call
 
       expect(Journey.last.liquid_template)
         .to eql("<article id='specification'><h1>Liquid {{templating}}</h1></article>")
@@ -36,7 +48,7 @@ RSpec.describe CreateJourney do
         fixture_filename: "multiple-sections-and-steps.json"
       )
 
-      described_class.new(category_name: "catering").call
+      described_class.new(category_name: "catering", user: build(:user)).call
 
       journey = Journey.last
 
@@ -69,7 +81,7 @@ RSpec.describe CreateJourney do
         )
 
         # Force a validation error by not providing a category_name
-        expect { described_class.new(category_name: nil).call }
+        expect { described_class.new(category_name: nil, user: build(:user)).call }
           .to raise_error(ActiveRecord::RecordInvalid)
       end
     end

--- a/spec/support/sign_in_helpers.rb
+++ b/spec/support/sign_in_helpers.rb
@@ -22,7 +22,7 @@ module SignInHelpers
     user_starts_the_journey
   end
 
-  def user_is_signed_in(user: anything)
+  def user_is_signed_in(user: build(:user))
     allow_any_instance_of(FindOrCreateUserFromSession)
       .to receive(:call)
       .and_return(user)


### PR DESCRIPTION
**This is based atop #238, which should be merged first.**

<!-- Do you need to update the changelog? -->

## Changes in this PR

* There is a new view which lists all existing specifications
* The dashboard now has a new link to the view of existing specifications
* Every new journey now belongs to a a single User
* Users can only see the journeys (and associated steps and answers) that they belong to
* Improve `CreateJourney` service so it fails loudly if for some reason it can't create a journey we can use

## Screenshots of UI changes

Log in as User A:
![Screenshot_2021-03-22 User Info(1)](https://user-images.githubusercontent.com/912473/112868634-31443a00-90b4-11eb-8bd9-24d2ee477ade.png)
View a single attached journey:
![Screenshot_2021-03-29 Existing specifications](https://user-images.githubusercontent.com/912473/112868647-33a69400-90b4-11eb-917e-d43a42ebc954.png)

Log in as User B
![Screenshot_2021-03-29 User Info](https://user-images.githubusercontent.com/912473/112868608-28ebff00-90b4-11eb-9c83-63d70ebfa17b.png)
View does not contain journey from User A
![Screenshot_2021-03-29 Existing specifications(1)](https://user-images.githubusercontent.com/912473/112868614-2be6ef80-90b4-11eb-99d8-4e8c9734d763.png)

## Next steps

* It should be easier to identify which specification is which
* Distinguish between 'in progress' and 'completed' specifications
