### PR TITLE
Docker build succeeds without needing environment variables

### DIFF
--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -1,5 +1,7 @@
-uri = URI(ENV["APPLICATION_URL"])
+if ENV["APPLICATION_URL"]
+  uri = URI(ENV["APPLICATION_URL"])
 
-Rails.application.routes.default_url_options[:host] = uri.host
-Rails.application.routes.default_url_options[:port] = uri.port
-Rails.application.routes.default_url_options[:protocol] = uri.scheme
+  Rails.application.routes.default_url_options[:host] = uri.host
+  Rails.application.routes.default_url_options[:port] = uri.port
+  Rails.application.routes.default_url_options[:protocol] = uri.scheme
+end


### PR DESCRIPTION
`APPLICATION_URL` was recently added and as an initialiser causes the docker build process to fail.

There is no way to provide a real URL during the build stage since we don't know what environment the docker image will be used in. Instead we guard against this variable being unset and if it is, we do nothing, reverting back to Rails defaults.

When the container is started off this image, the initialisers should re run and have the environment variables available to set this as originally intended.
