### PR TITLE
Load REDIS_URL and other GPaaS variables before initialisation

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Load environment variables that are created by GPaaS
+require_relative "../../lib/vcap_parser"
+VcapParser.load_service_environment_variables!
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/vcap_services.rb
+++ b/config/initializers/vcap_services.rb
@@ -1,2 +1,0 @@
-require "vcap_parser"
-VcapParser.load_service_environment_variables!

--- a/spec/lib/vcap_parser_spec.rb
+++ b/spec/lib/vcap_parser_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "vcap_parser"
 
 RSpec.describe VcapParser do
   describe ".load_service_environment_variables!" do


### PR DESCRIPTION
* The previous implementation had the vcap_parser called in an initialiser. Rails calls these files in alphabetical order [1] which meant it was being run after the redis initialiser. Causing REDIS_URL to be missing
* The Vcap parser only needs to run in the live environment as that's the only place `ENV["VCAP_SERVICES"]` will ever exist.
* I could have numbered the files and ordered vcap before session store but this felt fragile. Someone could easily change the order without realising the consequences.

[1] https://guides.rubyonrails.org/configuring.html#using-initializer-files
