### PR TITLE
(490) Automatically remove stale Journey records

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ ROLLBAR_ENV=development
 DATABASE_URL=postgres://postgres@localhost:5432/buy-for-your-school-development
 REDIS_URL=redis://localhost:6379
 
+# Miscellaneous
+DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR=30
+
 # Contentful
 CONTENTFUL_URL=cdn.contentful.com
 CONTENTFUL_SPACE=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - add new dashboard page with the ability to create new specifications
 - users can only see their past journeys from the dashboard
 - new API endpoint to allow Contentful to invalidate cached entries, allowing caching to stay on which prevents the app from being very slow/crashing on journey start
+- automatically delete Journey and associated records if we deem it to have become stale, to reclaim the unused database rows
 
 ## [release-005] - 2021-1-19
 

--- a/app/jobs/delete_stale_journeys_job.rb
+++ b/app/jobs/delete_stale_journeys_job.rb
@@ -1,0 +1,8 @@
+class DeleteStaleJourneysJob < ApplicationJob
+  queue_as :default
+  sidekiq_options retry: 1
+
+  def perform
+    DeleteStaleJourneys.new.call
+  end
+end

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -13,6 +13,7 @@ class Journey < ApplicationRecord
 
   def freshen!
     attributes = {}
+    attributes[:last_worked_on] = Time.zone.now
     attributes[:started] = true unless started == true
 
     update(attributes)

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -10,4 +10,11 @@ class Journey < ApplicationRecord
   def all_steps_completed?
     visible_steps.all? { |step| step.answer.present? }
   end
+
+  def freshen!
+    attributes = {}
+    attributes[:stale] = false unless stale == false
+
+    update(attributes)
+  end
 end

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -13,7 +13,7 @@ class Journey < ApplicationRecord
 
   def freshen!
     attributes = {}
-    attributes[:stale] = false unless stale == false
+    attributes[:started] = true unless started == true
 
     update(attributes)
   end

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -11,8 +11,9 @@ class CreateJourney
     sections = GetSectionsFromCategory.new(category: category).call
     journey = Journey.new(
       category: category_name,
-      liquid_template: category.specification_template,
-      user: user
+      user: user,
+      started: true,
+      liquid_template: category.specification_template
     )
 
     journey.section_groups = build_section_groupings(sections: sections)

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -13,6 +13,7 @@ class CreateJourney
       category: category_name,
       user: user,
       started: true,
+      last_worked_on: Time.zone.now,
       liquid_template: category.specification_template
     )
 

--- a/app/services/delete_stale_journeys.rb
+++ b/app/services/delete_stale_journeys.rb
@@ -1,0 +1,7 @@
+class DeleteStaleJourneys
+  def call
+    Journey.where(started: false)
+      .where("last_worked_on > ?", 1.month.ago)
+      .destroy_all
+  end
+end

--- a/app/services/delete_stale_journeys.rb
+++ b/app/services/delete_stale_journeys.rb
@@ -1,7 +1,8 @@
 class DeleteStaleJourneys
   def call
-    Journey.where(started: false)
-      .where("last_worked_on > ?", 1.month.ago)
-      .destroy_all
+    qualifying_journeys = Journey.where(started: false)
+      .where("last_worked_on < ?", 1.month.ago)
+    qualifying_journeys.destroy_all
+  end
   end
 end

--- a/app/services/delete_stale_journeys.rb
+++ b/app/services/delete_stale_journeys.rb
@@ -1,8 +1,14 @@
 class DeleteStaleJourneys
   def call
     qualifying_journeys = Journey.where(started: false)
-      .where("last_worked_on < ?", 1.month.ago)
+      .where("last_worked_on < ?", date_a_journey_can_be_inactive_until)
     qualifying_journeys.destroy_all
   end
+
+  private def date_a_journey_can_be_inactive_until
+    return 1.month.ago unless ENV["DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR"].present?
+
+    day_count = ENV["DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR"].to_i
+    day_count.days.ago
   end
 end

--- a/app/services/save_answer.rb
+++ b/app/services/save_answer.rb
@@ -19,6 +19,7 @@ class SaveAnswer
 
     if answer.valid?
       answer.save
+      answer.step.journey.freshen!
       ToggleAdditionalSteps.new(step: answer.step).call
       result.success = true
     end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -6,3 +6,10 @@ warm_contentful_entry_cache:
     provide some resilience to downtime or minor connection issues. As this
     service is used infrequently by real users, we automatically update the
     cache.
+
+delete_stale_journeys:
+  cron: "0 2 * * *"
+  class: "DeleteStaleJourneysJob"
+  description: Automatically remove Journey and associated child records when
+    we identify it as having become stale. This is intended to free up unused
+    database rows given every new specification generates 100-200 rows.

--- a/db/migrate/20210330105313_add_started_state_to_journey.rb
+++ b/db/migrate/20210330105313_add_started_state_to_journey.rb
@@ -1,0 +1,6 @@
+class AddStartedStateToJourney < ActiveRecord::Migration[6.1]
+  def change
+    add_column :journeys, :started, :boolean, default: true
+    add_index :journeys, :started
+  end
+end

--- a/db/migrate/20210330111201_add_stale_time_stamp_to_journey.rb
+++ b/db/migrate/20210330111201_add_stale_time_stamp_to_journey.rb
@@ -1,0 +1,6 @@
+class AddStaleTimeStampToJourney < ActiveRecord::Migration[6.1]
+  def change
+    add_column :journeys, :last_worked_on, :datetime
+    add_index :journeys, :last_worked_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,6 +43,8 @@ ActiveRecord::Schema.define(version: 2021_04_01_100528) do
     t.jsonb "section_groups"
     t.uuid "user_id"
     t.index ["user_id"], name: "index_journeys_on_user_id"
+    t.boolean "started", default: true
+    t.index ["started"], name: "index_journeys_on_started"
   end
 
   create_table "long_text_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(version: 2021_04_01_100528) do
     t.index ["user_id"], name: "index_journeys_on_user_id"
     t.boolean "started", default: true
     t.index ["started"], name: "index_journeys_on_started"
+    t.datetime "last_worked_on"
+    t.index ["last_worked_on"], name: "index_journeys_on_last_worked_on"
   end
 
   create_table "long_text_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/journey.rb
+++ b/spec/factories/journey.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     category { "catering" }
     liquid_template { "Your answer was {{ answer_47EI2X2T5EDTpJX9WjRR9p }}" }
     section_groups { [] }
+    started { true }
+    last_worked_on { Time.zone.now }
 
     association :user, factory: :user
 

--- a/spec/jobs/delete_stale_journeys_job_spec.rb
+++ b/spec/jobs/delete_stale_journeys_job_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe DeleteStaleJourneysJob, type: :job do
+  include ActiveJob::TestHelper
+
+  before(:each) do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  describe ".perform_later" do
+    it "enqueues a job asynchronously on the default queue" do
+      expect {
+        described_class.perform_later
+      }.to have_enqueued_job.on_queue("default")
+    end
+
+    it "destroys all unstarted journeys" do
+      more_than_one_month_ago = (1.month + 1.day).ago
+      less_than_one_month_ago = (1.month - 1.day).ago
+
+      legacy_journey = create(:journey, started: true, last_worked_on: nil)
+      unstarted_journey = create(:journey, started: false, last_worked_on: more_than_one_month_ago)
+      becoming_stale_journey = create(:journey, started: false, last_worked_on: less_than_one_month_ago)
+      active_journey = create(:journey, started: true, last_worked_on: more_than_one_month_ago)
+
+      described_class.perform_later
+      perform_enqueued_jobs
+
+      remaining_journeys = Journey.all
+      expect(remaining_journeys).to include(legacy_journey)
+      expect(remaining_journeys).to include(active_journey)
+      expect(remaining_journeys).to include(becoming_stale_journey)
+      expect(remaining_journeys).not_to include(unstarted_journey)
+    end
+  end
+end

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -65,4 +65,29 @@ RSpec.describe Journey, type: :model do
       end
     end
   end
+
+  describe "freshen!" do
+    it "set started to true" do
+      journey = build(:journey, :catering)
+      journey.freshen!
+      expect(journey.reload.started).to eq(true)
+    end
+
+    it "sets the last_worked_on to now" do
+      travel_to Time.zone.local(2004, 11, 24, 1, 4, 44)
+      journey = build(:journey, :catering)
+
+      journey.freshen!
+
+      expect(journey.last_worked_on).to eq(Time.zone.now)
+    end
+
+    context "when started is already true" do
+      it "does not update the record" do
+        journey = build(:journey, :catering, started: true)
+        expect(journey).not_to receive(:update).with(started: true)
+        journey.freshen!
+      end
+    end
+  end
 end

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe CreateJourney do
       expect(Journey.last.user).to eq(user)
     end
 
+    it "sets started to true (until questions have been answered)" do
+      stub_contentful_category(
+        fixture_filename: "category-with-no-steps.json",
+        stub_steps: false
+      )
+      described_class.new(category_name: "catering", user: build(:user)).call
+      expect(Journey.last.started).to eq(true)
+    end
+
     it "stores a copy of the Liquid template" do
       stub_contentful_category(
         fixture_filename: "category-with-liquid-template.json"

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe CreateJourney do
       expect(Journey.last.started).to eq(true)
     end
 
+    it "sets last_worked_on to now" do
+      travel_to Time.zone.local(2004, 11, 24, 1, 4, 44)
+      stub_contentful_category(
+        fixture_filename: "category-with-no-steps.json",
+        stub_steps: false
+      )
+
+      described_class.new(category_name: "catering", user: build(:user)).call
+
+      expect(Journey.last.last_worked_on).to eq(Time.zone.now)
+    end
+
     it "stores a copy of the Liquid template" do
       stub_contentful_category(
         fixture_filename: "category-with-liquid-template.json"

--- a/spec/services/delete_stale_journeys_spec.rb
+++ b/spec/services/delete_stale_journeys_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe DeleteStaleJourneys do
+  describe "#call" do
+    it "destroys a journey and all associated records" do
+      journey = create(:journey, started: false, last_worked_on: 1.month.ago + 1.day)
+      step = create(:step, :radio, journey: journey)
+      _radio_answer = create(:radio_answer, step: step)
+      _short_text_answer = create(:short_text_answer, step: step)
+
+      DeleteStaleJourneys.new.call
+
+      expect(Journey.count).to eq(0)
+      expect(Step.count).to eq(0)
+      expect(RadioAnswer.count).to eq(0)
+      expect(ShortTextAnswer.count).to eq(0)
+    end
+
+    context "when the journey is marked as started" do
+      it "is not destroyed" do
+        legacy_journey_with_no_activity = create(:journey, started: true, last_worked_on: nil)
+        old_journey_with_activity = create(:journey, started: true, last_worked_on: 1.month.ago + 1.day)
+        recent_journey_with_activity = create(:journey, started: true, last_worked_on: 1.month.ago - 1.day)
+
+        DeleteStaleJourneys.new.call
+
+        remaining_journeys = Journey.all
+        expect(remaining_journeys).to include(legacy_journey_with_no_activity)
+        expect(remaining_journeys).to include(old_journey_with_activity)
+        expect(remaining_journeys).to include(recent_journey_with_activity)
+      end
+    end
+
+    context "when the journey is not marked as started" do
+      context "and the journey hasn't been worked on for more than 1 month" do
+        it "is destroyed" do
+          journey = create(:journey, started: false, last_worked_on: 1.month.ago + 1.day)
+          DeleteStaleJourneys.new.call
+          expect { Journey.find(journey.id) }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "and the journey has been worked on in the last 1 month" do
+        it "is not destroyed" do
+          journey = create(:journey, started: true, last_worked_on: 1.month.ago - 1.day)
+          DeleteStaleJourneys.new.call
+          expect(Journey.find(journey.id)).to eq(journey)
+        end
+      end
+
+      context "and the journey has been worked on exactly 1 month ago" do
+        it "is not destroyed" do
+          journey = create(:journey, started: true, last_worked_on: 1.month.ago)
+          DeleteStaleJourneys.new.call
+          expect(Journey.find(journey.id)).to eq(journey)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/delete_stale_journeys_spec.rb
+++ b/spec/services/delete_stale_journeys_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe DeleteStaleJourneys do
+  before(:each) { travel_to Time.zone.local(2021, 4, 8, 14, 24, 0) }
+  after(:each) { travel_back }
+
   describe "#call" do
     it "destroys a journey and all associated records" do
-      journey = create(:journey, started: false, last_worked_on: 1.month.ago + 1.day)
+      journey = create(:journey, started: false, last_worked_on: (1.month + 1.day).ago)
       step = create(:step, :radio, journey: journey)
       _radio_answer = create(:radio_answer, step: step)
       _short_text_answer = create(:short_text_answer, step: step)
@@ -17,10 +20,10 @@ RSpec.describe DeleteStaleJourneys do
     end
 
     context "when the journey is marked as started" do
-      it "is not destroyed" do
+      it "is not destroyed regardless of last_worked_on" do
         legacy_journey_with_no_activity = create(:journey, started: true, last_worked_on: nil)
-        old_journey_with_activity = create(:journey, started: true, last_worked_on: 1.month.ago + 1.day)
-        recent_journey_with_activity = create(:journey, started: true, last_worked_on: 1.month.ago - 1.day)
+        old_journey_with_activity = create(:journey, started: true, last_worked_on: (1.month + 1.day).ago)
+        recent_journey_with_activity = create(:journey, started: true, last_worked_on: (1.month - 1.day).ago)
 
         DeleteStaleJourneys.new.call
 
@@ -34,7 +37,7 @@ RSpec.describe DeleteStaleJourneys do
     context "when the journey is not marked as started" do
       context "and the journey hasn't been worked on for more than 1 month" do
         it "is destroyed" do
-          journey = create(:journey, started: false, last_worked_on: 1.month.ago + 1.day)
+          journey = create(:journey, started: false, last_worked_on: (1.month + 1.day).ago)
           DeleteStaleJourneys.new.call
           expect { Journey.find(journey.id) }.to raise_error(ActiveRecord::RecordNotFound)
         end
@@ -42,7 +45,7 @@ RSpec.describe DeleteStaleJourneys do
 
       context "and the journey has been worked on in the last 1 month" do
         it "is not destroyed" do
-          journey = create(:journey, started: true, last_worked_on: 1.month.ago - 1.day)
+          journey = create(:journey, started: true, last_worked_on: (1.month - 1.day).ago)
           DeleteStaleJourneys.new.call
           expect(Journey.find(journey.id)).to eq(journey)
         end
@@ -54,6 +57,29 @@ RSpec.describe DeleteStaleJourneys do
           DeleteStaleJourneys.new.call
           expect(Journey.find(journey.id)).to eq(journey)
         end
+      end
+    end
+
+    context "when the environment variable DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR is set" do
+      around do |example|
+        ClimateControl.modify(
+          DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR: "5"
+        ) do
+          example.run
+        end
+      end
+
+      it "only deletes unstarted journeys that were last modified more than 5 days ago" do
+        stale_journey = create(:journey, started: false, last_worked_on: 6.days.ago)
+        about_to_become_stale_journey = create(:journey, started: false, last_worked_on: 5.days.ago)
+        active_journey = create(:journey, started: false, last_worked_on: 4.days.ago)
+
+        DeleteStaleJourneys.new.call
+
+        remaining_journeys = Journey.all
+        expect(remaining_journeys).not_to include(stale_journey)
+        expect(remaining_journeys).to include(about_to_become_stale_journey)
+        expect(remaining_journeys).to include(active_journey)
       end
     end
   end

--- a/spec/services/save_answer_spec.rb
+++ b/spec/services/save_answer_spec.rb
@@ -68,5 +68,17 @@ RSpec.describe SaveAnswer do
         expect(result.success?).to eql(false)
       end
     end
+
+    context "when the associated journey is unstarted" do
+      it "updates the journey to be started" do
+        journey = create(:journey, started: false)
+        step = create(:step, :radio, journey: journey)
+        answer = create(:short_text_answer, step: step)
+
+        _result = described_class.new(answer: answer).call(answer_params: {})
+
+        expect(journey.reload.started).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

Everytime a user starts a specification journey within the service it creates 100-200 database rows. Each row represents a copy of Contentful content, most commonly a question. We make this copy to ensure that the journey remains future proof if the content in Contentful changes (versioning) and if the Contentful service becomes unavailable.

We are finding that we are creating approximately 10,000 a week on staging on our Heroky hobby database which is the limit. Whilst our live database will have millions of rows the problem remains that many thousands of rows will become occupied over time and there is a big potential that many of them will serve no value. There is no option or need for users to delete old specifications we present in the dashboard so for now the service is going to slowly fill up and undoubtedly in 6months/1year's time the database limit will be hit, long after we have stopped developing.

The starting definition is the Journey isn't association with a _single_ answer *and* it hasn't been worked on in the last month. The time period is arbitrary so we can increase it to become more defensive if we are concerned we might accidentally delete journeys where users have invested their time and effort. I think with the stale check, 1 month is fine. If the user comes back they are likely going to create a new journey, if they look for an old one and don't find it, they will hopefully find the new call to action and not be frustrated since no effort is lost on their part.

## Changes in this PR

- add some state to the Journey to avoid ugly and expensive database queries to find all qualifying journeys
- add a service that will contain the definition of what stale means
- add a new job that runs nightly to remove all stale journeys (this could be run less frequently but I think running it often while the dev team is on hand is sensible for relatively little cost in having it run every night)

