### PR TITLE
Update terraform state location

### DIFF
--- a/terraform/app/README.md
+++ b/terraform/app/README.md
@@ -4,7 +4,7 @@ We use terraform to create the services needed by the application and to deploy 
 
 We use terraform workspaces to keep the terraform state seperate for each environment.
 
-At the time of writing, we store our state in an s3 bucket on the PaaS in the `sct-research` space. This is planned to move to a new space, `sct-terraform`.
+The terraform state is stored in an S3 bucket in the `sct-terraform` Cloud Foundry space
 
 ### Setup
 
@@ -19,7 +19,7 @@ $ export CF_PASSWORD="password"
 ```
 - get the terraform state S3 Bucket AWS credentials
 ```
-$ cf target -s sct-research
+$ cf target -s sct-terraform
 $ cf service-key terraform-state terraform-state-key
 {
  "aws_access_key_id": "AWS_ACCESS_KEY",

--- a/terraform/app/backend.tf
+++ b/terraform/app/backend.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    bucket = "paas-s3-broker-prod-lon-b2db1a0a-5a37-488b-858f-5e850ff4fdfb"
+    bucket = "paas-s3-broker-prod-lon-04cdce2c-ebd3-4525-924e-d6ce670d2ee3"
     key    = "terraform"
     region = "eu-west-2"
   }


### PR DESCRIPTION
## Changes in this PR

A new S3 bucket has been created in the `sct-terraform` space, which is where the terraform state is now stored.

This PR updates the terraform backend, and Readme
