### PR TITLE
Debug GitHub Action deployment failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set Docker tag environment variable
-        run: echo "DOCKER_TAG=${GITHUB_RUN_ID}-${GITHUB_SHA}" >> $GITHUB_ENV
+        run: |
+          echo "DOCKER_TAG=${GITHUB_RUN_ID}-${GITHUB_SHA}" >> $GITHUB_ENV
+          echo "**** GITHUB_RUN_ID: ${GITHUB_RUN_ID}"
+          echo "**** GITHUB_SHA: ${GITHUB_SHA}"
       - name: Set Docker Image environment variable
-        run: echo "DOCKER_IMAGE=$GHCR_REPO:$DOCKER_TAG" >> $GITHUB_ENV
+        run: |
+          echo "DOCKER_IMAGE=$GHCR_REPO:$DOCKER_TAG" >> $GITHUB_ENV
+          echo "**** GHCR_REPO: ${GHCR_REPO}"
+          echo "**** DOCKER_TAG: ${DOCKER_TAG}"
       - name: Set TFVAR Docker Image environment variable
         run: echo "TF_VAR_docker_image=$DOCKER_IMAGE" >> $GITHUB_ENV
       - name: Set TFVAR Docker Image output
@@ -42,6 +48,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+      - name: DEBUG
+        run: echo "${{steps.tf_var_docker_image.outputs.value}}"
       - name: Set TFVAR Docker Image environment variable
         run: echo "TF_VAR_docker_image=${{needs.build.outputs.tf_var_docker_image}}" >> $GITHUB_ENV
       - name: Deploy terraform to staging


### PR DESCRIPTION
Staging deployments aren't working with GitHub Actions https://github.com/DFE-Digital/buy-for-your-school/runs/2235529241?check_suite_focus=true

This looks to be because the new docker image is not set: `- docker_image               = "***:latest" -> null`

Try using the syntax found in this documentation to access the docker image name of the image we built in the previous job: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#using-workflow-commands-to-access-toolkit-functions

I see there's a warning about this variable which may also be to blame that GitHub Actions thinks it's a secret (which it isn't) 
![Screenshot 2021-03-31 at 10 37 45](https://user-images.githubusercontent.com/912473/113124234-38329000-920d-11eb-8d56-fee3367ba7d8.png)

This points to the case where it GitHub may think it contains a secret. Some or all of the variable we are setting is probably being included in `.secrets` somewhere so we can share that value between jobs. Add echo commands in to see which piece of information that contributes to the construction of `TF_VAR_docker_image` is being accidentally obfuscated.