### PR TITLE
Add Sections as a model in the application

### DIFF
--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -1,6 +1,7 @@
 class Journey < ApplicationRecord
   self.implicit_order_column = "created_at"
   has_many :steps
+  has_many :sections
   has_many :visible_steps, -> { where(steps: {hidden: false}) }, class_name: "Step"
   belongs_to :user
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,0 +1,6 @@
+class Section < ApplicationRecord
+  self.implicit_order_column = "created_at"
+  belongs_to :journey
+
+  validates :title, presence: true
+end

--- a/db/migrate/20210401100528_create_sections.rb
+++ b/db/migrate/20210401100528_create_sections.rb
@@ -1,0 +1,9 @@
+class CreateSections < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sections, id: :uuid do |t|
+      t.references :journey, type: :uuid
+      t.string :title, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_145645) do
+ActiveRecord::Schema.define(version: 2021_04_01_100528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -68,6 +68,14 @@ ActiveRecord::Schema.define(version: 2021_03_25_145645) do
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "further_information"
     t.index ["step_id"], name: "index_radio_answers_on_step_id"
+  end
+
+  create_table "sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "journey_id"
+    t.string "title", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["journey_id"], name: "index_sections_on_journey_id"
   end
 
   create_table "short_text_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Journey, type: :model do
   it { should have_many(:steps) }
+  it { should have_many(:sections) }
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:category) }

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Section, type: :model do
+  it { should belong_to(:journey) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:title) }
+  end
+end


### PR DESCRIPTION
Currently, only Journeys & Steps are models in the application, and Sections
are stored as a json blob `section_groups` on Journeys.

We want to add a new model type to Contentful & the application between Section
and Step ("Tasks") and to do so it makes sense to add Sections as a concrete
model in the application, and later add Tasks as a model as well.

This PR is the first step in the process. Sections are added as a model,
attached to a Journey. Eventually we will add tasks as a `has_many` association
to Sections, and Steps as a `has_many` association to Tasks.

<!-- Do you need to update the changelog? -->

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->
