### PR TITLE
Add noindex,nofollow meta tag to all pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- Add `noindex,nofollow` meta tag to all pages, as per Gov.UK guidance
+
 ## [release-006] - 2021-04-01
 
 - specification templates are now sourced from the Contentful Category entry

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <meta name="theme-color" content="#0b0c0c">
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="robots" content="noindex,nofollow">
 
     <%= favicon_link_tag %>
     <%= favicon_link_tag 'govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg+xml', color: '#0b0c0c' %>

--- a/spec/features/visitors/see_a_planning_start_page_spec.rb
+++ b/spec/features/visitors/see_a_planning_start_page_spec.rb
@@ -54,4 +54,9 @@ feature "Users can see a start page for planning their purchase" do
 
     expect(page).to have_content(I18n.t("specifying.start_page.page_title"))
   end
+
+  scenario "the start page has the right content headers" do
+    visit root_path
+    expect(page).to have_xpath("//meta[@name=\"robots\" and contains(@content, \"noindex,nofollow\")]", visible: false)
+  end
 end


### PR DESCRIPTION
As per Gov.uk guidelines, all pages on the application should have a "robots"
meta tag with the content "noindex,nofollow"

<!-- Do you need to update the changelog? -->

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->
