### PR TITLE
Do not allow access to the Preview endpoints on non-preview environment

### DIFF
--- a/app/controllers/preview/entries_controller.rb
+++ b/app/controllers/preview/entries_controller.rb
@@ -1,4 +1,6 @@
 class Preview::EntriesController < ApplicationController
+  before_action :check_app_is_running_in_preview_env
+
   def show
     @journey = Journey.create(
       category: "catering",
@@ -18,5 +20,10 @@ class Preview::EntriesController < ApplicationController
 
   def entry_id
     params[:id]
+  end
+
+  def check_app_is_running_in_preview_env
+    return if ENV["CONTENTFUL_PREVIEW_APP"].eql?("true")
+    render file: "public/404.html", status: :not_found, layout: false
   end
 end

--- a/spec/features/school_buying_professionals/preview_a_journey_step_spec.rb
+++ b/spec/features/school_buying_professionals/preview_a_journey_step_spec.rb
@@ -1,16 +1,24 @@
 feature "Users can preview a journey step" do
-  scenario "the appropriate step is displayed" do
-    stub_contentful_entry(
-      entry_id: "radio-question",
-      fixture_filename: "steps/radio-question.json"
-    )
+  context "when the user is on the preview environment" do
+    around do |example|
+      ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "true") do
+        example.run
+      end
+    end
 
-    user_is_signed_in
+    scenario "the appropriate step is displayed" do
+      stub_contentful_entry(
+        entry_id: "radio-question",
+        fixture_filename: "steps/radio-question.json"
+      )
 
-    visit preview_entry_path("radio-question")
+      user_is_signed_in
 
-    expect(page).to have_content("Which service do you need?")
-    expect(page).to have_content("Catering")
-    expect(page).to have_content("Cleaning")
+      visit preview_entry_path("radio-question")
+
+      expect(page).to have_content("Which service do you need?")
+      expect(page).to have_content("Catering")
+      expect(page).to have_content("Cleaning")
+    end
   end
 end

--- a/spec/requests/entry_preview_spec.rb
+++ b/spec/requests/entry_preview_spec.rb
@@ -3,24 +3,47 @@ require "rails_helper"
 RSpec.describe "Entry previews", type: :request do
   before { user_is_signed_in }
 
-  it "creates a dummy journey and redirects to the question creation flow" do
-    entry_id = "123"
-    fake_journey = create(:journey)
-    expect(Journey).to receive(:create)
-      .with(category: anything, user: anything, liquid_template: anything)
-      .and_return(fake_journey)
+  context "when PREVIEW_APP is configured to true" do
+    around do |example|
+      ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "true") do
+        example.run
+      end
+    end
 
-    fake_get_contentful_entry = instance_double(Contentful::Entry)
-    allow_any_instance_of(GetEntry).to receive(:call)
-      .and_return(fake_get_contentful_entry)
+    it "creates a dummy journey and redirects to the question creation flow" do
+      entry_id = "123"
+      fake_journey = create(:journey)
+      expect(Journey).to receive(:create)
+        .with(category: anything, user: anything, liquid_template: anything)
+        .and_return(fake_journey)
 
-    fake_step = create(:step, :radio)
-    allow_any_instance_of(CreateJourneyStep).to receive(:call)
-      .and_return(fake_step)
+      fake_get_contentful_entry = instance_double(Contentful::Entry)
+      allow_any_instance_of(GetEntry).to receive(:call)
+        .and_return(fake_get_contentful_entry)
 
-    get "/preview/entries/#{entry_id}"
+      fake_step = create(:step, :radio)
+      allow_any_instance_of(CreateJourneyStep).to receive(:call)
+        .and_return(fake_step)
 
-    expect(response).to have_http_status(:found)
-    expect(response).to redirect_to("/journeys/#{fake_journey.id}/steps/#{fake_step.id}")
+      get "/preview/entries/#{entry_id}"
+
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to("/journeys/#{fake_journey.id}/steps/#{fake_step.id}")
+    end
+  end
+
+  context "when PREVIEW_APP is configured to false" do
+    around do |example|
+      ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "false") do
+        example.run
+      end
+    end
+
+    it "does not create a dummy journey and shows not_found" do
+      get "/preview/entries/123"
+
+      expect(Journey).to_not receive(:create)
+      expect(response).to have_http_status(:not_found)
+    end
   end
 end


### PR DESCRIPTION
The "preview" endpoints are for the Preview environment only. Hitting this
endpoint on the non-preview environment creates cruft entries in the database.

Resolve this by checking on the sole preview controller that we are on the 
Preview environment. If we are not, return `not_found`

<!-- Do you need to update the changelog? -->

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->
