### PR TITLE
Fix contentful webhook authentication issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Unreleased]
 
 - Add `noindex,nofollow` meta tag to all pages, as per Gov.UK guidance
+- fix API auth by switching mechanism from Basic to Token
 
 ## [release-006] - 2021-04-01
 

--- a/app/controllers/api/contentful/entries_controller.rb
+++ b/app/controllers/api/contentful/entries_controller.rb
@@ -1,6 +1,7 @@
 class Api::Contentful::EntriesController < ApplicationController
   skip_before_action :authenticate_user!
   http_basic_authenticate_with name: "api", password: ENV["CONTENTFUL_WEBHOOK_API_KEY"]
+  skip_before_action :verify_authenticity_token
 
   def changed
     Cache.delete(key: cache_key)

--- a/app/controllers/api/contentful/entries_controller.rb
+++ b/app/controllers/api/contentful/entries_controller.rb
@@ -1,6 +1,7 @@
 class Api::Contentful::EntriesController < ApplicationController
+  before_action :authenticate_api_user!
+
   skip_before_action :authenticate_user!
-  http_basic_authenticate_with name: "api", password: ENV["CONTENTFUL_WEBHOOK_API_KEY"]
   skip_before_action :verify_authenticity_token
 
   def changed
@@ -14,5 +15,11 @@ class Api::Contentful::EntriesController < ApplicationController
 
   private def changed_params
     params.permit("entityId")
+  end
+
+  private def authenticate_api_user!
+    authenticate_or_request_with_http_token do |token, _options|
+      token == ENV["CONTENTFUL_WEBHOOK_API_KEY"]
+    end
   end
 end

--- a/spec/requests/cache_invalidation_spec.rb
+++ b/spec/requests/cache_invalidation_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe "Cache invalidation", type: :request do
       }
     }
 
-    headers = {"HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic
-      .encode_credentials("api", ENV["CONTENTFUL_WEBHOOK_API_KEY"])}
+    credentials = ActionController::HttpAuthentication::Token
+      .encode_credentials(ENV["CONTENTFUL_WEBHOOK_API_KEY"])
+    headers = {"AUTHORIZATION" => credentials}
 
     post "/api/contentful/entry_updated", {
       params: fake_contentful_webook_payload,
@@ -45,9 +46,13 @@ RSpec.describe "Cache invalidation", type: :request do
         }
       }
 
-      # No basic auth
+      credentials = ActionController::HttpAuthentication::Token
+        .encode_credentials("an invalid token!")
+      headers = {"AUTHORIZATION" => credentials}
+
       post "/api/contentful/entry_updated",
         params: fake_contentful_webook_payload,
+        headers: headers,
         as: :json
 
       expect(response).to have_http_status(:unauthorized)


### PR DESCRIPTION
The webhook that Contentful fires to tell us of a change [has been failing since Faye came back and started making changes](https://rollbar.com/dxw/dfe-buy-for-your-school/items/109/?utm_campaign=item_velocity_message&utm_medium=slack&utm_source=rollbar-notification) to content.

I tried to debug this locally but couldn't replicate the exact issue, though I did find a CSRF problem which I also fixed.

On my journey to debug what was happening I couldn't find a way to debug Rails's basic auth mechanism. I stumbled across this [Thoughtbot article](https://thoughtbot.com/blog/token-authentication-with-rails) which allowed me to debug it but only whe using the Token mechanism. Turns out this token based auth mechanism is also what the initial implementation should probably have been using! I verified it works and you should be able to test locally with this after adding your `CONTENTFUL_WEBHOOK_API_KEY`:

```
curl -XPOST -H 'Authorization: Token <REDACTED>' -H "Content-type: application/json" -d '{
  "entityId": "3fiIye7RVTAXMiblGhjLqV",
  "spaceId": "rwl7tyzv9sys",
  "parameters": {
    "text": "Entity version: undefined"
  }
}' 'localhost:3000/api/contentful/entry_updated'
```