### PR TITLE
In development DSI is disabled by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,4 +31,4 @@ DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk:443
 DFE_SIGN_IN_IDENTIFIER=buyforyourschool
 DFE_SIGN_IN_SECRET=
 DFE_SIGN_IN_REDIRECT_URL=http://localhost:3000/auth/dfe/callback
-DFE_SIGN_IN_ENABLED=true
+DFE_SIGN_IN_ENABLED=false


### PR DESCRIPTION
DSI doesn't work in development unless we have DSI environment configured to work with localhost.

So that the app starts for new devs with the minimum amount of fuss, disable this so the OmniAuth developer mode is used for signing in.
