### PR TITLE
(568) Sanitise user answers before persisting and on rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix API auth by switching mechanism from Basic to Token
 - remove `Returning to this specification` URL from task list
 - Add Tasks to the database when iterating through Sections from Contentful
+- fix XSS vulnerability by sanitising all user answers
 
 ## [release-006] - 2021-04-01
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -14,11 +14,7 @@ class AnswersController < ApplicationController
     @answer = AnswerFactory.new(step: @step).call
     @answer.step = @step
 
-    result = SaveAnswer.new(answer: @answer).call(
-      further_information_params: further_information_params,
-      answer_params: answer_params,
-      date_params: date_params
-    )
+    result = SaveAnswer.new(answer: @step.answer).call(params: prepared_params(step: @step))
     @answer = result.object
 
     if result.success?
@@ -33,11 +29,7 @@ class AnswersController < ApplicationController
     @step = Step.find(step_id)
     @step_presenter = StepPresenter.new(@step)
 
-    result = SaveAnswer.new(answer: @step.answer).call(
-      further_information_params: further_information_params,
-      answer_params: answer_params,
-      date_params: date_params
-    )
+    result = SaveAnswer.new(answer: @step.answer).call(params: prepared_params(step: @step))
     @answer = result.object
 
     if result.success?
@@ -55,6 +47,17 @@ class AnswersController < ApplicationController
 
   def step_id
     params[:step_id]
+  end
+
+  def prepared_params(step:)
+    case step.contentful_type
+    when "checkboxes", "radios"
+      further_information_params
+    when "single_date"
+      date_params
+    else
+      answer_params
+    end
   end
 
   def answer_params

--- a/app/services/get_answers_for_steps.rb
+++ b/app/services/get_answers_for_steps.rb
@@ -23,7 +23,9 @@ class GetAnswersForSteps
       else raise UnexpectedAnswer.new("Trying to present an unknown type of answer: #{step.answer.class.name}")
       end
 
-      hash["answer_#{step.contentful_id}"] = answer.to_param.with_indifferent_access
+      safe_answer = StringSanitiser.new(args: answer.to_param).call
+
+      hash["answer_#{step.contentful_id}"] = safe_answer.with_indifferent_access
     }
   end
 end

--- a/app/services/save_answer.rb
+++ b/app/services/save_answer.rb
@@ -8,7 +8,8 @@ class SaveAnswer
   def call(params:)
     result = Result.new(false, answer)
 
-    answer.assign_attributes(params.to_hash)
+    safe_params = StringSanitiser.new(args: params.to_hash).call
+    answer.assign_attributes(safe_params)
 
     if answer.valid?
       answer.save

--- a/app/services/save_answer.rb
+++ b/app/services/save_answer.rb
@@ -5,17 +5,10 @@ class SaveAnswer
     self.step = answer.step
   end
 
-  def call(answer_params: {}, further_information_params: {}, date_params: {})
+  def call(params:)
     result = Result.new(false, answer)
 
-    case step.contentful_type
-    when "checkboxes", "radios"
-      answer.assign_attributes(further_information_params)
-    when "single_date"
-      answer.assign_attributes(date_params)
-    else
-      answer.assign_attributes(answer_params)
-    end
+    answer.assign_attributes(params.to_hash)
 
     if answer.valid?
       answer.save

--- a/app/services/string_sanitiser.rb
+++ b/app/services/string_sanitiser.rb
@@ -9,15 +9,24 @@ class StringSanitiser
       if value.is_a?(Array)
         value = value.map do |sub_value|
           if sub_value.is_a?(String)
-            sub_value = Rails::Html::FullSanitizer.new.sanitize(sub_value)
+            sub_value = sanitize(sub_value)
           end
           sub_value
         end
       elsif value.is_a?(String)
-        value = Rails::Html::FullSanitizer.new.sanitize(value)
+        value = sanitize(value)
       end
 
       value
     end
+  end
+
+  private def sanitize(value)
+    safe_list_sanitizer = Rails::Html::SafeListSanitizer.new
+    safe_list_sanitizer.sanitize(value, tags: allowed_html_tags)
+  end
+
+  private def allowed_html_tags
+    %w[p b i]
   end
 end

--- a/app/services/string_sanitiser.rb
+++ b/app/services/string_sanitiser.rb
@@ -1,0 +1,23 @@
+class StringSanitiser
+  attr_accessor :args
+  def initialize(args:)
+    self.args = args
+  end
+
+  def call
+    args.deep_merge(args) do |_, _, value|
+      if value.is_a?(Array)
+        value = value.map do |sub_value|
+          if sub_value.is_a?(String)
+            sub_value = Rails::Html::FullSanitizer.new.sanitize(sub_value)
+          end
+          sub_value
+        end
+      elsif value.is_a?(String)
+        value = Rails::Html::FullSanitizer.new.sanitize(value)
+      end
+
+      value
+    end
+  end
+end

--- a/spec/services/get_answers_for_steps_spec.rb
+++ b/spec/services/get_answers_for_steps_spec.rb
@@ -205,5 +205,19 @@ RSpec.describe GetAnswersForSteps do
         expect(result.keys).not_to include("answer_#{unanswerable_step.contentful_id}")
       end
     end
+
+    context "when the answer includes script characters" do
+      it "removes them  from the answer that is then saved" do
+        answer = create(:short_text_answer,
+          response: "<script>alert('problem');</script>A little text")
+
+        expect_any_instance_of(StringSanitiser).to receive(:call).and_call_original
+
+        result = described_class.new(visible_steps: [answer.step]).call
+
+        expect(result["answer_#{answer.step.contentful_id}"])
+          .to eql({"response" => "alert('problem');A little text"})
+      end
+    end
   end
 end

--- a/spec/services/save_answer_spec.rb
+++ b/spec/services/save_answer_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe SaveAnswer do
 
         result = described_class.new(answer: answer).call(params: params)
 
-        expect(result.object.response).to eql("A little text")
+        expect(result.object.response).to eql("alert('problem');A little text")
       end
     end
   end

--- a/spec/services/save_answer_spec.rb
+++ b/spec/services/save_answer_spec.rb
@@ -75,9 +75,22 @@ RSpec.describe SaveAnswer do
         step = create(:step, :radio, journey: journey)
         answer = create(:short_text_answer, step: step)
 
-        _result = described_class.new(answer: answer).call(answer_params: {})
+        _result = described_class.new(answer: answer).call(params: {})
 
         expect(journey.reload.started).to eq(true)
+      end
+    end
+
+    context "when the answer includes script characters" do
+      it "removes them from the answer that is then saved" do
+        answer = create(:short_text_answer)
+        params = ActionController::Parameters.new(response: "<script>alert('problem');</script>A little text").permit!
+
+        expect_any_instance_of(StringSanitiser).to receive(:call).and_call_original
+
+        result = described_class.new(answer: answer).call(params: params)
+
+        expect(result.object.response).to eql("A little text")
       end
     end
   end

--- a/spec/services/save_answer_spec.rb
+++ b/spec/services/save_answer_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe SaveAnswer do
   describe "#call" do
-    it "updates the answer with the answer_params" do
+    it "updates the answer with the params" do
       answer = create(:short_text_answer)
       params = ActionController::Parameters.new(response: "A little text").permit!
 
-      result = described_class.new(answer: answer).call(answer_params: params)
+      result = described_class.new(answer: answer).call(params: params)
 
       expect(result.success?).to eql(true)
       expect(result.object.response).to eql("A little text")
@@ -19,7 +19,7 @@ RSpec.describe SaveAnswer do
       expect(ToggleAdditionalSteps).to receive(:new).with(step: answer.step).and_return(toggle_service)
       expect(toggle_service).to receive(:call)
 
-      described_class.new(answer: answer).call(answer_params: {})
+      described_class.new(answer: answer).call(params: {})
     end
 
     context "when the step is a checkbox question" do
@@ -27,7 +27,7 @@ RSpec.describe SaveAnswer do
         answer = create(:checkbox_answers)
         params = ActionController::Parameters.new(response: ["A", "B"]).permit!
 
-        result = described_class.new(answer: answer).call(further_information_params: params)
+        result = described_class.new(answer: answer).call(params: params)
 
         expect(result.success?).to eql(true)
         expect(result.object.response).to eql(["A", "B"])
@@ -40,7 +40,7 @@ RSpec.describe SaveAnswer do
         date = Date.new(2000, 1, 29)
         params = {response: date}
 
-        result = described_class.new(answer: answer).call(date_params: params)
+        result = described_class.new(answer: answer).call(params: params)
 
         expect(result.success?).to eql(true)
         expect(result.object.response).to eql(date)
@@ -54,7 +54,7 @@ RSpec.describe SaveAnswer do
         allow(answer).to receive(:valid?).and_return(false)
         expect(answer).not_to receive(:save)
 
-        described_class.new(answer: answer).call(answer_params: {})
+        described_class.new(answer: answer).call(params: {})
       end
 
       it "returns a failed result" do
@@ -63,7 +63,7 @@ RSpec.describe SaveAnswer do
 
         allow(answer).to receive(:valid?).and_return(false)
 
-        result = described_class.new(answer: answer).call(answer_params: params)
+        result = described_class.new(answer: answer).call(params: params)
 
         expect(result.success?).to eql(false)
       end

--- a/spec/services/string_sanitiser_spec.rb
+++ b/spec/services/string_sanitiser_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe StringSanitiser do
+  describe "#call" do
+    it "strips malicious tags from every value in a hash" do
+      args = {key: "<script>alert('problem');</script>Some allowed text"}
+      result = described_class.new(args: args).call
+      expect(result).to eq(key: "Some allowed text")
+    end
+
+    context "when the value is an Array" do
+      it "strips malicious tags from every value of the array (only going 1 level deep)" do
+        args = {key: ["<script>alert('problem');</script>Some allowed text", "<a href='evil.com'>Link</a>"]}
+        result = described_class.new(args: args).call
+        expect(result).to eq(key: ["Some allowed text", "Link"])
+      end
+
+      context "when the array contains non string values" do
+        it "doesn't raise an error" do
+          date = Date.current
+          args = {key: ["A string", date, 1]}
+
+          result = described_class.new(args: args).call
+
+          expect(result).to eq(key: ["A string", date, 1])
+        end
+      end
+    end
+
+    context "when the value is a hash of more args" do
+      it "strips malicious tags from every value in every hash" do
+        args = {
+          first_hash_key: {
+            second_hash_key: "<script>alert('problem');</script>2",
+            nested_hash: {
+              third_hash_key: "<a href='evil.com'>Link</a>"
+            }
+          }
+        }
+        result = described_class.new(args: args).call
+        expect(result).to eq(
+          first_hash_key: {
+            second_hash_key: "2",
+            nested_hash: {
+              third_hash_key: "Link"
+            }
+          }
+        )
+      end
+    end
+
+    context "when the value is a Date" do
+      it "returns the date without raising an error" do
+        date = Date.current
+        args = {key: date}
+
+        result = described_class.new(args: args).call
+
+        expect(result).to eq(key: date)
+      end
+    end
+  end
+end

--- a/spec/services/string_sanitiser_spec.rb
+++ b/spec/services/string_sanitiser_spec.rb
@@ -5,14 +5,20 @@ RSpec.describe StringSanitiser do
     it "strips malicious tags from every value in a hash" do
       args = {key: "<script>alert('problem');</script>Some allowed text"}
       result = described_class.new(args: args).call
-      expect(result).to eq(key: "Some allowed text")
+      expect(result).to eq(key: "alert('problem');Some allowed text")
+    end
+
+    it "doesn't strip safe tags" do
+      args = {key: "<p>paragraph</p><b>bold</b><i>italic</i>"}
+      result = described_class.new(args: args).call
+      expect(result).to eq(key: "<p>paragraph</p><b>bold</b><i>italic</i>")
     end
 
     context "when the value is an Array" do
       it "strips malicious tags from every value of the array (only going 1 level deep)" do
         args = {key: ["<script>alert('problem');</script>Some allowed text", "<a href='evil.com'>Link</a>"]}
         result = described_class.new(args: args).call
-        expect(result).to eq(key: ["Some allowed text", "Link"])
+        expect(result).to eq(key: ["alert('problem');Some allowed text", "Link"])
       end
 
       context "when the array contains non string values" do
@@ -40,7 +46,7 @@ RSpec.describe StringSanitiser do
         result = described_class.new(args: args).call
         expect(result).to eq(
           first_hash_key: {
-            second_hash_key: "2",
+            second_hash_key: "alert('problem');2",
             nested_hash: {
               third_hash_key: "Link"
             }


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- refactor how params are passed to `SaveAnswer` depending on the different types of `Answer` before we begin extending the `SaveAnswer` with sanitisation logic
- strip unsafe tags from all user answers so that we only store safe values in the database. If an answer.response is used with `.html_safe` then no script will be executed in the clients browser

User input given to LongTextAnswer was being unintentionally escaped by using `.to_param` within 
[GetAnswersForSteps](https://github.com/DFE-Digital/buy-for-your-school/blob/develop/app/services/get_answers_for_steps.rb#L26).

User input given to `ShortTextAnswer` or `further_information` fields within `Radios` or `CheckboxAnswers` was not being stripped by `to_param` in the same way so scripts were executed when viewing the spec. 

`CurrencyAnswer` and `NumberAnswer` have validation for numerical input only so were safe.

This change does introduces several new changes:

1. unsafe tags like `<a>`, `<script>` and `<img>` are stripped out along with anything else except those on our whitelist (more on this next)
1. tags `<p>`, `<b>` and `<i>` are allowed since they are stored for `LongTextAnswer` to render line breaks - we want to keep this

## Screenshots of UI changes

### Before

I add `<script>alert();</script>` into `LongTextAnswer`, `ShortTextAnswer` and `CheckboxAnswers` (with further info).

We can see that before _only_ long text was escaped by `.to_param`:

![Screenshot 2021-04-14 at 16 17 28](https://user-images.githubusercontent.com/912473/114735530-2ab4f400-9d3d-11eb-8167-35db2c64d4a2.png)
![Screenshot 2021-04-14 at 16 17 32](https://user-images.githubusercontent.com/912473/114735531-2ab4f400-9d3d-11eb-81cc-bb399f29b12f.png)

### After

Now all question types strip the <script> tag and output the contents safely:
![Screenshot 2021-04-14 at 16 18 31](https://user-images.githubusercontent.com/912473/114735508-2688d680-9d3d-11eb-92f4-5dde9f2f4d7b.png)



