### PR TITLE
Fix/cache warming task not running

### DIFF
--- a/app/jobs/warm_entry_cache_job.rb
+++ b/app/jobs/warm_entry_cache_job.rb
@@ -5,6 +5,8 @@ class WarmEntryCacheJob < ApplicationJob
   sidekiq_options retry: 5
 
   def perform
+    Rollbar.info("Cache warming task started…")
+
     category = GetCategory.new(category_entry_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"]).call
     sections = GetSectionsFromCategory.new(category: category).call
     steps = begin
@@ -18,6 +20,8 @@ class WarmEntryCacheJob < ApplicationJob
     [steps].flatten.each do |entry|
       store_in_cache(cache: cache, key: "contentful:entry:#{entry.id}", entry: entry)
     end
+
+    Rollbar.info("Cache warming task complete.")
   end
 
   private

--- a/app/jobs/warm_entry_cache_job.rb
+++ b/app/jobs/warm_entry_cache_job.rb
@@ -7,14 +7,17 @@ class WarmEntryCacheJob < ApplicationJob
   def perform
     category = GetCategory.new(category_entry_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"]).call
     sections = GetSectionsFromCategory.new(category: category).call
-    steps = sections.map { |section| GetStepsFromSection.new(section: section).call }
+    steps = begin
+      sections.map { |section| GetStepsFromSection.new(section: section).call }
+    rescue GetStepsFromSection::RepeatEntryDetected
+      cache.extend_ttl_on_all_entries
+      return
+    end
 
     # TODO: Cache category and sections too
     [steps].flatten.each do |entry|
       store_in_cache(cache: cache, key: "contentful:entry:#{entry.id}", entry: entry)
     end
-  rescue GetStepsFromSection::RepeatEntryDetected
-    cache.extend_ttl_on_all_entries
   end
 
   private

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,5 @@
 Sidekiq.configure_server do |config|
-  config.redis = {url: "#{ENV["REDIS_URL"]}/2"}
+  config.redis = {url: "#{ENV["REDIS_URL"]}/0"}
 
   # Sidekiq Cron
   schedule_file = "config/schedule.yml"
@@ -9,5 +9,5 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = {url: "#{ENV["REDIS_URL"]}/2"}
+  config.redis = {url: "#{ENV["REDIS_URL"]}/0"}
 end


### PR DESCRIPTION
An attempt to diagnose and [fix this issue appearing on Staging where cache warming is not working on gpaas](https://rollbar.com/dxw/dfe-buy-for-your-school/items/107/). We have only recently turned caching on in anger.

- I consoled to Heroku Staging and GPaaS staging and ran the task with `WarmEntryCacheJob.perform_now` - the job works fine when run synchronously 

Given gpaas is a new environment I went back to Heroku to confirm it has ever worked:

- there are `redis.keys` within the first Redis database (`<REDIS_URL>/1`) which proces that `Redis.set` and other commands are working during a real request. Caching on the fly is OK.
- there are no `redis.keys` in the second Redis database Heroku (`<REDIS_URL>/2`) which is the database Sidekiq is using. In fact I get this error that suggests cache warming is NOT OK:

```
$ Redis.new(url: "#{ENV["REDIS_URL"]}/2").keys

Traceback (most recent call last):
        1: from (irb):3
Redis::CommandError (ERR DB index is out of range)
```

## Changes in this PR

- Investigation so far suggests Redis database 2 might not be available. To rule this out we move Sidekiq to use Redis database /0 which has been present but unused.
- We add `Rollbar.info` into the cache warming job so we can observe the behaviour on each environment in relation to the `NotImplementedError` error. How far do we get before this error is thrown? There is a chance swithing to database 0 solves the issue but it isn't clear and these tasks are set to run once a night.

![Screenshot 2021-04-12 at 16 41 26](https://user-images.githubusercontent.com/912473/114422397-26a69c00-9bae-11eb-99cb-87958b58cc9a.png)
