### PR TITLE
(412) Include govuk table styling

### DIFF
--- a/app/assets/stylesheets/components/_specification.scss
+++ b/app/assets/stylesheets/components/_specification.scss
@@ -15,4 +15,28 @@
     @extend .govuk-list;
     @extend .govuk-list--number;
   }
+
+  table {
+    @extend .govuk-table !optional;
+  }
+
+  thead {
+    @extend .govuk-table__head !optional;
+  }
+
+  tbody {
+    @extend .govuk-table__body !optional;
+  }
+
+  tr {
+    @extend .govuk-table__row !optional;
+  }
+
+  th {
+    @extend .govuk-table__header !optional;
+  }
+
+  td {
+    @extend .govuk-table__cell !optional;
+  }
 }


### PR DESCRIPTION
## Changes in this PR

If these lines are not provided the Contentful specification template field has to include all the HTML classes. There are a lot and are easily missed.

If `optional!` is not used the app errors out saying these classes are unavailable. This is a mystery to me. The extensions above don't have this issue so the load order of the frontend CSS is seemingly correct.

## Screenshots of UI changes

![Screenshot 2021-04-12 at 17 57 53](https://user-images.githubusercontent.com/912473/114432870-0d571d00-9bb9-11eb-8edd-951d8ef9609f.png)

![Screenshot 2021-04-12 at 17 57 42](https://user-images.githubusercontent.com/912473/114432876-0defb380-9bb9-11eb-9526-3232586c81dd.png)

![Screenshot 2021-04-12 at 17 58 16](https://user-images.githubusercontent.com/912473/114432867-0cbe8680-9bb9-11eb-8e3f-2d5b3a7de1ba.png)

## Next steps

- [x] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS)
