### PR TITLE
Add Tasks to the database when iterating through Contentful sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Add `noindex,nofollow` meta tag to all pages, as per Gov.UK guidance
 - fix API auth by switching mechanism from Basic to Token
 - remove `Returning to this specification` URL from task list
+- Add Tasks to the database when iterating through Sections from Contentful
 
 ## [release-006] - 2021-04-01
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,6 +1,7 @@
 class Section < ApplicationRecord
   self.implicit_order_column = "created_at"
   belongs_to :journey
+  has_many :tasks
 
   validates :title, presence: true
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -3,5 +3,5 @@ class Section < ApplicationRecord
   belongs_to :journey
   has_many :tasks
 
-  validates :title, presence: true
+  validates :title, :contentful_id, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,6 @@
+class Task < ApplicationRecord
+  self.implicit_order_column = "created_at"
+  belongs_to :section
+
+  validates :title, :contentful_id, presence: true
+end

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -8,7 +8,7 @@ class CreateJourney
 
   def call
     category = GetCategory.new(category_entry_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"]).call
-    sections = GetSectionsFromCategory.new(category: category).call
+    contentful_sections = GetSectionsFromCategory.new(category: category).call
     journey = Journey.new(
       category: category_name,
       user: user,
@@ -17,10 +17,14 @@ class CreateJourney
       liquid_template: category.specification_template
     )
 
-    journey.section_groups = build_section_groupings(sections: sections)
+    journey.section_groups = build_section_groupings(sections: contentful_sections)
     journey.save!
 
-    sections.each do |section|
+    contentful_sections.each do |contentful_section|
+      CreateSection.new(journey: journey, contentful_section: contentful_section).call
+    end
+
+    contentful_sections.each do |section|
       question_entries = GetStepsFromSection.new(section: section).call
       question_entries.each do |entry|
         CreateJourneyStep.new(

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -22,14 +22,17 @@ class CreateJourney
 
     contentful_sections.each do |contentful_section|
       CreateSection.new(journey: journey, contentful_section: contentful_section).call
-    end
 
-    contentful_sections.each do |section|
-      question_entries = GetStepsFromSection.new(section: section).call
+      question_entries = GetStepsFromSection.new(section: contentful_section).call
       question_entries.each do |entry|
         CreateJourneyStep.new(
           journey: journey, contentful_entry: entry
         ).call
+      end
+
+      tasks = GetTasksFromSection.new(section: contentful_section).call
+      tasks.each do |task|
+        CreateTask.new(section: contentful_section, contentful_task: task)
       end
     end
 

--- a/app/services/create_section.rb
+++ b/app/services/create_section.rb
@@ -1,0 +1,13 @@
+class CreateSection
+  attr_accessor :journey, :contentful_section
+
+  def initialize(journey:,contentful_section:)
+    @journey = journey
+    @contentful_section = contentful_section
+  end
+
+  def call
+    section = Section.new(journey: journey, contentful_id: contentful_section.id, title: contentful_section.title)
+    section.save!
+  end
+end

--- a/app/services/create_section.rb
+++ b/app/services/create_section.rb
@@ -1,7 +1,7 @@
 class CreateSection
   attr_accessor :journey, :contentful_section
 
-  def initialize(journey:,contentful_section:)
+  def initialize(journey:, contentful_section:)
     @journey = journey
     @contentful_section = contentful_section
   end
@@ -9,5 +9,6 @@ class CreateSection
   def call
     section = Section.new(journey: journey, contentful_id: contentful_section.id, title: contentful_section.title)
     section.save!
+    section
   end
 end

--- a/app/services/create_task.rb
+++ b/app/services/create_task.rb
@@ -1,0 +1,14 @@
+class CreateTask
+  attr_accessor :section, :contentful_task
+
+  def initialize(section:, contentful_task:)
+    @section = section
+    @contentful_task = contentful_task
+  end
+
+  def call
+    task = Task.new(section: section, title: contentful_task.title, contentful_id: contentful_task.id)
+    task.save!
+    task
+  end
+end

--- a/app/services/get_tasks_from_section.rb
+++ b/app/services/get_tasks_from_section.rb
@@ -1,0 +1,19 @@
+class GetTasksFromSection
+  attr_accessor :section
+
+  def initialize(section:)
+    self.section = section
+  end
+
+  def call
+    return [] unless section.respond_to?(:tasks)
+    task_ids = []
+    section.tasks.each do |task|
+      task_ids << task.id
+    end
+
+    task_ids.map { |entry_id|
+      GetEntry.new(entry_id: entry_id).call
+    }
+  end
+end

--- a/db/migrate/20210401105730_create_tasks.rb
+++ b/db/migrate/20210401105730_create_tasks.rb
@@ -1,0 +1,10 @@
+class CreateTasks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tasks, id: :uuid do |t|
+      t.references :section, type: :uuid
+      t.string :title, null: false
+      t.string :contentful_id, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210407111600_add_contentful_id_to_sections.rb
+++ b/db/migrate/20210407111600_add_contentful_id_to_sections.rb
@@ -1,0 +1,5 @@
+class AddContentfulIdToSections < ActiveRecord::Migration[6.1]
+  def change
+    add_column :sections, :contentful_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_01_105730) do
+ActiveRecord::Schema.define(version: 2021_04_07_111600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2021_04_01_105730) do
     t.string "title", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "contentful_id"
     t.index ["journey_id"], name: "index_sections_on_journey_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_01_100528) do
+ActiveRecord::Schema.define(version: 2021_04_01_105730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -115,6 +115,15 @@ ActiveRecord::Schema.define(version: 2021_04_01_100528) do
     t.jsonb "additional_step_rules"
     t.string "skip_call_to_action_text"
     t.index ["journey_id"], name: "index_steps_on_journey_id"
+  end
+
+  create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "section_id"
+    t.string "title", null: false
+    t.string "contentful_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["section_id"], name: "index_tasks_on_section_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/section.rb
+++ b/spec/factories/section.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :section do
+    title { "Section title" }
+    contentful_id { "5m26U35YLau4cOaJq6FXZA" }
+    association :journey
+  end
+end

--- a/spec/fixtures/contentful/sections/tasks-section.json
+++ b/spec/fixtures/contentful/sections/tasks-section.json
@@ -1,0 +1,41 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "rwl7tyzv9sys"
+      }
+    },
+    "id": "tasks-section",
+    "type": "Entry",
+    "createdAt": "2021-04-12T10:41:36.073Z",
+    "updatedAt": "2021-04-12T10:42:51.119Z",
+    "environment": {
+      "sys": {
+        "id": "develop",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 2,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "section"
+      }
+    },
+    "locale": "en-US"
+  },
+  "fields": {
+    "title": "Section with tasks",
+    "tasks": [{
+      "sys": {
+        "type": "Link",
+        "linkType": "Entry",
+        "id": "checkboxes-task"
+      }
+    }]
+  }
+}

--- a/spec/fixtures/contentful/tasks/checkboxes-task.json
+++ b/spec/fixtures/contentful/tasks/checkboxes-task.json
@@ -1,0 +1,46 @@
+{
+  "metadata": {
+    "tags": []
+  },
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "rwl7tyzv9sys"
+      }
+    },
+    "id": "checkboxes-task",
+    "type": "Entry",
+    "createdAt": "2021-04-12T09:38:48.990Z",
+    "updatedAt": "2021-04-12T10:11:05.670Z",
+    "environment": {
+      "sys": {
+        "id": "develop",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 3,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "task"
+      }
+    },
+    "locale": "en-US"
+  },
+  "fields": {
+    "name": "Task 1",
+    "steps": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "1DqhwF2XkJJ0Um6NSweWlZ"
+        }
+      }
+    ]
+  }
+}

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -5,5 +5,6 @@ RSpec.describe Section, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:contentful_id) }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Task, type: :model do
+  it { should belong_to(:section) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:contentful_id) }
+  end
+end

--- a/spec/services/create_journey_step_spec.rb
+++ b/spec/services/create_journey_step_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CreateJourneyStep do
     context "when the new step is of type step" do
       it "creates a local copy of the new step" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/radio-question.json"
         )
 
@@ -64,7 +64,7 @@ RSpec.describe CreateJourneyStep do
     context "when the question is of type 'short_text'" do
       it "sets help_text and options to nil" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/short-text-question.json"
         )
 
@@ -75,7 +75,7 @@ RSpec.describe CreateJourneyStep do
 
       it "replaces spaces with underscores" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/short-text-question.json"
         )
 
@@ -88,7 +88,7 @@ RSpec.describe CreateJourneyStep do
     context "when the new entry has a body field" do
       it "updates the step with the body" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/static-content.json"
         )
 
@@ -106,7 +106,7 @@ process around March.")
     context "when the new entry has a 'primaryCallToAction' field" do
       it "updates the step with the body" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/primary-button.json"
         )
 
@@ -121,7 +121,7 @@ process around March.")
     context "when no 'primaryCallToAction' is provided" do
       it "default copy is used for the button" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/no-primary-button.json"
         )
 
@@ -136,7 +136,7 @@ process around March.")
     context "when no 'skipCallToAction' is provided" do
       it "default copy is used for the button" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/skippable-checkboxes-question.json"
         )
 
@@ -151,7 +151,7 @@ process around March.")
     context "when no 'alwaysShowTheUser' is provided" do
       it "default hidden to true" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/no-hidden-field.json"
         )
 
@@ -166,7 +166,7 @@ process around March.")
     context "when 'showAdditionalQuestion' is provided" do
       it "stores the rule as JSON" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/show-one-additional-question.json"
         )
 
@@ -186,7 +186,7 @@ process around March.")
     context "when the new entry has an unexpected content model" do
       it "raises an error" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/unexpected-contentful-type.json"
         )
 
@@ -197,7 +197,7 @@ process around March.")
       it "raises a rollbar event" do
         journey = create(:journey, :catering)
 
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/unexpected-contentful-type.json"
         )
 
@@ -220,7 +220,7 @@ process around March.")
     context "when the new step has an unexpected step type" do
       it "raises an error" do
         journey = create(:journey, :catering)
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/unexpected-contentful-question-type.json"
         )
 
@@ -231,7 +231,7 @@ process around March.")
       it "raises a rollbar event" do
         journey = create(:journey, :catering)
 
-        fake_entry = fake_contentful_step(
+        fake_entry = fake_contentful_step_or_task(
           contentful_fixture_filename: "steps/unexpected-contentful-question-type.json"
         )
 

--- a/spec/services/create_section_spec.rb
+++ b/spec/services/create_section_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe CreateSection do
+  let(:journey) { FactoryBot.create(:journey) }
+  let(:contentful_section) { double(id: "5m26U35YLau4cOaJq6FXZA", title: "Section A") }
+
+  describe "#call" do
+    it "creates a new section" do
+      expect { described_class.new(journey: journey, contentful_section: contentful_section).call }
+        .to change { Section.count }.by(1)
+      expect(Section.last.title).to eql("Section A")
+      expect(Section.last.journey).to eql(journey)
+    end
+  end
+end

--- a/spec/services/create_task_spec.rb
+++ b/spec/services/create_task_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe CreateTask do
+  let(:section) { FactoryBot.create(:section) }
+  let(:contentful_task) { double(id: "5m26U35YLau4cOaJq6FXZA", title: "Task 1") }
+
+  describe "#call" do
+    it "creates a new task" do
+      expect { described_class.new(section: section, contentful_task: contentful_task).call }
+        .to change { Task.count }.by(1)
+      expect(Task.last.title).to eql("Task 1")
+      expect(Task.last.contentful_id).to eql("5m26U35YLau4cOaJq6FXZA")
+      expect(Task.last.section).to eql(section)
+    end
+  end
+end

--- a/spec/services/get_tasks_from_section_spec.rb
+++ b/spec/services/get_tasks_from_section_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe GetTasksFromSection do
+  describe "#call" do
+    it "returns the list of entry objects referenced by the task list" do
+      section = fake_contentful_section(
+        contentful_fixture_filename: "sections/tasks-section.json"
+      )
+      stub_contentful_section_tasks(sections: [section])
+
+      result = described_class.new(section: section).call
+
+      expect(result).to be_kind_of(Array)
+      # INFO: We should test this is a Contentful::Entry however it wasn't
+      # possible to create an instance_double due to an unusual way the object
+      # is constructed within the gem. Creating the object seems overly complex.
+      expect(result.first.id).to eq("checkboxes-task")
+    end
+  end
+end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -4,7 +4,7 @@ module ContentfulHelpers
     fixture_filename: "radio-question-example.json"
   )
     contentful_connector = stub_contentful_connector
-    contentful_response = fake_contentful_step(contentful_fixture_filename: fixture_filename)
+    contentful_response = fake_contentful_step_or_task(contentful_fixture_filename: fixture_filename)
     allow(contentful_connector).to receive(:get_entry_by_id)
       .with(entry_id)
       .and_return(contentful_response)
@@ -63,7 +63,7 @@ module ContentfulHelpers
 
     sections.each do |section|
       fake_steps = section.steps.map { |step|
-        fake_step = fake_contentful_step(contentful_fixture_filename: "steps/#{step.id}.json")
+        fake_step = fake_contentful_step_or_task(contentful_fixture_filename: "steps/#{step.id}.json")
         expect(contentful_connector).to receive(:get_entry_by_id)
           .with(fake_step.id)
           .and_return(fake_step)
@@ -83,10 +83,29 @@ module ContentfulHelpers
       .and_return(contentful_connector)
 
     category.steps.each do |step|
-      step = fake_contentful_step(contentful_fixture_filename: "steps/#{step.id}.json")
+      step = fake_contentful_step_or_task(contentful_fixture_filename: "steps/#{step.id}.json")
       allow(contentful_connector).to receive(:get_entry_by_id)
         .with(step.id)
         .and_return(step)
+    end
+  end
+
+  def stub_contentful_section_tasks(
+    sections:,
+    contentful_connector: instance_double(ContentfulConnector)
+  )
+    allow(ContentfulConnector).to receive(:new)
+      .and_return(contentful_connector)
+
+    sections.each do |section|
+      fake_tasks = section.tasks.map { |task|
+        fake_task = fake_contentful_step_or_task(contentful_fixture_filename: "tasks/#{task.id}.json")
+        expect(contentful_connector).to receive(:get_entry_by_id)
+          .with(fake_task.id)
+          .and_return(fake_task)
+        fake_task
+      }
+      allow(section).to receive(:tasks).and_return(fake_tasks)
     end
   end
 
@@ -125,15 +144,19 @@ module ContentfulHelpers
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{contentful_fixture_filename}")
     hash_response = JSON.parse(raw_response)
 
+    steps = hash_response.dig("fields", "steps")
+    tasks = hash_response.dig("fields", "tasks")
+
     double(
       Contentful::Entry,
       id: hash_response.dig("sys", "id"),
       title: hash_response.dig("fields", "title"),
-      steps: hash_response.dig("fields", "steps").map { |step_hash| double(id: step_hash.dig("sys", "id")) }
+      steps: steps.nil? ? {} : steps.map { |step_hash| double(id: step_hash.dig("sys", "id")) },
+      tasks: tasks.nil? ? {} : tasks.map { |task_hash| double(id: task_hash.dig("sys", "id")) }
     )
   end
 
-  def fake_contentful_step(contentful_fixture_filename:)
+  def fake_contentful_step_or_task(contentful_fixture_filename:)
     raw_response = File.read("#{Rails.root}/spec/fixtures/contentful/#{contentful_fixture_filename}")
     hash_response = JSON.parse(raw_response)
 


### PR DESCRIPTION
## Changes in this PR

- Add Tasks as a model. A Task is a new Contentful model which sits between Section and Steps. A Section can have many Tasks, and a Task can have many Steps.
- When creating a new Journey in the database, we iterate over the Sections and add them to the database. We Then iterate over the Tasks in the section, and add them to the database.
- Currently the Tasks are not visible in the UI, this will be added in later commits. 
- Currently Steps are still grouped by their Sections in the code, not by referring to their parent sections. This will be added in a later commit.

## Screenshots of UI changes

### Before

### After

## Next steps

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->
