### PR TITLE
(569) Fix Sidekiq connection failure due to NotImplementedError

### DIFF
--- a/app/jobs/warm_entry_cache_job.rb
+++ b/app/jobs/warm_entry_cache_job.rb
@@ -2,7 +2,6 @@ class WarmEntryCacheJob < ApplicationJob
   include CacheableEntry
 
   queue_as :caching
-  sidekiq_options retry: 5
 
   def perform
     Rollbar.info("Cache warming task started…")


### PR DESCRIPTION
The [stacktrace from the error message](https://rollbar.com/dxw/dfe-buy-for-your-school/items/131/) for NotImplementedError wasn't helpful so this change is based on trial and error. 

I was able to confirm that Sidekiq was not connecting to Redis. On the Heroku research environment this was further confused by the fact the worker wasn't enabled at all. I stripped the various configuration parts out until finding that removing `sidekiq_options` fixed the issue. This is surprising because [Sidekiq include this in the documentation for setting up a job with ActiveJob](https://github.com/mperham/sidekiq/wiki/Active-Job#customizing-error-handling).

I checked that the Sidekiq patch upgrade that was applied 5 days didn't introduce this issue.

There isn't a suggested way to configure retry limits so with this removal the default retry limit will be the Sidekiq default which is 28 days.

We should probably consider Sidekiq health checks. Leaving the Rollbar info debugging in for now so we can be confident it's fixed on gpaas too.

## You can test this by:

```
# ssh to research where this commit is currently present
$ heroku run rails c -a dfe-bfys-beta-research

# Check the cache in Redis 1
$ Redis.new(url: "#{ENV['REDIS_URL']}/1").keys

# Clear any cached keys if they exist so we start a fresh
$ Redis.new(url: "#{ENV['REDIS_URL']}/1").flushdb

# Run the task asynchronously
$ WarmEntryCacheJob.perform_later

# Check to see if there are lots of nice new cache keys
$ Redis.new(url: "#{ENV['REDIS_URL']}/1").keys
```
