### PR TITLE
(490) Delete stale journey does not raise NotImplementedError

### DIFF
--- a/app/jobs/delete_stale_journeys_job.rb
+++ b/app/jobs/delete_stale_journeys_job.rb
@@ -3,5 +3,7 @@ class DeleteStaleJourneysJob < ApplicationJob
 
   def perform
     DeleteStaleJourneys.new.call
+
+    Rollbar.info("Delete stale journeys task complete.")
   end
 end

--- a/app/jobs/delete_stale_journeys_job.rb
+++ b/app/jobs/delete_stale_journeys_job.rb
@@ -1,6 +1,5 @@
 class DeleteStaleJourneysJob < ApplicationJob
   queue_as :default
-  sidekiq_options retry: 1
 
   def perform
     DeleteStaleJourneys.new.call

--- a/app/jobs/warm_entry_cache_job.rb
+++ b/app/jobs/warm_entry_cache_job.rb
@@ -4,8 +4,6 @@ class WarmEntryCacheJob < ApplicationJob
   queue_as :caching
 
   def perform
-    Rollbar.info("Cache warming task started…")
-
     category = GetCategory.new(category_entry_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"]).call
     sections = GetSectionsFromCategory.new(category: category).call
     steps = begin


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

We saw recently on our first job that including sidekiq_options threw a `NotImplementerError`. We fixed it by removing the retry configuration but the root cause remains a mystery. https://github.com/DFE-Digital/buy-for-your-school/pull/283

The same error happens here so to quickly get moving we remove the retry count and use the Sidekiq defaults. https://rollbar.com/dxw/dfe-buy-for-your-school/items/107/occurrences/160269956473/. If we really do need retry in the future we can invest more time in figuring out why this happens. It is presumably a problem with sidekiq or some conflicting configuration we have that we haven't found yet.

This change should mean this asynchronous starts running at 2am again.

## Next steps

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->
