### PR TITLE
(573) Support specification templates that exceed 50k characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - remove `Returning to this specification` URL from task list
 - Add Tasks to the database when iterating through Sections from Contentful
 - fix XSS vulnerability by sanitising all user answers
+- support specification templates that exceed 50,000 characters in Contentful
 
 ## [release-006] - 2021-04-01
 

--- a/app/assets/stylesheets/components/_specification.scss
+++ b/app/assets/stylesheets/components/_specification.scss
@@ -1,4 +1,4 @@
-#specification {
+#specification, .specification {
   h2 {
     @extend .govuk-heading-m;
   }

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -14,7 +14,7 @@ class CreateJourney
       user: user,
       started: true,
       last_worked_on: Time.zone.now,
-      liquid_template: category.specification_template
+      liquid_template: category.combined_specification_template
     )
 
     journey.section_groups = build_section_groupings(sections: contentful_sections)

--- a/spec/features/school_buying_professionals/see_their_catering_specification_spec.rb
+++ b/spec/features/school_buying_professionals/see_their_catering_specification_spec.rb
@@ -83,4 +83,18 @@ feature "Users can see their catering specification" do
       expect(page).to have_content("You have not completed all the tasks. There may be information missing from your specification.")
     end
   end
+
+  context "when the spec template is configured using multiple sections" do
+    it "renders both parts in the spec" do
+      start_journey_from_category_and_go_to_question(category: "multiple-specification-templates.json")
+
+      choose("Catering")
+      click_on(I18n.t("generic.button.next"))
+      click_on(I18n.t("journey.specification.button"))
+
+      expect(page).to have_content(I18n.t("journey.specification.header"))
+      expect(page).to have_content("Part 1")
+      expect(page).to have_content("Part 2")
+    end
+  end
 end

--- a/spec/fixtures/contentful/categories/multiple-specification-templates.json
+++ b/spec/fixtures/contentful/categories/multiple-specification-templates.json
@@ -1,0 +1,48 @@
+{
+    "metadata": {
+        "tags": []
+    },
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-04-15T13:27:29.725Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 78,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": "Catering",
+        "sections": [
+            {
+                "sys": {
+                    "type": "Link",
+                    "linkType": "Entry",
+                    "id": "radio-section"
+                }
+            }
+        ],
+        "specification_template": "<article id='specification'>\n  <section>\n   <p>Part 1</p>\n  </section>\n</article>",
+        "specification_template_part_2": "<article id='specification'>\n  <section>\n    <p>Part 2</p>\n  </section>\n</article>"
+    }
+}

--- a/spec/services/get_category_spec.rb
+++ b/spec/services/get_category_spec.rb
@@ -59,5 +59,39 @@ RSpec.describe GetCategory do
         }.to raise_error(GetCategory::InvalidLiquidSyntax)
       end
     end
+
+    context "when there are multiple specification fields on the category (specification_template_x)" do
+      it "returns a merged and sorted set separated by newlines" do
+        stub_contentful_category(
+          fixture_filename: "multiple-specification-templates.json",
+          stub_sections: false
+        )
+        result = described_class.new(category_entry_id: "contentful-category-entry").call
+
+        # It should leave the original fields as they were
+        expect(result.specification_template).to eql("<article id='specification'>\n  <section>\n   <p>Part 1</p>\n  </section>\n</article>")
+        expect(result.specification_template_part_2).to eql("<article id='specification'>\n  <section>\n    <p>Part 2</p>\n  </section>\n</article>")
+
+        # The result object can be asked for the combined specification template
+        expect(result.combined_specification_template)
+          .to eql("<article id='specification'>\n  <section>\n   <p>Part 1</p>\n  </section>\n</article>\n<article id='specification'>\n  <section>\n    <p>Part 2</p>\n  </section>\n</article>")
+      end
+    end
+
+    context "when there are multiple specification fields on the category (specification_template_x)" do
+      it "validates both specification field inputs" do
+        stub_contentful_category(
+          fixture_filename: "multiple-specification-templates.json",
+          stub_sections: false
+        )
+
+        expect(Liquid::Template).to receive(:parse).with(
+          "<article id='specification'>\n  <section>\n   <p>Part 1</p>\n  </section>\n</article>\n<article id='specification'>\n  <section>\n    <p>Part 2</p>\n  </section>\n</article>",
+          error_mode: :strict
+        )
+
+        _result = described_class.new(category_entry_id: "contentful-category-entry").call
+      end
+    end
   end
 end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -132,12 +132,24 @@ module ContentfulHelpers
       double(id: section.dig("sys", "id"))
     }
 
-    double(
+    combined_specification_template = [
+      hash_response.dig("fields", "specification_template"),
+      hash_response.dig("fields", "specification_template_part_2")
+    ].compact.join("\n")
+
+    category_double = double(
       Contentful::Entry,
       id: hash_response.dig("sys", "id"),
       sections: sections,
-      specification_template: hash_response.dig("fields", "specification_template")
+      specification_template: hash_response.dig("fields", "specification_template"),
+      specification_template_part_2: hash_response.dig("fields", "specification_template_part_2"),
+      combined_specification_template: combined_specification_template
     )
+
+    allow(category_double).to receive(:combined_specification_template=)
+      .with(combined_specification_template)
+
+    category_double
   end
 
   def fake_contentful_section(contentful_fixture_filename:)


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

The field coming back from Contentful for a Category called `specification_template` has a problem in that we have added more than 50,000 characters to it. The team still need to add more but we think it is unlikely it will ever need to be more than 100k.

Given Categories are generic and may be reused for Catering as well as future categories like Energy, we should keep our field naming approach generic too. For instance, "specification_template_food_section" would not make sense when creating a Energy section and vice versa.

There are 27 unique sections of the specification at the moment. This is far too many to make a single field per section as every new section would require a code change. Eg. `specification_template_section_28` etc.

The solution we've gone for here is to allow the content team to split their content across multiple fields as they see fit. We'll add `specification_template_part_2` and make it easy to add `specification_template_part_3` (or more) in the future _with only_ changes required to Contentful.

Our approach is to intercept the category _as soon as it comes back from Contentful_ and merge it there before it goes any further into the code base. This means we don't have to make more changes to things like our Liquid validator or how we create the Journey record.

## Screenshots of UI changes

### Before

![Screenshot 2021-04-12 at 15 27 03](https://user-images.githubusercontent.com/912473/114904633-f9592880-9e0f-11eb-9d0f-dff31434c39c.png)

### After 
![Screenshot 2021-04-15 at 17 26 45](https://user-images.githubusercontent.com/912473/114904542-e181a480-9e0f-11eb-9173-9d72c5bd5b43.png)
![Screenshot 2021-04-15 at 17 26 31](https://user-images.githubusercontent.com/912473/114904551-e3e3fe80-9e0f-11eb-952b-8f258130ee7c.png)

## Next steps

- [ ] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) 
- [ ] Update Content Model in master environment with new fields