### PR TITLE
Pushes to research branch auto deploy research environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,12 @@ jobs:
         run: |
           script/deploy-terraform
         if: github.ref == 'refs/heads/research'
+      - name: Deploy terraform to preview
+        env:
+          TF_VAR_environment: "preview"
+        run: |
+          script/deploy-terraform
+        if: github.ref == 'refs/heads/main'
       - name: Deploy terraform to prod
         env:
           TF_VAR_environment: "prod"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,12 @@ jobs:
         run: |
           script/deploy-terraform
         if: github.ref == 'refs/heads/develop'
+      - name: Deploy terraform to research
+        env:
+          TF_VAR_environment: "research"
+        run: |
+          script/deploy-terraform
+        if: github.ref == 'refs/heads/research'
       - name: Deploy terraform to prod
         env:
           TF_VAR_environment: "prod"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- auto deploy research and preview environments
+
 ## [release-007] - 2021-05-19
 
 - Add `noindex,nofollow` meta tag to all pages, as per Gov.UK guidance


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

[Our research environment currently doesn't work](https://buy-for-your-school-research.london.cloudapps.digital/). This is in part because environment variables hadn't been set yet. In order to propagate those changes I noticed that there was no automatic dpeloyment of that environment configured yet. 

## Changes in this PR

On pushes to the research branch, deploy terraform.
