### PR TITLE
release-007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+## [release-007] - 2021-05-19
+
 - Add `noindex,nofollow` meta tag to all pages, as per Gov.UK guidance
 - fix API auth by switching mechanism from Basic to Token
 - remove `Returning to this specification` URL from task list
@@ -120,7 +122,8 @@ Contentful fixture
 - Contentful can redirect users to preview endpoints
 - users can be asked to answer a long text question
 
-[unreleased]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-006...HEAD
+[unreleased]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-007...HEAD
+[release-007]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-006...release-007
 [release-006]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-005...release-006
 [release-005]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-004...release-005
 [release-004]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-003...release-004


### PR DESCRIPTION
- Add `noindex,nofollow` meta tag to all pages, as per Gov.UK guidance
- fix API auth by switching mechanism from Basic to Token
- remove `Returning to this specification` URL from task list
- Add Tasks to the database when iterating through Sections from Contentful
- fix XSS vulnerability by sanitising all user answers
- Terraform a new CDN to support the custom host name
