### PR TITLE
(573) Fix fixtures to align with Contentful for multiple specification fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- fix multiple specification fields
+
 ## [release-008] - 2021-05-19
 
 - auto deploy research and preview environments

--- a/app/services/get_category.rb
+++ b/app/services/get_category.rb
@@ -54,7 +54,7 @@ class GetCategory
     # Allow a new `specification_template_part_x` field to be added in Contentful
     # without requiring an additional code change.
     all_specification_fields = (category.public_methods - Object.methods)
-      .grep(/^specification_template(_part_[0-9]+)*(?<!=)$/)
+      .grep(/^specification_template(_part[0-9]+)*(?<!=)$/)
       .sort
 
     all_specification_fields.each do |specification_field|

--- a/spec/fixtures/contentful/categories/category-with-dynamic-liquid-template.json
+++ b/spec/fixtures/contentful/categories/category-with-dynamic-liquid-template.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'>\n  <section>\n    <h2>Menus and ordering</h2>\n    <h3>Food standards</h2>\n    <ol>\n      {% if answer_radio-question %}\n        <li>\n          <p class='govuk-body'>The school also requires the service to comply with the following non-mandatory food standards or schemes:</p>\n          <p class='govuk-body'>{{answer_radio-question}}</p>\n        </li>\n      {% endif %}\n    </ol>\n  </section>\n</artcile>"
+        "specificationTemplate": "<article id='specification'>\n  <section>\n    <h2>Menus and ordering</h2>\n    <h3>Food standards</h2>\n    <ol>\n      {% if answer_radio-question %}\n        <li>\n          <p class='govuk-body'>The school also requires the service to comply with the following non-mandatory food standards or schemes:</p>\n          <p class='govuk-body'>{{answer_radio-question}}</p>\n        </li>\n      {% endif %}\n    </ol>\n  </section>\n</artcile>"
     }
 }

--- a/spec/fixtures/contentful/categories/category-with-invalid-liquid-template.json
+++ b/spec/fixtures/contentful/categories/category-with-invalid-liquid-template.json
@@ -31,6 +31,6 @@
     "fields": {
         "title": "Catering",
         "sections": [],
-        "specification_template": "<h1>{{{invalid Liquid%}}}</h1>"
+        "specificationTemplate": "<h1>{{{invalid Liquid%}}}</h1>"
     }
 }

--- a/spec/fixtures/contentful/categories/category-with-liquid-template.json
+++ b/spec/fixtures/contentful/categories/category-with-liquid-template.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/category-with-no-steps.json
+++ b/spec/fixtures/contentful/categories/category-with-no-steps.json
@@ -31,6 +31,6 @@
     "fields": {
         "title": "Catering",
         "sections": [],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/checkboxes-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/currency-question.json
+++ b/spec/fixtures/contentful/categories/currency-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/extended-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/extended-checkboxes-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1><ul>{% for checkbox_answer in answer_extended-checkboxes-question['selected_answers'] %}<li>{{ checkbox_answer['human_value'] }}</li><li>{{ checkbox_answer.further_information }}</li>{% endfor %}</ul></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1><ul>{% for checkbox_answer in answer_extended-checkboxes-question['selected_answers'] %}<li>{{ checkbox_answer['human_value'] }}</li><li>{{ checkbox_answer.further_information }}</li>{% endfor %}</ul></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/extended-long-answer-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/extended-long-answer-checkboxes-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/extended-long-answer-radio-question.json
+++ b/spec/fixtures/contentful/categories/extended-long-answer-radio-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>{{answer_extended-radio-question}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>{{answer_extended-radio-question}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/extended-radio-question.json
+++ b/spec/fixtures/contentful/categories/extended-radio-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>{{answer_extended-radio-question}}</h1><ul>{% for extended_answer in extended_answer_extended-radio-question %}<li>{{ extended_answer['response'] }}</li><li>{{ extended_answer['further_information'] }}</li>{% endfor %}</ul></article>"
+        "specificationTemplate": "<article id='specification'><h1>{{answer_extended-radio-question}}</h1><ul>{% for extended_answer in extended_answer_extended-radio-question %}<li>{{ extended_answer['response'] }}</li><li>{{ extended_answer['further_information'] }}</li>{% endfor %}</ul></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/hidden-field.json
+++ b/spec/fixtures/contentful/categories/hidden-field.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>{{answer_hidden-field}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>{{answer_hidden-field}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/journey-with-multiple-entries.json
+++ b/spec/fixtures/contentful/categories/journey-with-multiple-entries.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/journey-with-repeat-entries.json
+++ b/spec/fixtures/contentful/categories/journey-with-repeat-entries.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/long-text-question.json
+++ b/spec/fixtures/contentful/categories/long-text-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/markdown-help-text.json
+++ b/spec/fixtures/contentful/categories/markdown-help-text.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/missing-entry-id.json
+++ b/spec/fixtures/contentful/categories/missing-entry-id.json
@@ -31,6 +31,6 @@
     "fields": {
         "title": "Catering",
         "sections": [],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/multiple-sections-and-steps.json
+++ b/spec/fixtures/contentful/categories/multiple-sections-and-steps.json
@@ -46,6 +46,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/multiple-sections.json
+++ b/spec/fixtures/contentful/categories/multiple-sections.json
@@ -46,6 +46,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/multiple-specification-templates.json
+++ b/spec/fixtures/contentful/categories/multiple-specification-templates.json
@@ -42,7 +42,7 @@
                 }
             }
         ],
-        "specification_template": "<article id='specification'>\n  <section>\n   <p>Part 1</p>\n  </section>\n</article>",
-        "specification_template_part_2": "<article id='specification'>\n  <section>\n    <p>Part 2</p>\n  </section>\n</article>"
+        "specificationTemplate": "<article id='specification'>\n  <section>\n   <p>Part 1</p>\n  </section>\n</article>",
+        "specificationTemplatePart2": "<article id='specification'>\n  <section>\n    <p>Part 2</p>\n  </section>\n</article>"
     }
 }

--- a/spec/fixtures/contentful/categories/nil-help-text-radios.json
+++ b/spec/fixtures/contentful/categories/nil-help-text-radios.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/nil-help-text-short-text.json
+++ b/spec/fixtures/contentful/categories/nil-help-text-short-text.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/number-question.json
+++ b/spec/fixtures/contentful/categories/number-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/radio-question-with-separator.json
+++ b/spec/fixtures/contentful/categories/radio-question-with-separator.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/radio-question.json
+++ b/spec/fixtures/contentful/categories/radio-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/short-text-question.json
+++ b/spec/fixtures/contentful/categories/short-text-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/show-one-additional-question.json
+++ b/spec/fixtures/contentful/categories/show-one-additional-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>{{answer_hidden-field}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>{{answer_hidden-field}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/single-date-question.json
+++ b/spec/fixtures/contentful/categories/single-date-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/skippable-checkboxes-question.json
+++ b/spec/fixtures/contentful/categories/skippable-checkboxes-question.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1>{% if answer_skippable-checkboxes-question['skipped'] == true %}Skipped question detected{% endif %}</article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1>{% if answer_skippable-checkboxes-question['skipped'] == true %}Skipped question detected{% endif %}</article>"
     }
 }

--- a/spec/fixtures/contentful/categories/static-content.json
+++ b/spec/fixtures/contentful/categories/static-content.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/unexpected-contentful-question-type.json
+++ b/spec/fixtures/contentful/categories/unexpected-contentful-question-type.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/fixtures/contentful/categories/unexpected-contentful-type.json
+++ b/spec/fixtures/contentful/categories/unexpected-contentful-type.json
@@ -39,6 +39,6 @@
             }
           }
         ],
-        "specification_template": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
     }
 }

--- a/spec/services/get_category_spec.rb
+++ b/spec/services/get_category_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe GetCategory do
 
         # It should leave the original fields as they were
         expect(result.specification_template).to eql("<article id='specification'>\n  <section>\n   <p>Part 1</p>\n  </section>\n</article>")
-        expect(result.specification_template_part_2).to eql("<article id='specification'>\n  <section>\n    <p>Part 2</p>\n  </section>\n</article>")
+        expect(result.specification_template_part2).to eql("<article id='specification'>\n  <section>\n    <p>Part 2</p>\n  </section>\n</article>")
 
         # The result object can be asked for the combined specification template
         expect(result.combined_specification_template)

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -133,16 +133,16 @@ module ContentfulHelpers
     }
 
     combined_specification_template = [
-      hash_response.dig("fields", "specification_template"),
-      hash_response.dig("fields", "specification_template_part_2")
+      hash_response.dig("fields", "specificationTemplate"),
+      hash_response.dig("fields", "specificationTemplatePart2")
     ].compact.join("\n")
 
     category_double = double(
       Contentful::Entry,
       id: hash_response.dig("sys", "id"),
       sections: sections,
-      specification_template: hash_response.dig("fields", "specification_template"),
-      specification_template_part_2: hash_response.dig("fields", "specification_template_part_2"),
+      specification_template: hash_response.dig("fields", "specificationTemplate"),
+      specification_template_part2: hash_response.dig("fields", "specificationTemplatePart2"),
       combined_specification_template: combined_specification_template
     )
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

If you ask for a category over the Contentful API you get `specificationTemplate` rather than `specification_template`. Fortunantely this hasn't caused a problem so far as Contentful makes the method `specification_template` automatically available as a getter on `Contentful::Model`. 

- update all existing fixtures with `specification_template` set from snake case to camel case, making it more accurate which should reduce the chances that this causes a problem in future, but should cause no functional change
- update `specification_template_part_2` to `specificationTemplatePart2` in our fixtures
- fix the regex to account for how Contentful defines getting methods with numbers. Instead of the expected `specification_template_part_2` it actually makes `specification_template_part2` available. Update our calls and stubs to reflect this
