### PR TITLE
(590) Force SSL in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Unreleased]
 - add header and footer information for feedback and data requests
 
+- force SSL in production to only accept HTTPS traffic, enable HSTS and secure tower cookies
+
 ## [release-009] - 2021-05-21
 
 - fix multiple specification fields

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
This does several things that make our app more secure:

1. Redirects any HTTP traffic to HTTPS
1. Enables [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) headers which ensure user agents change HTTP into HTTPS before the request is made
1. Marks cookies as secure so they are not sent over the wire in the clear

https://github.com/rails/rails/blob/794252d70990162d14da17ee854ad353e74297ee/actionpack/lib/action_dispatch/middleware/ssl.rb

