### PR TITLE
Document how to change environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Unreleased]
 
 - error pages are styled
+- document how to manage live environment variables
 
 ## [release-010] - 2021-05-27
 

--- a/doc/managing-environment-variables.md
+++ b/doc/managing-environment-variables.md
@@ -1,5 +1,7 @@
 # Managing environment variables
 
+## Locally
+
 We use [Dotenv](https://github.com/bkeepers/dotenv) to manage our environment variables locally.
 
 The repository will include safe defaults for development in `/.env.example` and for test in `/.env.test`. We use 'example' instead of 'development' (from the Dotenv docs) to be consistent with current dxw conventions and to make it more explicit that these values are not to be committed.
@@ -9,4 +11,7 @@ To manage sensitive environment variables:
 1. Add the new key and safe default value to the `/.env.example` file eg. `ROLLBAR_TOKEN=ROLLBAR_TOKEN`
 2. Add the new key and real value to your local `/.env.development.local` file, which should never be checked into Git. This file will look something like `ROLLBAR_TOKEN=123456789`
 
-Add critical environment variable keys to the Dockerfile where `rake assets:precompile` is run.
+If the environment variable is critical whereby it is required to start the application:
+
+- Add it to [the Dotenv initialiser](../config/initializers/_dotenv.rb).
+- Add it to the Dockerfile where `rake assets:precompile` is run.

--- a/doc/managing-environment-variables.md
+++ b/doc/managing-environment-variables.md
@@ -15,3 +15,52 @@ If the environment variable is critical whereby it is required to start the appl
 
 - Add it to [the Dotenv initialiser](../config/initializers/_dotenv.rb).
 - Add it to the Dockerfile where `rake assets:precompile` is run.
+
+## Live environments
+
+We use [GitHub Secrets as the canonical source of our environment variables](https://github.com/DFE-Digital/buy-for-your-school/settings/secrets/actions).
+
+Environment variables are all managed in the same way. Secrets are kept secret by taking advantage of the protection GitHub Secrets offers. Configuration options which don't necessarily need to be kept secret are still managed through environment variables as part of being [a 12 factor app](https://12factor.net/config).
+
+### Adding a variable
+
+#### Application
+
+A variable will usually be required to be added into each environment through [a new repository secret](https://github.com/DFE-Digital/buy-for-your-school/settings/secrets/actions/new). For this we use prefixes in our environment variable names:
+
+```
+APP_ENV_PROD_
+APP_ENV_STAGING_
+APP_ENV_RESEARCH_
+APP_ENV_PREVIEW_
+```
+
+For instance if the app needed to access `ENV["RAILS_ENV"]` in production we would add this as the key:
+
+```
+APP_ENV_PROD_RAILS_ENV
+```
+
+
+**Important!**
+To propagate these new environment variables to the live environments we must finally deploy them manually. [Find the most recent passing deploy](https://github.com/DFE-Digital/buy-for-your-school/actions/workflows/deploy.yml) for the environment you want to provision the new variable on, view it and select "re-run jobs".
+
+### Infrastructure
+
+We can also make variables available for Terraform so that it can be configured.
+
+Here's an example of how `_TF_VAR` is used together with environment prefixes to pass `SYSLOG_DRAIN_URL` information. In this case it configures where logs should be forwarded to at the infrastructure level:
+
+```
+PREVIEW_TF_VAR_SYSLOG_DRAIN_URL
+```
+
+## Viewing a variable
+
+There is no way to view variables through GitHub Secrets once set.
+
+Though the GitHub secret API could be used, the easiest way to get application variables is to [access the console for the environment you want](console-access.md) and ask Rails for it over the console.
+
+```
+$irb> ENV["RAILS_ENV"]
+```

--- a/script/test
+++ b/script/test
@@ -31,5 +31,5 @@ else
   bundle exec rspec
 
   echo "==> Running Brakeman"
-  bundle exec brakeman
+  bundle exec brakeman -o /dev/stdout
 fi

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "Authentication", type: :request do
+  after(:each) do
+    RedisSessions.redis.flushdb
+    RedisSessionLookup.redis.flushdb
+  end
+
   describe "Endpoints that don't require authentication" do
     it "the health_check endpoint is not authenticated" do
       get health_check_path


### PR DESCRIPTION
- Document how to view, change and apply environment variables on the live GPaaS environments.
- We make a minor addition to local environment management to include reference to our Dotenv initialiser for use with critical variables whose absense would prevent the app starting.