### PR TITLE
Notify the team on failed deployments

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,3 +17,11 @@ jobs:
         run: docker-compose -f docker-compose.ci.yml build
       - name: Test
         run: docker-compose -f docker-compose.ci.yml run --rm test script/test
+      - name: Notify
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          fields: workflow,job,commit,repo,ref,author,took
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,14 @@ jobs:
         run: echo "::set-output name=value::$TF_VAR_docker_image"
       - name: Build
         run: script/docker-push-ghcr
+      - name: Notify
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          fields: workflow,job,commit,repo,ref,author,took
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy:
     needs: build
@@ -69,3 +77,11 @@ jobs:
         run: |
           script/deploy-terraform
         if: github.ref == 'refs/heads/main'
+      - name: Notify
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          fields: workflow,job,commit,repo,ref,author,took
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
We recently failed to notice that [all deployments to all environments were silently failing](https://github.com/DFE-Digital/buy-for-your-school/pull/312).

This was fixed but this change introduces Slack notifications to improve the process so that it proactively tells us when failures are occuring.

We can change the output by following the documentation here https://github.com/8398a7/action-slack.

![Screenshot 2021-04-26 at 14 03 57](https://user-images.githubusercontent.com/912473/116086987-4eaafa80-a698-11eb-9932-95205d8a0483.png)
