### PR TITLE
Existing Specification page displays useful message when no specs exisit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Show Tasks on Journey page; clicking on a Task name takes you to a task page.
 - Show Steps on Task page and allow users to answer questions from Task page
 - fix CI not running RSpec
+- existing specification page displays useful message when no specs exist
 
 ## [release-009] - 2021-05-21
 

--- a/app/views/journeys/index.html.erb
+++ b/app/views/journeys/index.html.erb
@@ -3,19 +3,26 @@
 
 <h1 class="govuk-heading-xl"><%= I18n.t("journey.index.existing.header") %></h1>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Date started</th>
-      <th scope="col" class="govuk-table__header govuk-table__cell--numeric"> </th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @journeys.each do |journey| %>
+<% unless @journeys.empty? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= journey.created_at.strftime("%e %B %Y") %></td>
-        <td class="govuk-table__cell govuk-table__cell--numeric"><a href="<%= journey_path(journey) %>" class="govuk-link">Review and edit</a></td>
+        <th scope="col" class="govuk-table__header">Date started</th>
+        <th scope="col" class="govuk-table__header govuk-table__cell--numeric"> </th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @journeys.each do |journey| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= journey.created_at.strftime("%e %B %Y") %></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"><a href="<%= journey_path(journey) %>" class="govuk-link">Review and edit</a></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="govuk-body"><%= I18n.t("journey.index.existing.empty") %></p>
+  <ul class="govuk-list">
+    <li><a href="start_new-specification" class="govuk-link"><%= link_to I18n.t("dashboard.create.link"), new_journey_path, class: "govuk-link" %></a></li>
+  </ul>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
     index:
       existing:
         header: "Existing specifications"
+        empty: "You currently have no existing specifications, return to create a new specification"
     specification:
       header: "Your specification"
       warning: "You have not completed all the tasks. There may be information missing from your specification."

--- a/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
@@ -33,6 +33,16 @@ feature "Anyone can view a dashboard" do
     expect(page).to have_content("15 February 2021")
   end
 
+  scenario "when a user has no specifications a message is shown" do
+    user = create(:user)
+    user_is_signed_in(user: user)
+
+    visit journeys_path
+
+    expect(page).to have_content(I18n.t("journey.index.existing.empty"))
+    expect(page).to have_content(I18n.t("dashboard.create.link"))
+  end
+
   scenario "user can start a new specification" do
     stub_contentful_category(fixture_filename: "radio-question.json")
 


### PR DESCRIPTION
The Existing Specification page displays a useful message when no specifications exisit

## Screenshots of UI changes

![Screen Shot 2021-04-27 at 11 39 18](https://user-images.githubusercontent.com/59832893/116073625-92960380-a688-11eb-813d-6b18c8f315a9.png)

