### PR TITLE
RSpec now runs on all examples when run by CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog 1.0.0].
   between Tasks and Steps.
 - Show Tasks on Journey page; clicking on a Task name takes you to a task page.
 - Show Steps on Task page and allow users to answer questions from Task page
+- fix CI not running RSpec
 
 ## [release-009] - 2021-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
+
 - add header and footer information for feedback and data requests
-
 - force SSL in production to only accept HTTPS traffic, enable HSTS and secure tower cookies
-
 - prevent concurrent sign ins
-
 - Create Task model; fetch tasks from Contentful and create them in the
   database.
 - Break direct association between Journey and Steps. Create new association
   between Tasks and Steps.
-- Show Tasks on Journey page; clicking on a Task name takes you to a task page. 
+- Show Tasks on Journey page; clicking on a Task name takes you to a task page.
 - Show Steps on Task page and allow users to answer questions from Task page
 
 ## [release-009] - 2021-05-21

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY lib ${INSTALL_PATH}/lib
 COPY config ${INSTALL_PATH}/config
 COPY db ${INSTALL_PATH}/db
 COPY script ${INSTALL_PATH}/script
+COPY spec ${INSTALL_PATH}/spec
 COPY app ${INSTALL_PATH}/app
 # End
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -53,10 +53,6 @@ class AnswersController < ApplicationController
     @step.task
   end
 
-  def journey_id
-    params[:journey_id]
-  end
-
   def step_id
     params[:step_id]
   end

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -32,10 +32,4 @@ class JourneysController < ApplicationController
     @journey = current_journey
     @sections = @journey.sections.includes(:tasks)
   end
-
-  private
-
-  def journey_id
-    params[:id]
-  end
 end

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -25,10 +25,4 @@ class SpecificationsController < ApplicationController
       end
     end
   end
-
-  private
-
-  def journey_id
-    params[:journey_id]
-  end
 end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -40,8 +40,4 @@ class StepsController < ApplicationController
   def parent_task
     @step.task
   end
-
-  def journey_id
-    params[:journey_id]
-  end
 end

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -16,7 +16,7 @@ services:
        - .env.test
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: redis://test-redis:6379
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
     networks:
       - test

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,6 +18,7 @@ services:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
       REDIS_URL: redis://test-redis:6379
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+      CI: "true"
     networks:
       - test
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -16,7 +16,7 @@ services:
        - .env.test
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: redis://test-redis:6379
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
     volumes:
       - .:/srv/app

--- a/script/test
+++ b/script/test
@@ -1,9 +1,35 @@
 #!/bin/sh
 
-# script/server: Launch the application and any extra required processes
-#                locally.
+# script/test: Run the test suite for the application. Optionally pass in a path
+#              to an individual test file to run a single test.
 
 set -e
 
-bundle exec rake
-bundle exec brakeman -o /dev/stdout
+cd "$(dirname "$0")/.."
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+echo "==> Updating..."
+
+TEST_FILE=$1
+
+if [ -n "$TEST_FILE" ]; then
+  echo "==> Running the tests matching '$TEST_FILE'..."
+  bundle exec rspec --pattern "$TEST_FILE"
+else
+  if [ -n "$CI" ]; then
+    echo "==> Linting Ruby..."
+    bundle exec standardrb
+  else
+    echo "==> Linting Ruby in fix mode..."
+    bundle exec standardrb --fix
+  fi
+
+  echo "==> Running the tests..."
+  bundle exec rspec
+
+  echo "==> Running Brakeman"
+  bundle exec brakeman
+fi


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- CI has been running RSpec but RSpec hasn't had any files to test in 1 month https://github.com/DFE-Digital/buy-for-your-school/pull/245. [For example this is a feature 11 days ago with missing rspec ourput](https://github.com/DFE-Digital/buy-for-your-school/runs/2354797149?check_suite_focus=true#step:4:40) (action history doesn't go back that far)
- Fix this issue by copying spec files into the image (remember this used to be `COPY . .` so this change isn't conceptually new)
- Fix missed docker-compose redis configuration problem we now get when running rspec again

Please investigate the Test action for this pull request and verify that the output of RSpec is actually testing our ~359 examples!