### PR TITLE
Don't notify on every failed build, only those during deployments

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,11 +17,3 @@ jobs:
         run: docker-compose -f docker-compose.ci.yml build
       - name: Test
         run: docker-compose -f docker-compose.ci.yml run --rm test script/test
-      - name: Notify
-        uses: 8398a7/action-slack@v3
-        if: failure()
-        with:
-          fields: workflow,job,commit,repo,ref,author,took
-          status: ${{ job.status }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
The slack channel is going to get very noisy if we notify on test failures for pull request test runs. The dev should already be looking at the pull request to go green before moving it into review so an additional Slack message isn't necessary, I don't think.