### PR TITLE
Text input field width is now to set to `full` to fit the screen width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Show Steps on Task page and allow users to answer questions from Task page
 - fix CI not running RSpec
 - existing specification page displays useful message when no specs exist
+- fix text input field width to fit full screen width
 
 ## [release-009] - 2021-05-21
 

--- a/app/views/steps/long_text.html.erb
+++ b/app/views/steps/long_text.html.erb
@@ -2,7 +2,7 @@
   <%= f.govuk_text_area :response,
     label: { text: @step_presenter.title, size: "l" },
     hint: -> { @step_presenter.help_text_html },
-    width: "one-third",
+    width: "full",
     rows: 9
   %>
 <% end %>

--- a/app/views/steps/short_text.html.erb
+++ b/app/views/steps/short_text.html.erb
@@ -2,6 +2,6 @@
   <%= f.govuk_text_field :response,
     label: { text: @step_presenter.title, size: "l" },
     hint: -> { @step_presenter.help_text_html },
-    width: "one-third"
+    width: "full"
   %>
 <% end %>


### PR DESCRIPTION
## Changes in this PR

Fixes text input fields width and now displays to full width

## Screenshots of UI changes

### Before

![Screen Shot 2021-04-27 at 17 14 07](https://user-images.githubusercontent.com/59832893/116116316-eddceb80-a6b2-11eb-8708-fda8600dc552.png)

### After

![Screen Shot 2021-04-27 at 17 13 46](https://user-images.githubusercontent.com/59832893/116116331-f2090900-a6b2-11eb-9932-2af6d1ad6503.png)

