### PR TITLE
Document where to find the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix CI not running RSpec
 - existing specification page displays useful message when no specs exist
 - fix text input field width to fit full screen width
+- document where to find the service in the readme
 
 ## [release-009] - 2021-05-21
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ in doc/architecture/decisions and contributed to with the
 
 ## Access
 
-TODO: Where can people find the service and the different environments?
+| Environment    | URL                                                            |
+| :------------- | :------------------------------------------------------------: |
+|  Development   | http://localhost:3000                                          |
+|  Research      | https://buy-for-your-school-research.london.cloudapps.digital  |
+|  Preview       | https://buy-for-your-school-preview.london.cloudapps.digital   |
+|  Staging       | https://staging-get-help-buying-for-schools.education.gov.uk   |
+|  Production    | https://get-help-buying-for-schools.education.gov.uk           |
 
 ## Source
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->
Now we are on GPaaS add our education.gov.uk domains.

![Screenshot 2021-04-26 at 18 15 29](https://user-images.githubusercontent.com/912473/116123871-72cc0300-a6bb-11eb-888e-798dec089004.png)

We will hopefully be able to update production without our service.gov.uk domain after passing a beta assessment.

