### PR TITLE
Log webhook information to Rollbar for debugging

### DIFF
--- a/app/controllers/api/contentful/entries_controller.rb
+++ b/app/controllers/api/contentful/entries_controller.rb
@@ -5,6 +5,8 @@ class Api::Contentful::EntriesController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def changed
+    Rollbar.info("Accepted request to cache bust key: #{cache_key}", params: params)
+
     Cache.delete(key: cache_key)
     render json: {status: "OK"}, status: :ok
   end


### PR DESCRIPTION
Webhooks are successfully received but we are finding that the right redis key is not being deleted. Check we are unpacking the params correctly.