### PR TITLE
Always log info about Contentful webhook receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - fix text input field width to fit full screen width
 - document where to find the service in the readme
 - cache CI builds to reduce build times
+- log information about contentful cache busting webhooks for debugging
 
 ## [release-009] - 2021-05-21
 

--- a/app/controllers/api/contentful/entries_controller.rb
+++ b/app/controllers/api/contentful/entries_controller.rb
@@ -5,7 +5,7 @@ class Api::Contentful::EntriesController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def changed
-    Rollbar.info("Accepted request to cache bust key: #{cache_key}", params: params)
+    Rollbar.info("Accepted request to cache bust Contentful Entry", cache_key: cache_key)
 
     Cache.delete(key: cache_key)
     render json: {status: "OK"}, status: :ok

--- a/spec/requests/cache_invalidation_spec.rb
+++ b/spec/requests/cache_invalidation_spec.rb
@@ -34,6 +34,32 @@ RSpec.describe "Cache invalidation", type: :request do
     expect(RedisCache.redis.get("contentful:entry:6zeSz4F4YtD66gT5SFpnSB")).to eq(nil)
   end
 
+  it "logs information of the event in Rollbar for debugging" do
+    fake_contentful_webook_payload = {
+      "entityId": "6zeSz4F4YtD66gT5SFpnSB",
+      "spaceId": "rwl7tyzv9sys",
+      "parameters": {
+        "text": "Entity version: 62"
+      }
+    }
+
+    credentials = ActionController::HttpAuthentication::Token
+      .encode_credentials(ENV["CONTENTFUL_WEBHOOK_API_KEY"])
+    headers = {"AUTHORIZATION" => credentials}
+
+    expect(Rollbar).to receive(:info)
+      .with(
+        "Accepted request to cache bust Contentful Entry",
+        cache_key: "contentful:entry:6zeSz4F4YtD66gT5SFpnSB"
+      ).and_call_original
+
+    post "/api/contentful/entry_updated", {
+      params: fake_contentful_webook_payload,
+      headers: headers,
+      as: :json
+    }
+  end
+
   context "when no basic auth was provided" do
     it "does not delete anything from the cache and returns 401" do
       RedisCache.redis.set("contentful:entry:6zeSz4F4YtD66gT5SFpnSB", "a dummy value")


### PR DESCRIPTION
This was useful for debugging our Contentful webhooks as they weren't working correctly. In this case the Contentful webhook didn't have the right content type set.

Instead of removing this logging, let's make it permenant so we can quickly review basic data on how the service is performing.

We don't want a unique Rollbar event to occur for every entry id so we remove it from the title and move it to the payload. This will mean there should only be a single rollbar item per environment with many occurences, much easier to manage.
