### PR TITLE
Add display of task completion to task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - Update all fixtures to include tasks
 - Update the specs to work with the new task-enabled fixtures
 - Remove `Journey#section_groups` and sever the direct Journey -> Steps association
+- tasks now have their completion status indicated on the task list
 
 ## [release-010] - 2021-05-27
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -25,6 +25,10 @@ class Step < ApplicationRecord
       end
   end
 
+  def answered?
+    !answer.nil?
+  end
+
   def primary_call_to_action_text
     return I18n.t("generic.button.next") unless super.present?
     super

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,11 +5,45 @@ class Task < ApplicationRecord
 
   validates :title, :contentful_id, presence: true
 
+  attr_accessor
+
+  NOT_STARTED = 0
+  IN_PROGRESS = 1
+  COMPLETED = 2
+
   def visible_steps
     steps.where(hidden: false)
   end
 
+  def visible_steps_count
+    visible_steps.count
+  end
+
   def has_single_visible_step?
-    visible_steps.count == 1
+    visible_steps_count == 1
+  end
+
+  def answered_questions_count
+    visible_steps.includes([
+      :short_text_answer,
+      :long_text_answer,
+      :radio_answer,
+      :checkbox_answers,
+      :currency_answer,
+      :number_answer,
+      :single_date_answer
+    ]).count { |step| step.answered? }
+  end
+
+  def status
+    if answered_questions_count == visible_steps_count
+      return COMPLETED
+    end
+
+    if answered_questions_count > 0
+      return IN_PROGRESS
+    end
+
+    NOT_STARTED
   end
 end

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -31,6 +31,13 @@
               <span class="app-task-list__task-name">
                 <%= link_to task.title, journey_task_path(@journey, task), class: "govuk-link", 'aria-describedby': task.id + "-status"%>
               </span>
+              <% if task.status == Task::COMPLETED %>
+                <strong class="govuk-tag app-task-list__tag" id="<%= task.id + "-status" %>"><%= I18n.t("task_list.status.completed") %></strong>
+              <% elsif task.status == Task::IN_PROGRESS %>
+                <strong class="govuk-tag govuk-tag--blue app-task-list__tag" id="<%= task.id + "-status" %>"><%= I18n.t("task_list.status.in_progress") %></strong>
+              <% elsif task.status == Task::NOT_STARTED %>
+                <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="<%= task.id + "-status" %>"><%= I18n.t("task_list.status.not_started") %></strong>
+              <% end %>
             </li>
           <% end %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,7 @@ en:
   task_list:
     status:
       not_started: Not started
+      in_progress: In progress
       completed: Completed
   task:
     buttons:

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Task, type: :model do
     end
   end
 
+  describe "#visible_steps_count" do
+    it "returns the number of visible steps" do
+      task = create(:task)
+      create(:step, :radio, hidden: false, task: task)
+      create(:step, :radio, hidden: true, task: task)
+
+      expect(task.visible_steps_count).to eq 1
+    end
+  end
+
   describe "#has_single_visible_step?" do
     context "when the task has one visible step" do
       it "returns true" do
@@ -38,6 +48,56 @@ RSpec.describe Task, type: :model do
 
         expect(task.has_single_visible_step?).to be false
       end
+    end
+  end
+
+  describe "#answered_questions_count" do
+    it "returns the number of visible questions which have been answered" do
+      task = create(:task)
+      step_1 = create(:step, :radio, hidden: false, task: task)
+      create(:radio_answer, step: step_1)
+      step_2 = create(:step, :radio, hidden: true, task: task)
+      create(:radio_answer, step: step_2)
+      create(:step, :radio, hidden: false, task: task)
+      create(:step, :radio, hidden: true, task: task)
+
+      expect(task.answered_questions_count).to eq 1
+    end
+  end
+
+  describe "#status" do
+    it "returns NOT_STARTED when no visible questions have been answered" do
+      task = create(:task)
+      create(:step, :radio, hidden: false, task: task)
+      step_2 = create(:step, :radio, hidden: true, task: task)
+      create(:radio_answer, step: step_2)
+
+      expect(task.status).to eq Task::NOT_STARTED
+    end
+
+    it "returns IN_PROGRESS when some but not all visible questions have been answered" do
+      task = create(:task)
+      step_1 = create(:step, :radio, hidden: false, task: task)
+      create(:radio_answer, step: step_1)
+      step_2 = create(:step, :radio, hidden: true, task: task)
+      create(:radio_answer, step: step_2)
+      create(:step, :radio, hidden: true, task: task)
+      create(:step, :radio, hidden: false, task: task)
+
+      expect(task.status).to eq Task::IN_PROGRESS
+    end
+
+    it "returns COMPLETED when all visible questions have been answered" do
+      task = create(:task)
+      step_1 = create(:step, :radio, hidden: false, task: task)
+      create(:radio_answer, step: step_1)
+      step_2 = create(:step, :radio, hidden: true, task: task)
+      create(:radio_answer, step: step_2)
+      step_3 = create(:step, :radio, hidden: false, task: task)
+      create(:radio_answer, step: step_3)
+      create(:step, :radio, hidden: true, task: task)
+
+      expect(task.status).to eq Task::COMPLETED
     end
   end
 end


### PR DESCRIPTION
This adds display of "not started", "in progress" or "completed" labels to task groups on the task list.

## Screenshots of UI changes

### Before

![localhost_3000_journeys_3f749c37-b869-48d3-ad3f-7ad4e3a1fbc9 (1)](https://user-images.githubusercontent.com/619082/116253588-82555580-a768-11eb-9795-7c3746c48f7c.png)

### After

![localhost_3000_journeys_3f749c37-b869-48d3-ad3f-7ad4e3a1fbc9](https://user-images.githubusercontent.com/619082/116253579-81242880-a768-11eb-9057-c1e29a1d5f0b.png)

## Next steps

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) --
