### PR TITLE
Fix deployments by removing yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN mkdir -p ${DEPS_HOME}
 WORKDIR $DEPS_HOME
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
-  && apt-get install -y nodejs \
-  && npm install --global yarn
+  && apt-get install -y nodejs
 
 # Install Javascript dependencies
 COPY package-lock.json $DEPS_HOME/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,9 +84,19 @@ RUN mkdir -p tmp/pids
 RUN cp -R $DEPS_HOME/node_modules $APP_HOME/node_modules
 RUN cp -R $DEPS_HOME/node_modules/govuk-frontend/govuk/assets $APP_HOME/app/assets
 
-RUN if [ "$RAILS_ENV" = "production" ]; then \
-      RAILS_ENV=production SECRET_KEY_BASE="key" bundle exec rake assets:precompile; \
-    fi
+RUN RAILS_ENV=production \
+    SECRET_KEY_BASE="key" \
+    APPLICATION_URL= \
+    CONTENTFUL_URL= \
+    CONTENTFUL_SPACE= \
+    CONTENTFUL_ENVIRONMENT= \
+    CONTENTFUL_ACCESS_TOKEN= \
+    CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID= \
+    CONTENTFUL_PREVIEW_APP= \
+    CONTENTFUL_ENTRY_CACHING= \
+    SUPPORT_EMAIL= \
+    REDIS_URL= \
+    bundle exec rake assets:precompile
 
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/doc/managing-environment-variables.md
+++ b/doc/managing-environment-variables.md
@@ -8,3 +8,5 @@ To manage sensitive environment variables:
 
 1. Add the new key and safe default value to the `/.env.example` file eg. `ROLLBAR_TOKEN=ROLLBAR_TOKEN`
 2. Add the new key and real value to your local `/.env.development.local` file, which should never be checked into Git. This file will look something like `ROLLBAR_TOKEN=123456789`
+
+Add critical environment variable keys to the Dockerfile where `rake assets:precompile` is run.


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

We recently changed the Dockerfile so it accidentally installed `yarn`. This has an unintended consequence when running `bundle exec rake assets:precompile` which causes [builds to fail](https://github.com/DFE-Digital/buy-for-your-school/runs/2449168818?check_suite_focus=true).

I'm not sure how we would install `yarn` and switch from `npm`. Perhaps by using `webpacker`. Suffice to say this is not the current aim so we can fight that one another day.

We make a change to how we run precompile so it we get failure feedback when CI runs on pull requests. Preventing this scenario where the deployment pipeline is unexpectedly blocked.