### PR TITLE
Inline scripts now use nonce's

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,12 +23,14 @@
     <%= csrf_meta_tags %>
 
     <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
+
+    <%= csp_meta_tag %>
   </head>
 
   <body class="govuk-template__body ">
-    <script>
+      <%= javascript_tag nonce: true do -%>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <% end -%>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
@@ -99,9 +101,9 @@
     </footer>
 
     <%= javascript_include_tag "application", "data-turbolinks-track" => "reload" %>
-    <script>
+    <%= javascript_tag nonce: true do -%>
       window.GOVUKFrontend.initAll()
-    </script>
+    <% end -%>
   </body>
 
 </html>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -20,6 +20,8 @@ Rails.application.config.content_security_policy do |policy|
   # policy.report_uri "/csp-violation-report-endpoint"
 end
 
+Rails.application.config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
+
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
 


### PR DESCRIPTION
## Changes made

Expandable text fields were visible by default

When we switched on the content security policy, we didn't allow inline scripts. We now use the built in helper to generate a nonce for these so the scripts can be loaded.

## Screenshots

## Before

![Screen Shot 2021-04-29 at 17 41 20](https://user-images.githubusercontent.com/59832893/116441096-0979fa80-a849-11eb-9f14-5bc1b2ae381d.png)

![Screen Shot 2021-04-29 at 17 41 14](https://user-images.githubusercontent.com/59832893/116441130-126acc00-a849-11eb-8ba3-be718d465913.png)

## After

![Screen Shot 2021-04-29 at 17 39 49](https://user-images.githubusercontent.com/59832893/116441183-21517e80-a849-11eb-8c15-a8d428e5b2d7.png)

![Screen Shot 2021-04-29 at 17 39 38](https://user-images.githubusercontent.com/59832893/116441196-24e50580-a849-11eb-9bac-a862df118923.png)




