### PR TITLE
(611) Fix bug that causes deployment failure when there short ENV values are present

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,6 @@ env:
   CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}
 
 jobs:
   build:
@@ -48,11 +47,12 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      TF_VAR_docker_image: ${{needs.build.outputs.tf_var_docker_image}}
+      GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Set TFVAR Docker Image environment variable
-        run: echo "TF_VAR_docker_image=${{needs.build.outputs.tf_var_docker_image}}" >> $GITHUB_ENV
       - name: Deploy terraform to staging
         env:
           TF_VAR_environment: "staging"


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## The problem

This change attempts to allow us to once again set environment variables that contain small numbers (such as `30`) without introducing the chance of random deployment failures. These have been occuring when the value appears randomly in the `GIT_SHA` of the commit being deployed.

This happens because of [the way we use `set-output` to pass `DOCKER_IMAGE`](https://github.com/DFE-Digital/buy-for-your-school/blob/develop/.github/workflows/deploy.yml#L36) from one GitHub Action step, to another. This works great normally, GitHub helpfully obfuscates usage of values that are also included as a secret to stop us leaking sensitive information by accident. 

When we want to use `set-output` to pass a value to another step and that value partially matches a secret, then we get the problem: 

When we intend to set `ghcr.io/buy-for-your-school-123-1234567890` we end up setting `ghcr.io/buy-for-your-school-123-12***4567890`. This isn't the image we pushed to the container registry and so the deployment fails with an unhelpful "No image exists".

## Changes in this PR

In this pull request we propose a fix and include 2 temporary WIP commits to demonstrate how this works. We will remove these before we merge!

I found that GitHub Actions only starts obfuscating our `set-output` output when we also load/use the `${{secrets}}` within the _same_ job. If we don't load the environment variable that includes the 30, it doesn't get obfuscated. This was always the case as we had `GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}` set globally. If you remove that, then most of the obfuscation stops.

* We move the GitHub Action ENV of `DOCKER_SECRETS_JSON` out of the global scope and pass it into each job that needs it. Whilst this is a small duplication it does 3 helpful things:
  1. `set-output` in the build job can successfully set a value if it includes a secret, eg. "production"
  2. we make it clearer which jobs use which variables for improved readability. This variable and its contents are only used for the app deployment to provision all configuration - no other part of the deployment process
  3. the first 'build' job to functions _without_ being given the application secrets. It doesn't need them and  allows GitHub Actions to log helpful information. Preventing unhelpful obfuscation of words like "research" and "production" which appear
* Instead of passing the `DOCKER_IMAGE` variable to the deployment script by environment variable, we avoid using `echo` and pass it as an argument to the deployment script. 

## Screenshots of UI changes

GitHub Actions continues to obfuscate the output making it hard to test and prove. Since it is hard to observe values output to the build log that have actually been set to include `***` as opposed to those that are still correct but obfuscated. To get around this this works I added a test script in the WIP commits which make a request to an open endpoint. 

This (hopefully) proves that using these changes, at the time of deployment the script now has available a correct `DOCKER_IMAGE`. 

You'll notice I added the suffix of "-production" to the `DOCKER_TAG` as we are building it. This is designed to conflict with the secret of `RAILS_ENV` which should simulate what happens when the `DOCKER_IMAGE` includes a value that's also a secret. If the Terraform script has access to the correct environment variable (no asterisks) then it should be able to deploy the right docker image, should a conflict occur.

![Screenshot 2021-05-05 at 13 55 01](https://user-images.githubusercontent.com/912473/117146511-2e6fef80-adac-11eb-822c-18df71a92754.png)


## Other options

Our plan B for this would be to squish both build and deploy tasks into the same job, removing the need to pass on knowledge of the `DOCKER_IMAGE` to each step. Failing that, we could make reduce the chances of this collision by meaning that all variables have to be 3 or 4 characters. 