### PR TITLE
Add backend functionality to record events

### DIFF
--- a/app/models/activity_log_item.rb
+++ b/app/models/activity_log_item.rb
@@ -1,0 +1,4 @@
+class ActivityLogItem < ApplicationRecord
+  self.implicit_order_column = "created_at"
+  self.table_name = "activity_log"
+end

--- a/app/services/record_action.rb
+++ b/app/services/record_action.rb
@@ -1,0 +1,72 @@
+class RecordAction
+  class UnexpectedActionType < StandardError; end
+
+  attr_accessor :action_type, :journey_id, :user_id, :contentful_category_id, :contentful_section_id, :contentful_task_id, :contentful_step_id, :data
+
+  ALLOWED_ACTION_TYPES = %w[
+    begin_journey
+  ].freeze
+
+  def initialize(
+    action:,
+    journey_id:,
+    user_id:,
+    contentful_category_id: nil,
+    contentful_section_id: nil,
+    contentful_task_id: nil,
+    contentful_step_id: nil,
+    data: nil
+  )
+    self.action_type = action
+    self.journey_id = journey_id
+    self.user_id = user_id
+    self.contentful_category_id = contentful_category_id
+    self.contentful_section_id = contentful_section_id
+    self.contentful_task_id = contentful_task_id
+    self.contentful_step_id = contentful_step_id
+    self.data = data
+  end
+
+  def call
+    if unexpected_action_type?
+      send_rollbar_warning
+      raise UnexpectedActionType
+    end
+
+    ActivityLogItem.create(
+      action: action_type,
+      journey_id: journey_id,
+      user_id: user_id,
+      contentful_category_id: contentful_category_id,
+      contentful_section_id: contentful_section_id,
+      contentful_task_id: contentful_task_id,
+      contentful_step_id: contentful_step_id,
+      data: data
+    )
+  end
+
+  private
+
+  def valid_action_type?
+    ALLOWED_ACTION_TYPES.include?(action_type)
+  end
+
+  def unexpected_action_type?
+    !valid_action_type?
+  end
+
+  def send_rollbar_warning
+    Rollbar.warning(
+      "An attempt was made to log an action with an invalid type",
+      action: action_type,
+      journey_id: journey_id,
+      user_id: user_id,
+      contentful_category_id: contentful_category_id,
+      contentful_section_id: contentful_section_id,
+      contentful_task_id: contentful_task_id,
+      contentful_step_id: contentful_step_id,
+      data: data,
+      allowed_action_types: ALLOWED_ACTION_TYPES.join(", ")
+    )
+  end
+end

--- a/db/migrate/20210518084959_create_activity_log.rb
+++ b/db/migrate/20210518084959_create_activity_log.rb
@@ -1,0 +1,22 @@
+class CreateActivityLog < ActiveRecord::Migration[6.1]
+  def change
+    create_table :activity_log, id: :uuid do |t|
+      t.string :journey_id
+      t.string :user_id
+      t.string :contentful_category_id
+      t.string :contentful_section_id
+      t.string :contentful_task_id
+      t.string :contentful_step_id
+      t.string :action
+      t.jsonb :data
+      t.timestamps
+      t.index :journey_id
+      t.index :user_id
+      t.index :contentful_category_id
+      t.index :contentful_section_id
+      t.index :contentful_task_id
+      t.index :contentful_step_id
+      t.index :action
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_11_161352) do
+ActiveRecord::Schema.define(version: 2021_05_18_084959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "activity_log", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "journey_id"
+    t.string "user_id"
+    t.string "contentful_category_id"
+    t.string "contentful_section_id"
+    t.string "contentful_task_id"
+    t.string "contentful_step_id"
+    t.string "action"
+    t.jsonb "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["action"], name: "index_activity_log_on_action"
+    t.index ["contentful_category_id"], name: "index_activity_log_on_contentful_category_id"
+    t.index ["contentful_section_id"], name: "index_activity_log_on_contentful_section_id"
+    t.index ["contentful_step_id"], name: "index_activity_log_on_contentful_step_id"
+    t.index ["contentful_task_id"], name: "index_activity_log_on_contentful_task_id"
+    t.index ["journey_id"], name: "index_activity_log_on_journey_id"
+    t.index ["user_id"], name: "index_activity_log_on_user_id"
+  end
 
   create_table "checkbox_answers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "step_id"

--- a/doc/architecture/013-store-user-activity-in-app.md
+++ b/doc/architecture/013-store-user-activity-in-app.md
@@ -1,0 +1,20 @@
+# 13. store-user-activity-in-app
+
+Date: 2021-05-18
+
+## Status
+
+Accepted
+
+## Context
+
+- We need to keep a record of activities taken by users so that we can gather quantitative research data
+- We need to avoid third-party tracking services, since these carry with them privacy concerns, lack of clarity around retention rules, additional user consent, and the need for additional approvals
+
+## Decision
+
+Store all records of activities taken by users in-app.
+
+## Consequences
+
+- The storing of activity logs will introduce additional database overhead, both in terms of quantity of data and number of queries.

--- a/spec/models/activity_log_item_spec.rb
+++ b/spec/models/activity_log_item_spec.rb
@@ -1,0 +1,4 @@
+require "rails_helper"
+
+RSpec.describe ActivityLogItem, type: :model do
+end

--- a/spec/services/record_action_spec.rb
+++ b/spec/services/record_action_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe RecordAction do
+  describe "#call" do
+    it "records the action in the database" do
+      action = described_class.new(
+        action: "begin_journey",
+        journey_id: "12345678",
+        user_id: "23456789"
+      ).call
+
+      expect(action.action).to eq("begin_journey")
+    end
+
+    context "when the action does not have additional parameters specified" do
+      it "defaults undefined parameters to nil" do
+        action = described_class.new(
+          action: "begin_journey",
+          journey_id: "12345678",
+          user_id: "23456789"
+        ).call
+
+        expect(action.contentful_category_id).to be_nil
+        expect(action.contentful_section_id).to be_nil
+        expect(action.contentful_task_id).to be_nil
+        expect(action.contentful_step_id).to be_nil
+        expect(action.data).to be_nil
+      end
+    end
+
+    context "when the action does has additional parameters specified" do
+      it "correctly records additional parameters" do
+        action = described_class.new(
+          action: "begin_journey",
+          journey_id: "12345678",
+          user_id: "23456789",
+          contentful_category_id: "34567890",
+          contentful_section_id: "45678901",
+          contentful_task_id: "56789012",
+          contentful_step_id: "67890123",
+          data: {}
+        ).call
+
+        expect(action.journey_id).to eq("12345678")
+        expect(action.user_id).to eq("23456789")
+        expect(action.contentful_category_id).to eq("34567890")
+        expect(action.contentful_section_id).to eq("45678901")
+        expect(action.contentful_task_id).to eq("56789012")
+        expect(action.contentful_step_id).to eq("67890123")
+        expect(action.data).to eq({})
+      end
+    end
+
+    context "when the new action has an unexpected action type" do
+      it "raises an error" do
+        expect {
+          described_class.new(
+            action: "invalid_action",
+            journey_id: "12345678",
+            user_id: "23456789"
+          ).call
+        }
+          .to raise_error(RecordAction::UnexpectedActionType)
+      end
+
+      it "raises a rollbar event" do
+        expect(Rollbar).to receive(:warning)
+          .with("An attempt was made to log an action with an invalid type",
+            action: "invalid_action",
+            journey_id: "12345678",
+            user_id: "23456789",
+            contentful_category_id: nil,
+            contentful_section_id: nil,
+            contentful_task_id: nil,
+            contentful_step_id: nil,
+            data: nil,
+            allowed_action_types: RecordAction::ALLOWED_ACTION_TYPES.join(", "))
+          .and_call_original
+        expect {
+          described_class.new(
+            action: "invalid_action",
+            journey_id: "12345678",
+            user_id: "23456789"
+          ).call
+        }
+          .to raise_error(RecordAction::UnexpectedActionType)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

Implement a new model for storing event log entries.

This is a timestamped record, along with:

- Internal user ID
- Internal journey ID
- Contentful category ID
- Contentful task ID
- Contentful section ID
- Contentful question ID
- String to describe the action being taken
- JSONB for additional payload needed to describe context

In all cases we are storing strings and not relationships, since journeys in particular may be purged from the database after inactivity, but we still may want to derive information.