### PR TITLE
Worker healthcheck timeout set to maximum

### DIFF
--- a/terraform/app/locals.tf
+++ b/terraform/app/locals.tf
@@ -40,5 +40,5 @@ locals {
   web_worker_instances            = var.web_worker_instances
   web_worker_disk_quota           = var.web_worker_disk_quota
   web_worker_timeout              = var.web_worker_timeout
-  web_worker_health_check_timeout = var.web_worker_timeout
+  web_worker_health_check_timeout = 180
 }


### PR DESCRIPTION
When we increase `var.web_worker_timeout` to 5 minutes, because it's tied to the `health_check_timeout`, Terraform throws an error since 180 seconds is the maximum for a healthcheck:

```
Error: The app is invalid: health_check_timeout Maximum exceeded: max 180s
```
