### PR TITLE
Rename CreateJourneyStep to CreateStep

### DIFF
--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -7,11 +7,11 @@ class JourneysController < ApplicationController
     render "errors/specification_template_invalid", status: 500, locals: {error: exception}
   end
 
-  rescue_from CreateJourneyStep::UnexpectedContentfulModel, CreateTask::UnexpectedContentfulModel do |exception|
+  rescue_from CreateStep::UnexpectedContentfulModel, CreateTask::UnexpectedContentfulModel do |exception|
     render "errors/unexpected_contentful_model", status: 500
   end
 
-  rescue_from CreateJourneyStep::UnexpectedContentfulStepType do |exception|
+  rescue_from CreateStep::UnexpectedContentfulStepType do |exception|
     render "errors/unexpected_contentful_step_type", status: 500
   end
 

--- a/app/controllers/preview/entries_controller.rb
+++ b/app/controllers/preview/entries_controller.rb
@@ -11,7 +11,7 @@ class Preview::EntriesController < ApplicationController
     task = Task.create(title: "Preview Task", section: section)
 
     contentful_entry = GetEntry.new(entry_id: entry_id).call
-    @step = CreateJourneyStep.new(
+    @step = CreateStep.new(
       task: task, contentful_entry: contentful_entry
     ).call
 

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -32,7 +32,7 @@ class CreateJourney
 
         question_entries = GetStepsFromTask.new(task: contentful_task).call
         question_entries.each do |entry|
-          CreateJourneyStep.new(
+          CreateStep.new(
             contentful_entry: entry, task: task
           ).call
         end

--- a/app/services/create_step.rb
+++ b/app/services/create_step.rb
@@ -1,4 +1,4 @@
-class CreateJourneyStep
+class CreateStep
   class UnexpectedContentfulModel < StandardError; end
 
   class UnexpectedContentfulStepType < StandardError; end

--- a/spec/requests/entry_preview_spec.rb
+++ b/spec/requests/entry_preview_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Entry previews", type: :request do
         .and_return(fake_get_contentful_entry)
 
       fake_step = create(:step, :radio)
-      allow_any_instance_of(CreateJourneyStep).to receive(:call)
+      allow_any_instance_of(CreateStep).to receive(:call)
         .and_return(fake_step)
 
       get "/preview/entries/#{entry_id}"

--- a/spec/services/create_step_spec.rb
+++ b/spec/services/create_step_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CreateJourneyStep do
+RSpec.describe CreateStep do
   describe "#call" do
     context "when the new step is of type step" do
       it "creates a local copy of the new step" do
@@ -221,7 +221,7 @@ process around March.")
         )
 
         expect { described_class.new(task: task, contentful_entry: fake_entry).call }
-          .to raise_error(CreateJourneyStep::UnexpectedContentfulModel)
+          .to raise_error(CreateStep::UnexpectedContentfulModel)
       end
 
       it "raises a rollbar event" do
@@ -241,11 +241,11 @@ process around March.")
             contentful_entry_id: "unexpected-contentful-type",
             content_model: "telepathy",
             step_type: "radios",
-            allowed_content_models: CreateJourneyStep::ALLOWED_CONTENTFUL_MODELS.join(", "),
-            allowed_step_types: CreateJourneyStep::ALLOWED_CONTENTFUL_ENTRY_TYPES.join(", "))
+            allowed_content_models: CreateStep::ALLOWED_CONTENTFUL_MODELS.join(", "),
+            allowed_step_types: CreateStep::ALLOWED_CONTENTFUL_ENTRY_TYPES.join(", "))
           .and_call_original
         expect { described_class.new(task: task, contentful_entry: fake_entry).call }
-          .to raise_error(CreateJourneyStep::UnexpectedContentfulModel)
+          .to raise_error(CreateStep::UnexpectedContentfulModel)
       end
     end
 
@@ -260,7 +260,7 @@ process around March.")
         )
 
         expect { described_class.new(task: task, contentful_entry: fake_entry).call }
-          .to raise_error(CreateJourneyStep::UnexpectedContentfulStepType)
+          .to raise_error(CreateStep::UnexpectedContentfulStepType)
       end
 
       it "raises a rollbar event" do
@@ -280,11 +280,11 @@ process around March.")
             contentful_entry_id: "unexpected-contentful-question-type",
             content_model: "question",
             step_type: "telepathy",
-            allowed_content_models: CreateJourneyStep::ALLOWED_CONTENTFUL_MODELS.join(", "),
-            allowed_step_types: CreateJourneyStep::ALLOWED_CONTENTFUL_ENTRY_TYPES.join(", "))
+            allowed_content_models: CreateStep::ALLOWED_CONTENTFUL_MODELS.join(", "),
+            allowed_step_types: CreateStep::ALLOWED_CONTENTFUL_ENTRY_TYPES.join(", "))
           .and_call_original
         expect { described_class.new(task: task, contentful_entry: fake_entry).call }
-          .to raise_error(CreateJourneyStep::UnexpectedContentfulStepType)
+          .to raise_error(CreateStep::UnexpectedContentfulStepType)
       end
     end
   end


### PR DESCRIPTION
A class rename. The naming now sits better alongside the more recent services of: 

```
- CreateJourney
- CreateJourneyStep => CreateStep
- CreateSection
- CreateTask
```
