### PR TITLE
Fix redis connections on randomly failing on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,8 +17,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/docker-save
-          key:
-            docker-save-${{ hashFiles('Dockerfile', 'Gemfile.lock',
+          key: docker-save-${{ hashFiles('Dockerfile', 'Gemfile.lock',
             'package-lock.json') }}
       - name: Load cached Docker image
         run: docker load -i /tmp/docker-save/snapshot.tar || true
@@ -26,9 +25,8 @@ jobs:
       - name: Build
         run: docker-compose -f docker-compose.ci.yml -p app build
       - name: Test
-        run: docker-compose -f docker-compose.ci.yml run --rm test script/test
+        run: docker-compose -f docker-compose.ci.yml run --rm test
       - name: Prepare Docker cache
-        run:
-          mkdir -p /tmp/docker-save && docker save app_test:latest -o
+        run: mkdir -p /tmp/docker-save && docker save app_test:latest -o
           /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save
         if: always() && steps.cache-docker.outputs.cache-hit != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- prevent random CI failures due to missing Redis connections
+
 ## [release-012] - 2021-05-11
 
 - sections are listed in the order set in Contentful rather than database insert order

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ CMD ["bundle", "exec", "rails", "server"]
 # ------------------------------------------------------------------------------
 FROM web as test
 
-RUN apt-get install -qq -y shellcheck
+RUN apt-get install -qq -y shellcheck wait-for-it
 
 COPY package.json ${APP_HOME}/package.json
 COPY package-lock.json ${APP_HOME}/package-lock.json

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,27 +1,27 @@
-version: "3.8"
+version: '3.8'
 services:
   test:
     build:
       context: .
       target: test
       args:
-        RAILS_ENV: "test"
+        RAILS_ENV: 'test'
       cache_from:
         - app_test:latest
     image: app_test
     command: bundle exec rake
     ports:
-      - "3000:3000"
+      - '3000:3000'
     depends_on:
       - test-db
       - test-redis
     env_file:
-       - .env.test
+      - .env.test
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
       REDIS_URL: redis://test-redis:6379
-      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      CI: "true"
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
+      CI: 'true'
     networks:
       - test
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,7 +9,7 @@ services:
       cache_from:
         - app_test:latest
     image: app_test
-    command: bundle exec rake
+    command: bash -c "wait-for-it test-redis:6379 --strict --timeout=60 -- bundle exec rake"
     ports:
       - '3000:3000'
     depends_on:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,7 +9,7 @@ services:
       cache_from:
         - app_test:latest
     image: app_test
-    command: bash -c "wait-for-it test-redis:6379 --strict --timeout=60 -- bundle exec rake"
+    command: bash -c "wait-for-it test-redis:6379 --strict --timeout=60 -- script/test"
     ports:
       - '3000:3000'
     depends_on:
@@ -21,7 +21,8 @@ services:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
       REDIS_URL: redis://test-redis:6379
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
-      CI: 'true'
+      DOCKER: 'true'
+      AUTOMATICALLY_FIX_LINTING: 'true'
     networks:
       - test
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,7 +6,7 @@ services:
       target: test
       args:
         RAILS_ENV: 'test'
-    command: bundle exec rake
+    command: bash -c "wait-for-it test-redis:6379 --strict --timeout=60 -- bundle exec rake"
     ports:
       - '3000:3000'
     depends_on:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,7 +6,7 @@ services:
       target: test
       args:
         RAILS_ENV: 'test'
-    command: bash -c "wait-for-it test-redis:6379 --strict --timeout=60 -- bundle exec rake"
+    command: bash -c "wait-for-it test-redis:6379 --strict --timeout=60 -- script/test"
     ports:
       - '3000:3000'
     depends_on:
@@ -18,6 +18,8 @@ services:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
       REDIS_URL: redis://test-redis:6379
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
+      DOCKER: 'true'
+      AUTOMATICALLY_FIX_LINTING: 'true'
     volumes:
       - .:/srv/app
     tty: true

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,23 +1,23 @@
-version: "3.8"
+version: '3.8'
 services:
   test:
     build:
       context: .
       target: test
       args:
-        RAILS_ENV: "test"
+        RAILS_ENV: 'test'
     command: bundle exec rake
     ports:
-      - "3000:3000"
+      - '3000:3000'
     depends_on:
       - test-db
       - test-redis
     env_file:
-       - .env.test
+      - .env.test
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/buy-for-your-school-test
       REDIS_URL: redis://test-redis:6379
-      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
     volumes:
       - .:/srv/app
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
-version: "3.8"
+version: '3.8'
 services:
   web:
     build:
       context: .
       target: web
       args:
-        RAILS_ENV: "development"
+        RAILS_ENV: 'development'
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
-      - "3000:3000"
-    image: "buy_for_your_school:dev"
+      - '3000:3000'
+    image: 'buy_for_your_school:dev'
     depends_on:
       - db
       - redis
     env_file:
-       - .env.development.local
+      - .env.development.local
     environment:
       DATABASE_URL: postgres://postgres:password@db:5432/buy-for-your-school-development
       REDIS_URL: redis://redis:6379

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,7 +12,7 @@ if [ -f .gitmodules ]; then
   git submodule update --init
 fi
 
-if [ -z "$CI" ]; then
+if [ -z "$DOCKER" ]; then
   if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
     if ! brew bundle check >/dev/null 2>&1; then
       echo "==> Installing Homebrew dependencies..."
@@ -45,7 +45,7 @@ if ! command -v bundle >/dev/null 2>&1; then
   echo "==> Installing Bundler..."
   gem install bundler
 
-  if [ -z "$CI" ]; then
+  if [ -z "$DOCKER" ]; then
     rbenv rehash
   fi
 fi

--- a/script/test
+++ b/script/test
@@ -20,12 +20,12 @@ if [ -n "$TEST_FILE" ]; then
   echo "==> Running the tests matching '$TEST_FILE'..."
   bundle exec rspec --pattern "$TEST_FILE"
 else
-  if [ -n "$CI" ]; then
-    echo "==> Linting Ruby..."
-    bundle exec standardrb
-  else
+  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
     echo "==> Linting Ruby in fix mode..."
     bundle exec standardrb --fix
+  else
+    echo "==> Linting Ruby..."
+    bundle exec standardrb
   fi
 
   echo "==> Running the tests..."


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

Failures - particularly on CI - have been randomly occurring recently. Sometimes the test suite runs before Redis is ready and a large part of the test suite fails due to failing Redis connections.

The Debian `wait-for-it` package is used to wait for Redis to be ready _before_ running the tests. This follows this Docker guidance [1]. We give Redis a generous 60 seconds to start up.

Wait for it is only installed in the test stage of the Dockerfile so it should not be included in the deployed image.

[1] https://docs.docker.com/compose/startup-order/


![Screenshot 2021-05-12 at 12 28 55](https://user-images.githubusercontent.com/912473/117968112-be1e1c80-b31d-11eb-8e63-1ce76e2abdf2.png)
