### PR TITLE
Use GitHub Action to clone the master Contentful environment to staging

### DIFF
--- a/.github/workflows/clone-contentful-to-research.yml
+++ b/.github/workflows/clone-contentful-to-research.yml
@@ -1,0 +1,23 @@
+name: Contentful clone - Master to Research
+on:
+  workflow_dispatch:
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm install -g contentful-cli
+
+      - name: Authenticate with Contentful
+        run: contentful login --management-token ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
+
+      - name: Delete previous research environment
+        run: contentful space --space-id ${{ secrets.APP_ENV_PROD_CONTENTFUL_SPACE }} environment delete --environment-id research
+
+      - name: Clone master environment to a new research environment
+        run: contentful space --space-id ${{ secrets.APP_ENV_PROD_CONTENTFUL_SPACE }} environment create --name research --environment-id research --source master

--- a/.github/workflows/clone-contentful-to-staging.yml
+++ b/.github/workflows/clone-contentful-to-staging.yml
@@ -1,0 +1,23 @@
+name: Contentful clone - Master to Staging
+on:
+  workflow_dispatch:
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm install -g contentful-cli
+
+      - name: Authenticate with Contentful
+        run: contentful login --management-token ${{ secrets.CONTENTFUL_MANAGEMENT_TOKEN }}
+
+      - name: Delete previous staging environment
+        run: contentful space --space-id ${{ secrets.APP_ENV_PROD_CONTENTFUL_SPACE }} environment delete --environment-id staging
+
+      - name: Clone master environment to a new staging environment
+        run: contentful space --space-id ${{ secrets.APP_ENV_PROD_CONTENTFUL_SPACE }} environment create --name staging --environment-id staging --source master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Unreleased]
 
 - prevent random CI failures due to missing Redis connections
+- GitHub action that allows manual cloning from master to staging with one-click for content testing
 
 ## [release-012] - 2021-05-11
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

The content team need a way to change test their changes to more complex logic such as branching flows that show and hide questions based on extra Contentful logic.

The preview function of Contentful is still useful for testing basic copy changes to a single question. It cannot help us when the test involves stepping through multiple entries.

As a first part of making this testing process easier, we create a new Contentful environment called `staging` and make it possible for GitHub users to easily clone master to staging with 1 click so that the service staging environment (rather than Contentful) can be used for testing purposes - without risking the integrity of production.

The `workflow_dispatch` trigger should only allow this to be triggered manually through the GitHub Actions web interface. We can allow the content team access to this.

I imagine the flow for a content change could be:

1. User clones the `master` Contentful environment into the staging environment using this Action
2. User makes their changes to the `staging` Contentful environment which is a now a copy of `master` which is safe to break
3. User uses our `staging` environment (just as they do now) to review their changes to branching logic etc
4. User copies their changes into the `master` Contentful environment manually (just as they do now) and publishes

This work does not solve the second half of this problem: how do tested changes get released? That action is the more dangerous of the 2. Having a workflow that allows the promotion of staging to master introduces risk to real users. If it's clicked when staging is not in a ready state or if another user had been working on the Contentful staging environment and removed something without the deploying user knowing. Before we get into this we should consider setting up an Amazon S3 bucket and using it store a new backup before each promotion, using the CLIs export feature. For now, the user would have to copy their tested changes from staging into master by hand. The risk of getting this wrong is still there but it is preferable as it's only limited to the entries the user modifies through the web interface.

## Screenshots of UI changes

![Screenshot 2021-05-12 at 15 29 14](https://user-images.githubusercontent.com/912473/117997327-c6388500-b33a-11eb-8f0c-cd355995e623.png)

## Next steps

- [ ] Point staging environment to the contentful staging environment
- [ ] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS)
- [ ] Tell the content team
- [ ] Give the content team access to push the button
