### PR TITLE
(654) Use GitHub environment rather than repository secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 env:
   GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
   GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
-  GHCR_REPO: "ghcr.io/dfe-digital/buy-for-your-school"
+  GHCR_REPO: 'ghcr.io/dfe-digital/buy-for-your-school'
   CF_USER: ${{ secrets.CF_USER }}
   CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -44,9 +44,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  deploy:
+  deploy_staging:
     needs: build
     runs-on: ubuntu-latest
+    environment: staging
+    if: success() && github.ref == 'refs/heads/develop'
     env:
       TF_VAR_docker_image: ${{needs.build.outputs.tf_var_docker_image}}
       GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}
@@ -55,28 +57,72 @@ jobs:
         uses: actions/checkout@v2
       - name: Deploy terraform to staging
         env:
-          TF_VAR_environment: "staging"
-        run: |
-          script/deploy-terraform
-        if: github.ref == 'refs/heads/develop'
+          TF_VAR_environment: 'staging'
+        run: script/deploy-terraform
+
+  deploy_research:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: research
+    if: success() && github.ref == 'refs/heads/research'
+    env:
+      TF_VAR_docker_image: ${{needs.build.outputs.tf_var_docker_image}}
+      GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
       - name: Deploy terraform to research
         env:
-          TF_VAR_environment: "research"
-        run: |
-          script/deploy-terraform
-        if: github.ref == 'refs/heads/research'
+          TF_VAR_environment: 'research'
+        run: script/deploy-terraform
+      - name: Notify
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          fields: workflow,job,commit,repo,ref,author,took
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  deploy_preview:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: preview
+    if: success() && github.ref == 'refs/heads/main'
+    env:
+      TF_VAR_docker_image: ${{needs.build.outputs.tf_var_docker_image}}
+      GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
       - name: Deploy terraform to preview
         env:
-          TF_VAR_environment: "preview"
-        run: |
-          script/deploy-terraform
-        if: github.ref == 'refs/heads/main'
+          TF_VAR_environment: 'preview'
+        run: script/deploy-terraform
+      - name: Notify
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          fields: workflow,job,commit,repo,ref,author,took
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  deploy_production:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    if: success() && github.ref == 'refs/heads/main'
+    env:
+      TF_VAR_docker_image: ${{needs.build.outputs.tf_var_docker_image}}
+      GITHUB_SECRETS_JSON: ${{ toJson(secrets) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
       - name: Deploy terraform to prod
         env:
-          TF_VAR_environment: "prod"
-        run: |
-          script/deploy-terraform
-        if: github.ref == 'refs/heads/main'
+          TF_VAR_environment: 'prod'
+        run: script/deploy-terraform
       - name: Notify
         uses: 8398a7/action-slack@v3
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [release-012] - 2021-05-11
 
 - sections are listed in the order set in Contentful rather than database insert order
+- fix github secret limit by moving from repo secrets to environment secrets
 
 ## [release-011] - 2021-05-10
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

This avoids the [limit of 100](https://docs.github.com/en/actions/reference/encrypted-secrets#limits-for-secrets) `repository` secrets that we just ran into.

By specifying the `environment` within the Github Action job, only the variables within that [Github environment](https://docs.github.com/en/actions/reference/environments#environment-secrets) will be made available.

Given that the environment can only be declared at the top of a `job`, we move  our 4 deployment proceses from `job steps` into individual `jobs`.

I've tested this on the reserch environment. I've removed all RESEARCH keys from the repository secret list and added them all into the environment called `research`. You can take a [peek inside this deployment](https://github.com/DFE-Digital/buy-for-your-school/runs/2582959652?check_suite_focus=true) that the deploy job still gets all the environment variables as previously configured.

The same `APP_ENV_RESEARCH_` prefix is still used even though this change introduces isolation of secrets so that each job should only get ENV for that environment. It is possible that these prefixes could be removed in future but we would need to do more investigation into the [Terraform deployment process that does complex key parsing](https://github.com/DFE-Digital/buy-for-your-school/blob/develop/script/deploy-terraform#L28) in order to pass the variables to the newly deployed containers.

I'll leave the rest of the environment variables on staging, production and preview unchanged until this proposal is reviewed. Once we're happy I'll change the rest of the variables from repoistory variables before we merge.

## Screenshots of UI changes

### Before

![Screenshot 2021-05-12 at 14 57 48](https://user-images.githubusercontent.com/912473/118255707-7b3a8100-b4a4-11eb-9366-596086118d31.png)

### After

![Screenshot 2021-05-14 at 11 14 18](https://user-images.githubusercontent.com/912473/118256576-9063df80-b4a5-11eb-8244-18a1beda5577.png)

![Screenshot 2021-05-14 at 11 03 24](https://user-images.githubusercontent.com/912473/118255641-69f17480-b4a4-11eb-81bb-449b06c3e81a.png)




## Next steps

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->
