### PR TITLE
Fix cloning Contentful environments by cache busting the category

### DIFF
--- a/.github/workflows/clone-contentful-to-research.yml
+++ b/.github/workflows/clone-contentful-to-research.yml
@@ -21,3 +21,10 @@ jobs:
 
       - name: Clone master environment to a new research environment
         run: contentful space --space-id ${{ secrets.APP_ENV_PROD_CONTENTFUL_SPACE }} environment create --name research --environment-id research --source master
+
+      - name: Cache bust the research category record to refresh the environment
+        run: |
+          curl -XPOST -H 'Authorization: Token ${{ secrets.CONTENTFUL_WEBHOOK_API_KEY }}' -H "Content-type: application/json" -d '{
+            "entityId": "${{ secrets.APP_ENV_PROD_CONTENTFUL_DEFAULT_CATEGORY_ENTRY }}",
+            "spaceId": "${{ secrets.APP_ENV_PROD_CONTENTFUL_SPACE }}"
+          }' '${{ secrets.RESEARCH_URL }}/api/contentful/entry_updated'

--- a/.github/workflows/clone-contentful-to-staging.yml
+++ b/.github/workflows/clone-contentful-to-staging.yml
@@ -21,3 +21,10 @@ jobs:
 
       - name: Clone master environment to a new staging environment
         run: contentful space --space-id ${{ secrets.APP_ENV_PROD_CONTENTFUL_SPACE }} environment create --name staging --environment-id staging --source master
+
+      - name: Cache bust the staging category record to refresh the environment
+        run: |
+          curl -XPOST -H 'Authorization: Token ${{ secrets.CONTENTFUL_WEBHOOK_API_KEY }}' -H "Content-type: application/json" -d '{
+            "entityId": "${{ secrets.APP_ENV_PROD_CONTENTFUL_DEFAULT_CATEGORY_ENTRY }}",
+            "spaceId": "${{ secrets.APP_ENV_PROD_CONTENTFUL_SPACE }}"
+          }' '${{ secrets.STAGING_URL }}/api/contentful/entry_updated'


### PR DESCRIPTION
Without this, cloning environments may have no effect on the target environment untill the currently cached content expires. This is 72 hours by default.

This change repurposes the endpoint we send Contentful webhooks to for cache busting. We will target the starting category entry. This is the first entry that is requested from Contentful and contains the mapping to discover all entries. By cache busting this entry, we make sure that all the latest sections, tasks and steps are requested.

A workaround for this change would be to manually edit the category within Contentful. That would have the same affect. This change automates that, making it more likely to not be forgotten.

For testing of entries, the content designer can still edit individual entries as normal and they will be cache busted too.

[I've tested this on the Research environment](https://github.com/DFE-Digital/buy-for-your-school/runs/2602873665?check_suite_focus=true):

![Screenshot 2021-05-17 at 17 44 44](https://user-images.githubusercontent.com/912473/118526427-24e57080-b738-11eb-873c-3fc72cd553ee.png)

