### PR TITLE
(639) Answering a task step takes user to the next step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ## [Unreleased]
 
 - remove now unused GetStepFromSection service to complete code migration to get steps from tasks
+- answering steps in a task may take you to the next step unless you've answered them all
 
 ## [release-013] - 2021-05-18
 

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -20,8 +20,10 @@ class AnswersController < ApplicationController
     if result.success?
       if parent_task.has_single_visible_step?
         redirect_to journey_path(@journey, anchor: @step.id)
-      else
+      elsif parent_task.all_steps_answered?
         redirect_to journey_task_path(@journey, parent_task)
+      else
+        redirect_to journey_step_path(@journey, parent_task.next_unanswered_step_id)
       end
     else
       render "steps/#{@step.contentful_type}", locals: {layout: "steps/new_form_wrapper"}

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -46,6 +46,10 @@ class Task < ApplicationRecord
 
     NOT_STARTED
   end
+
+  def all_steps_answered?
+    eager_loaded_steps.all?(&:answered?)
+  end
   private
 
   def eager_loaded_steps

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -46,4 +46,17 @@ class Task < ApplicationRecord
 
     NOT_STARTED
   end
+  private
+
+  def eager_loaded_steps
+    @eager_loaded_steps ||= steps.includes([
+      :short_text_answer,
+      :long_text_answer,
+      :radio_answer,
+      :checkbox_answers,
+      :currency_answer,
+      :number_answer,
+      :single_date_answer
+    ])
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -50,6 +50,17 @@ class Task < ApplicationRecord
   def all_steps_answered?
     eager_loaded_steps.all?(&:answered?)
   end
+
+  def next_unanswered_step_id
+    step_ids = eager_loaded_steps.pluck(:id)
+    answered_step_ids = steps_with_answers.pluck(:id)
+
+    remaining_ids = step_ids - answered_step_ids
+
+    return nil if remaining_ids.empty?
+
+    remaining_ids.first
+  end
   private
 
   def eager_loaded_steps

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -61,6 +61,11 @@ class Task < ApplicationRecord
 
     remaining_ids.first
   end
+
+  def steps_with_answers
+    eager_loaded_steps.select(&:answered?)
+  end
+
   private
 
   def eager_loaded_steps

--- a/spec/features/school_buying_professionals/complete_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/complete_a_journey_spec.rb
@@ -469,4 +469,29 @@ feature "Anyone can start a journey" do
       expect(page).to have_current_path(journey_url(journey, anchor: answer.step.id))
     end
   end
+
+  context "when a task has more than 1 question" do
+    scenario "the user is taken straight to the next question" do
+      start_journey_from_category_and_go_to_question(category: "task-with-multiple-steps.json")
+      journey = Journey.last
+      task = journey.sections.first.tasks.first
+
+      click_first_link_in_task_list
+
+      choose("Catering")
+      click_on(I18n.t("generic.button.next"))
+
+      fill_in "answer[response]", with: "This is my short answer"
+      click_on(I18n.t("generic.button.next"))
+
+      fill_in "answer[response]", with: "This is my long answer"
+      click_on(I18n.t("generic.button.next"))
+
+      check("Breakfast")
+      click_on(I18n.t("generic.button.next"))
+
+      expect(page).to have_content("Task with multiple steps")
+      expect(page).to have_current_path(journey_task_url(journey, task))
+    end
+  end
 end

--- a/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
@@ -188,6 +188,9 @@ feature "Users can view the task list" do
         choose("School expert")
         click_on("Continue")
 
+        # We get taken to the next question so we go back to the task page
+        click_on(I18n.t("generic.button.back"))
+
         # Check that "What colour is in the sky added to the correct place in the list"
         steps = find_all(".app-task-list__item.step__item")
         within(".app-task-list") do

--- a/spec/features/school_buying_professionals/view_a_task_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_task_spec.rb
@@ -63,7 +63,7 @@ feature "Users can view a task" do
       expect(page).to have_content "Task with multiple steps"
     end
 
-    it "allows the user to click on a step to supply an answer, and returns to the task page" do
+    it "allows the user to click on a step to supply an answer, and be taken to the next step" do
       start_journey_with_tasks_from_category(category: "section-with-multiple-tasks.json")
 
       within(".app-task-list") do
@@ -71,8 +71,33 @@ feature "Users can view a task" do
       end
 
       click_on "Which service do you need?"
+
       choose "Catering"
-      click_on "Continue"
+      click_on(I18n.t("generic.button.next"))
+
+      expect(page).to have_content "What email address did you use?"
+    end
+
+    it "allows the user to click on a step to supply the last answer in a task, and be taken to the task page" do
+      start_journey_with_tasks_from_category(category: "section-with-multiple-tasks.json")
+
+      within(".app-task-list") do
+        click_on "Task with multiple steps"
+      end
+
+      click_on "Which service do you need?"
+
+      choose "Catering"
+      click_on(I18n.t("generic.button.next"))
+
+      fill_in "answer[response]", with: "This is my short answer"
+      click_on(I18n.t("generic.button.next"))
+
+      fill_in "answer[response]", with: "This is my long answer"
+      click_on(I18n.t("generic.button.next"))
+
+      check("Breakfast")
+      click_on(I18n.t("generic.button.next"))
 
       expect(page).to have_content "Task with multiple steps"
       within(".app-task-list") do

--- a/spec/fixtures/contentful/001-categories/task-with-multiple-steps.json
+++ b/spec/fixtures/contentful/001-categories/task-with-multiple-steps.json
@@ -1,0 +1,44 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "rwl7tyzv9sys"
+      }
+    },
+    "id": "contentful-category-entry",
+    "type": "Entry",
+    "createdAt": "2021-01-20T12:19:10.220Z",
+    "updatedAt": "2021-01-20T15:06:12.067Z",
+    "environment": {
+      "sys": {
+        "id": "develop",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 2,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "category"
+      }
+    },
+    "locale": "en-US"
+  },
+  "fields": {
+    "title": "Catering",
+    "sections": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "task-with-multiple-steps"
+        }
+      }
+    ],
+    "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+  }
+}

--- a/spec/fixtures/contentful/002-sections/task-with-multiple-steps.json
+++ b/spec/fixtures/contentful/002-sections/task-with-multiple-steps.json
@@ -1,0 +1,43 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "rwl7tyzv9sys"
+      }
+    },
+    "id": "task-with-multiple-steps",
+    "type": "Entry",
+    "createdAt": "2021-02-01T10:47:10.257Z",
+    "updatedAt": "2021-02-01T10:47:10.257Z",
+    "environment": {
+      "sys": {
+        "id": "develop",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "section"
+      }
+    },
+    "locale": "en-US"
+  },
+  "fields": {
+    "title": "Section A",
+    "tasks": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "multiple-steps"
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/contentful/003-tasks/multiple-steps.json
+++ b/spec/fixtures/contentful/003-tasks/multiple-steps.json
@@ -1,0 +1,67 @@
+{
+  "metadata": {
+    "tags": []
+  },
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "rwl7tyzv9sys"
+      }
+    },
+    "id": "multiple-steps",
+    "type": "Entry",
+    "createdAt": "2021-04-12T09:38:48.990Z",
+    "updatedAt": "2021-04-12T10:11:05.670Z",
+    "environment": {
+      "sys": {
+        "id": "develop",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 3,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "task"
+      }
+    },
+    "locale": "en-US"
+  },
+  "fields": {
+    "title": "Task with multiple steps",
+    "steps": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "radio-question"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "short-text-question"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "long-text-question"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "checkboxes-question"
+        }
+      }
+    ]
+  }
+}

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -54,10 +54,12 @@ RSpec.describe Task, type: :model do
   describe "#answered_questions_count" do
     it "returns the number of visible questions which have been answered" do
       task = create(:task)
+
       step_1 = create(:step, :radio, hidden: false, task: task)
       create(:radio_answer, step: step_1)
       step_2 = create(:step, :radio, hidden: true, task: task)
       create(:radio_answer, step: step_2)
+
       create(:step, :radio, hidden: false, task: task)
       create(:step, :radio, hidden: true, task: task)
 
@@ -129,6 +131,15 @@ RSpec.describe Task, type: :model do
 
       expect(task.all_steps_answered?).to eq(false)
     end
+
+    context "when there is a hidden step without an answer" do
+      it "ignores it and returns true" do
+        task = create(:task)
+        _hidden_step = create(:step, :radio, task: task, hidden: true)
+
+        expect(task.all_steps_answered?).to eq(true)
+      end
+    end
   end
 
   describe "#next_unanswered_step_id" do
@@ -197,7 +208,7 @@ RSpec.describe Task, type: :model do
     end
   end
 
-  describe "#steps_with_answers" do
+  describe "#visible_steps_with_answers" do
     it "returns all steps with answers" do
       task = create(:task)
 
@@ -207,10 +218,36 @@ RSpec.describe Task, type: :model do
       step_2 = create(:step, :radio, task: task, order: 1)
       _answer_2 = create(:radio_answer, step: step_2)
 
-      result = task.steps_with_answers
+      result = task.visible_steps_with_answers
 
       expect(result).to include(step_2)
       expect(result).not_to include(step_1)
+    end
+
+    context "when there is a hidden step without an answer" do
+      it "returns an empty array" do
+        task = create(:task)
+
+        _step = create(:step, :radio, task: task, order: 0, hidden: true)
+        # Omit an answer for hidden step
+
+        result = task.visible_steps_with_answers
+
+        expect(result).to eq([])
+      end
+    end
+
+    context "when there is a hidden step with an answer" do
+      it "returns an empty array" do
+        task = create(:task)
+
+        step = create(:step, :radio, task: task, order: 0, hidden: true)
+        _answer = create(:radio_answer, step: step)
+
+        result = task.visible_steps_with_answers
+
+        expect(result).to eq([])
+      end
     end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -197,4 +197,20 @@ RSpec.describe Task, type: :model do
     end
   end
 
+  describe "#steps_with_answers" do
+    it "returns all steps with answers" do
+      task = create(:task)
+
+      step_1 = create(:step, :radio, task: task, order: 0)
+      # Omit an answer for step 1
+
+      step_2 = create(:step, :radio, task: task, order: 1)
+      _answer_2 = create(:radio_answer, step: step_2)
+
+      result = task.steps_with_answers
+
+      expect(result).to include(step_2)
+      expect(result).not_to include(step_1)
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -130,4 +130,71 @@ RSpec.describe Task, type: :model do
       expect(task.all_steps_answered?).to eq(false)
     end
   end
+
+  describe "#next_unanswered_step_id" do
+    context "when no steps have answers" do
+      it "returns the first step ID" do
+        task = create(:task)
+
+        step_1 = create(:step, :radio, task: task, order: 0)
+        _step_2 = create(:step, :radio, task: task, order: 1)
+
+        result = task.next_unanswered_step_id
+
+        expect(result).to eq(step_1.id)
+      end
+    end
+
+    context "when all steps have answers" do
+      it "returns nil" do
+        task = create(:task)
+
+        step_1 = create(:step, :radio, task: task, order: 0)
+        _answer_1 = create(:radio_answer, step: step_1)
+
+        step_2 = create(:step, :radio, task: task, order: 1)
+        _answer_2 = create(:radio_answer, step: step_2)
+
+        result = task.next_unanswered_step_id
+
+        expect(result).to eq(nil)
+      end
+    end
+
+    context "when only the first step has been answered" do
+      it "returns the second step ID" do
+        task = create(:task)
+
+        step_1 = create(:step, :radio, task: task, order: 0)
+        _answer_1 = create(:radio_answer, step: step_1)
+
+        step_2 = create(:step, :radio, task: task, order: 1)
+        # Omit an answer for step 2
+
+        result = task.next_unanswered_step_id
+
+        expect(result).to eq(step_2.id)
+      end
+    end
+
+    context "when a middle step has been answered" do
+      it "returns the first step ID" do
+        task = create(:task)
+
+        step_1 = create(:step, :radio, task: task, order: 0)
+        # Omit an answer for step 1
+
+        step_2 = create(:step, :radio, task: task, order: 1)
+        _answer_2 = create(:radio_answer, step: step_2)
+
+        _step_3 = create(:step, :radio, task: task, order: 2)
+        # Omit an answer for step 3
+
+        result = task.next_unanswered_step_id
+
+        expect(result).to eq(step_1.id)
+      end
+    end
+  end
+
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -100,4 +100,34 @@ RSpec.describe Task, type: :model do
       expect(task.status).to eq Task::COMPLETED
     end
   end
+
+  describe "#all_steps_answered?" do
+    it "returns true when all steps have answers" do
+      task = create(:task)
+      step = create(:step, :radio, task: task)
+      _answer = create(:radio_answer, step: step)
+
+      expect(task.all_steps_answered?).to eq(true)
+    end
+
+    it "returns false when no steps have answers" do
+      task = create(:task)
+      _step = create(:step, :radio, task: task)
+      # Omit the creation of an answer
+
+      expect(task.all_steps_answered?).to eq(false)
+    end
+
+    it "returns false when some steps have answers" do
+      task = create(:task)
+
+      step_1 = create(:step, :radio, task: task)
+      _answer_1 = create(:radio_answer, step: step_1)
+
+      _step_2 = create(:step, :radio, task: task)
+      # Omit the creation of an answer for step 2
+
+      expect(task.all_steps_answered?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

Before this change the user would click on one of their tasks and it would present a list of questions. The user would click into a question, answer it and be taken back to the task page.

This is quite a fair bit of back and forth for a user who wants to progress through a related task in the same session. This change will change the redirection in this scenario so that they now only return to the task when we think they're done.

There are more stories to come after this that will change this task page to a check your answers pattern.

## Changes in this PR

- If the task only has 1 step then answering it returns the user to the task page, as before.
- If the step is the last question to be answered then it returns the user to the task page, as before
- Otherwise if there is a remaining unanswered question the user will be taken straight to it now, instead of the task page.

## Screenshots of UI changes

### 1️⃣We start

![Screenshot 2021-05-19 at 16 18 26](https://user-images.githubusercontent.com/912473/118838821-ea0d4500-b8bd-11eb-8a96-6ed4750627cd.png)

### 2️⃣ We select the middle question

![Screenshot 2021-05-19 at 16 18 31](https://user-images.githubusercontent.com/912473/118838830-ebd70880-b8bd-11eb-9853-771edd6a8ae7.png)

### 3️⃣ We answer it and are taken to the first question

![Screenshot 2021-05-19 at 16 18 36](https://user-images.githubusercontent.com/912473/118838835-ed083580-b8bd-11eb-97ab-0701a170c136.png)

### 4️⃣ We answer it and are taken to the last question

![Screenshot 2021-05-19 at 16 18 44](https://user-images.githubusercontent.com/912473/118838849-ee396280-b8bd-11eb-8fe9-a2b1fc2dc2d7.png)

### 5️⃣ We answer it and are taken to back to the task page having completed the task
![Screenshot 2021-05-19 at 16 18 49](https://user-images.githubusercontent.com/912473/118838856-ef6a8f80-b8bd-11eb-86c3-32ccceb11ee1.png)
