### PR TITLE
release-014

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+## [release-014] - 2021-05-20
+
 - remove now unused GetStepFromSection service to complete code migration to get steps from tasks
 - answering steps in a task may take you to the next step unless you've answered them all
 
@@ -174,7 +176,8 @@ The format is based on [Keep a Changelog 1.0.0].
 - Contentful can redirect users to preview endpoints
 - users can be asked to answer a long text question
 
-[unreleased]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-013...HEAD
+[unreleased]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-014...HEAD
+[release-014]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-013...release-014
 [release-013]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-012...release-013
 [release-012]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-011...release-012
 [release-011]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-010...release-011


### PR DESCRIPTION
- remove now unused `GetStepFromSection` service to complete code migration to get steps from tasks
- answering steps in a task may take you to the next step unless you've answered them all

