### PR TITLE
(640) Starting a task should take the user to the first step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog 1.0.0].
 
 - remove now unused GetStepFromSection service to complete code migration to get steps from tasks
 - answering steps in a task may take you to the next step unless you've answered them all
+- tasks with no answers take the user straight to the first question instead of the task page
 
 ## [release-013] - 2021-05-18
 

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -11,9 +11,9 @@ class StepsController < ApplicationController
 
     @answer = AnswerFactory.new(step: @step).call
     @back_url = if !parent_task || parent_task.has_single_visible_step?
-      journey_path(@journey, anchor: @step.id)
+      journey_path(@journey, anchor: @step.id, back_link: true)
     else
-      journey_task_path(@journey, parent_task)
+      journey_task_path(@journey, parent_task, back_link: true)
     end
 
     render @step.contentful_type, locals: {layout: "steps/new_form_wrapper"}
@@ -27,9 +27,9 @@ class StepsController < ApplicationController
 
     @answer = @step.answer
     @back_url = if !parent_task || parent_task.has_single_visible_step?
-      journey_path(@journey, anchor: @step.id)
+      journey_path(@journey, anchor: @step.id, back_link: true)
     else
-      journey_task_path(@journey, parent_task)
+      journey_task_path(@journey, parent_task, back_link: true)
     end
 
     render "steps/#{@step.contentful_type}", locals: {layout: "steps/edit_form_wrapper"}

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -28,6 +28,7 @@ class TasksController < ApplicationController
 
   def redirect_to_first_step_if_task_has_no_answers
     return unless task.answered_questions_count.zero?
+    return if params.fetch(:back_link, nil).present?
 
     redirect_to journey_step_path(current_journey, task.next_unanswered_step_id)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,9 @@
 class TasksController < ApplicationController
+  before_action :redirect_to_first_step_if_task_has_no_answers, only: [:show]
+
   def show
     @journey = current_journey
-    @task = Task.find(task_id)
+    @task = task
     steps = @task.visible_steps.includes([
       :short_text_answer,
       :long_text_answer,
@@ -16,7 +18,17 @@ class TasksController < ApplicationController
 
   private
 
+  def task
+    @task ||= Task.find(task_id)
+  end
+
   def task_id
     params[:id]
+  end
+
+  def redirect_to_first_step_if_task_has_no_answers
+    return unless task.answered_questions_count.zero?
+
+    redirect_to journey_step_path(current_journey, task.next_unanswered_step_id)
   end
 end

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -3,7 +3,7 @@
 <%= link_to I18n.t("generic.button.back"), journeys_path, class: "govuk-back-link" %>
 <h1 class="govuk-heading-xl"><%= I18n.t("specifying.start_page.page_title") %></h1>
 
-<ol class="app-task-list">
+<ol class="app-task-list sections">
   <% @sections.each do |section| %>
     <h2 class="app-task-list__section"><%= section.title %></h2>
     <li>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -3,7 +3,7 @@
 
 <h1 class="govuk-heading-xl"><%= @task.title %></h1>
 
-<ol class="app-task-list">
+<ol class="app-task-list tasks">
   <li>
     <ul class="app-task-list__items">
       <% @steps.each do |step| %>

--- a/spec/features/school_buying_professionals/complete_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/complete_a_journey_spec.rb
@@ -19,7 +19,7 @@ feature "Anyone can start a journey" do
   end
 
   scenario "an answer must be provided" do
-    start_journey_from_category_and_go_to_question(category: "radio-question.json")
+    start_journey_from_category_and_go_to_first_section(category: "radio-question.json")
 
     # Omit a choice
 
@@ -31,12 +31,12 @@ feature "Anyone can start a journey" do
   context "when the Contentful model is of type question" do
     context "when Contentful entry is of type short_text" do
       scenario "user can answer using free text" do
-        start_journey_from_category_and_go_to_question(category: "short-text-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "short-text-question.json")
 
         fill_in "answer[response]", with: "email@example.com"
         click_on(I18n.t("generic.button.next"))
 
-        click_first_link_in_task_list
+        click_first_link_in_section_list
 
         expect(find_field("answer-response-field").value).to eql("email@example.com")
       end
@@ -44,18 +44,18 @@ feature "Anyone can start a journey" do
 
     context "when Contentful entry is of type numbers" do
       scenario "user can answer using a number input" do
-        start_journey_from_category_and_go_to_question(category: "number-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "number-question.json")
 
         fill_in "answer[response]", with: "190"
         click_on(I18n.t("generic.button.next"))
 
-        click_first_link_in_task_list
+        click_first_link_in_section_list
 
         expect(find_field("answer-response-field").value).to eql("190")
       end
 
       scenario "users receive an error when not entering a number" do
-        start_journey_from_category_and_go_to_question(category: "number-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "number-question.json")
 
         fill_in "answer[response]", with: "foo"
         click_on(I18n.t("generic.button.next"))
@@ -64,7 +64,7 @@ feature "Anyone can start a journey" do
       end
 
       scenario "users receive an error when entering a decimal number" do
-        start_journey_from_category_and_go_to_question(category: "number-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "number-question.json")
 
         fill_in "answer[response]", with: "435.65"
         click_on(I18n.t("generic.button.next"))
@@ -75,18 +75,18 @@ feature "Anyone can start a journey" do
 
     context "when Contentful entry is of type currency" do
       scenario "user can answer using a currency number input" do
-        start_journey_from_category_and_go_to_question(category: "currency-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "currency-question.json")
 
         fill_in "answer[response]", with: "1,000.01"
         click_on(I18n.t("generic.button.next"))
 
-        click_first_link_in_task_list
+        click_first_link_in_section_list
 
         expect(find_field("answer-response-field").value).to eql("1000.01")
       end
 
       scenario "throws error when non numerical values are entered" do
-        start_journey_from_category_and_go_to_question(category: "currency-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "currency-question.json")
 
         fill_in "answer[response]", with: "one hundred pounds"
         click_on(I18n.t("generic.button.next"))
@@ -97,12 +97,12 @@ feature "Anyone can start a journey" do
 
     context "when Contentful entry is of type long_text" do
       scenario "user can answer using free text with multiple lines" do
-        start_journey_from_category_and_go_to_question(category: "long-text-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "long-text-question.json")
 
         fill_in "answer[response]", with: "We would like a supplier to provide catering from September 2020.\nThey must be able to supply us for 3 years minumum."
         click_on(I18n.t("generic.button.next"))
 
-        click_first_link_in_task_list
+        click_first_link_in_section_list
 
         expect(find_field("answer-response-field").value).to eql("We would like a supplier to provide catering from September 2020.\r\nThey must be able to supply us for 3 years minumum.")
       end
@@ -110,7 +110,7 @@ feature "Anyone can start a journey" do
 
     context "when Contentful entry is of type single_date" do
       scenario "user can answer using a date input" do
-        start_journey_from_category_and_go_to_question(category: "single-date-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "single-date-question.json")
 
         fill_in "answer[response(3i)]", with: "12"
         fill_in "answer[response(2i)]", with: "8"
@@ -118,7 +118,7 @@ feature "Anyone can start a journey" do
 
         click_on(I18n.t("generic.button.next"))
 
-        click_first_link_in_task_list
+        click_first_link_in_section_list
 
         expect(find_field("answer_response_3i").value).to eql("12")
         expect(find_field("answer_response_2i").value).to eql("8")
@@ -126,7 +126,7 @@ feature "Anyone can start a journey" do
       end
 
       scenario "date validations" do
-        start_journey_from_category_and_go_to_question(category: "single-date-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "single-date-question.json")
 
         fill_in "answer[response(3i)]", with: "2"
         fill_in "answer[response(2i)]", with: "0"
@@ -139,27 +139,27 @@ feature "Anyone can start a journey" do
 
     context "when Contentful entry is of type checkboxes" do
       scenario "user can select multiple answers" do
-        start_journey_from_category_and_go_to_question(category: "checkboxes-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "checkboxes-question.json")
 
         check "Breakfast"
         check "Lunch"
 
         click_on(I18n.t("generic.button.next"))
 
-        click_first_link_in_task_list
+        click_first_link_in_section_list
 
         expect(page).to have_checked_field("answer-response-breakfast-field")
         expect(page).to have_checked_field("answer-response-lunch-field")
       end
 
       scenario "options follow the capitalisation given" do
-        start_journey_from_category_and_go_to_question(category: "checkboxes-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "checkboxes-question.json")
         expect(page).to have_content("Morning break")
       end
 
       context "when extra configuration is passed to collect further info" do
         scenario "asks the user for further information" do
-          start_journey_from_category_and_go_to_question(category: "extended-checkboxes-question.json")
+          start_journey_from_category_and_go_to_first_section(category: "extended-checkboxes-question.json")
 
           check("Yes")
           fill_in "answer[yes_further_information]", with: "The first piece of further information"
@@ -177,7 +177,7 @@ feature "Anyone can start a journey" do
 
           click_on(I18n.t("generic.button.next"))
 
-          click_first_link_in_task_list
+          click_first_link_in_section_list
 
           expect(page).to have_checked_field("Yes")
           expect(find_field("answer-yes-further-information-field").value)
@@ -195,7 +195,7 @@ feature "Anyone can start a journey" do
 
       context "when extended question is of type single" do
         scenario "a single text field is displayed" do
-          start_journey_from_category_and_go_to_question(category: "extended-checkboxes-question.json")
+          start_journey_from_category_and_go_to_first_section(category: "extended-checkboxes-question.json")
 
           check("Yes")
 
@@ -205,7 +205,7 @@ feature "Anyone can start a journey" do
 
       context "when extended question is of type long" do
         scenario "a long text area is displayed" do
-          start_journey_from_category_and_go_to_question(category: "extended-long-answer-checkboxes-question.json")
+          start_journey_from_category_and_go_to_first_section(category: "extended-long-answer-checkboxes-question.json")
 
           check("Yes")
 
@@ -215,7 +215,7 @@ feature "Anyone can start a journey" do
 
       context "when there is no extended question" do
         scenario "no extra text field is displayed" do
-          start_journey_from_category_and_go_to_question(category: "checkboxes-question.json")
+          start_journey_from_category_and_go_to_first_section(category: "checkboxes-question.json")
 
           expect(page).to_not have_selector("textarea#answer-yes-further-information-field")
           expect(page).to_not have_selector("input#answer-yes-further-information-field")
@@ -226,7 +226,7 @@ feature "Anyone can start a journey" do
     context "when Contentful entry is of type radios" do
       context "when extra configuration is passed to collect further info" do
         scenario "asks the user for further information" do
-          start_journey_from_category_and_go_to_question(category: "extended-radio-question.json")
+          start_journey_from_category_and_go_to_first_section(category: "extended-radio-question.json")
 
           choose("Catering")
           expect(page).not_to have_content("No_further_information") # It should not create a label when one isn't specified
@@ -238,7 +238,7 @@ feature "Anyone can start a journey" do
 
           click_on(I18n.t("generic.button.next"))
 
-          click_first_link_in_task_list
+          click_first_link_in_section_list
 
           expect(page).to have_checked_field("Catering")
           expect(find_field("answer-catering-further-information-field").value)
@@ -248,7 +248,7 @@ feature "Anyone can start a journey" do
 
       context "when extended question is of type single" do
         scenario "a single text field is displayed" do
-          start_journey_from_category_and_go_to_question(category: "extended-radio-question.json")
+          start_journey_from_category_and_go_to_first_section(category: "extended-radio-question.json")
 
           choose("Catering")
 
@@ -258,7 +258,7 @@ feature "Anyone can start a journey" do
 
       context "when extended question is of type long" do
         scenario "a long text area is displayed" do
-          start_journey_from_category_and_go_to_question(category: "extended-long-answer-radio-question.json")
+          start_journey_from_category_and_go_to_first_section(category: "extended-long-answer-radio-question.json")
 
           choose("Catering")
 
@@ -268,7 +268,7 @@ feature "Anyone can start a journey" do
 
       context "when there is no extended question" do
         scenario "no extra text field is displayed" do
-          start_journey_from_category_and_go_to_question(category: "radio-question.json")
+          start_journey_from_category_and_go_to_first_section(category: "radio-question.json")
 
           expect(page).to_not have_selector("textarea#answer-catering-further-information-field")
           expect(page).to_not have_selector("input#answer-catering-further-information-field")
@@ -277,7 +277,7 @@ feature "Anyone can start a journey" do
 
       context "when an 'or separator' has been configured" do
         scenario "shows an or separator" do
-          start_journey_from_category_and_go_to_question(category: "radio-question-with-separator.json")
+          start_journey_from_category_and_go_to_first_section(category: "radio-question-with-separator.json")
 
           expect(page).to have_selector("div.govuk-radios__divider")
           within("div.govuk-radios__divider") do
@@ -293,7 +293,7 @@ feature "Anyone can start a journey" do
 
     context "when Contentful entry includes a 'show additional question' rule" do
       scenario "additional questions are shown" do
-        start_journey_from_category_and_go_to_question(category: "show-one-additional-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "show-one-additional-question.json")
 
         choose("School expert")
         click_on(I18n.t("generic.button.next"))
@@ -314,7 +314,7 @@ feature "Anyone can start a journey" do
 
   context "when the question is skippable" do
     scenario "allows the user to not select an answer" do
-      start_journey_from_category_and_go_to_question(category: "skippable-checkboxes-question.json")
+      start_journey_from_category_and_go_to_first_section(category: "skippable-checkboxes-question.json")
 
       click_on(I18n.t("generic.button.next"))
       expect(page).to have_content("can't be blank")
@@ -323,7 +323,7 @@ feature "Anyone can start a journey" do
       check("Dinner")
       click_on(I18n.t("generic.button.next"))
 
-      click_first_link_in_task_list
+      click_first_link_in_section_list
 
       click_on("None of the above")
 
@@ -331,7 +331,7 @@ feature "Anyone can start a journey" do
         expect(page).to have_content("Complete")
       end
 
-      click_first_link_in_task_list
+      click_first_link_in_section_list
 
       expect(page).not_to have_checked_field("Lunch")
       expect(CheckboxAnswers.last.skipped).to be true
@@ -339,7 +339,7 @@ feature "Anyone can start a journey" do
 
     context "when the question has already been skipped" do
       scenario "selecting an answer marks the question as not being skipped" do
-        start_journey_from_category_and_go_to_question(category: "skippable-checkboxes-question.json")
+        start_journey_from_category_and_go_to_first_section(category: "skippable-checkboxes-question.json")
 
         click_on("None of the above")
 
@@ -347,7 +347,7 @@ feature "Anyone can start a journey" do
           expect(page).to have_content("Complete")
         end
 
-        click_first_link_in_task_list
+        click_first_link_in_section_list
 
         check("Lunch")
         check("Dinner")
@@ -376,20 +376,20 @@ feature "Anyone can start a journey" do
 
   context "when the help text contains Markdown" do
     scenario "paragraph breaks are parsed as expected" do
-      start_journey_from_category_and_go_to_question(category: "markdown-help-text.json")
+      start_journey_from_category_and_go_to_first_section(category: "markdown-help-text.json")
 
       expect(page.html).to include("<p>Paragraph Test: Paragraph 1</p>")
       expect(page.html).to include("<p>Paragraph Test: Paragraph 2</p>")
     end
 
     scenario "bold text is parsed as expected" do
-      start_journey_from_category_and_go_to_question(category: "markdown-help-text.json")
+      start_journey_from_category_and_go_to_first_section(category: "markdown-help-text.json")
 
       expect(page.html).to include("<strong>Bold text</strong> test")
     end
 
     scenario "lists are parsed as expected" do
-      start_journey_from_category_and_go_to_question(category: "markdown-help-text.json")
+      start_journey_from_category_and_go_to_first_section(category: "markdown-help-text.json")
 
       expect(page.html).to include("<li>List item one</li>")
       expect(page.html).to include("<li>List item two</li>")
@@ -399,13 +399,13 @@ feature "Anyone can start a journey" do
 
   context "when the help text is nil" do
     scenario "step page still renders when question is a radio" do
-      start_journey_from_category_and_go_to_question(category: "nil-help-text-radios.json")
+      start_journey_from_category_and_go_to_first_section(category: "nil-help-text-radios.json")
 
       expect(page.html).to include("Which service do you need?")
     end
 
     scenario "step page still renders when question is a short text" do
-      start_journey_from_category_and_go_to_question(category: "nil-help-text-short-text.json")
+      start_journey_from_category_and_go_to_first_section(category: "nil-help-text-short-text.json")
 
       expect(page.html).to include("What email address did you use?")
     end
@@ -455,9 +455,9 @@ feature "Anyone can start a journey" do
     end
   end
 
-  context "when a user answers a question" do
+  context "when a task has a single question and the user answers it" do
     scenario "the user is returned to the same place in the task list " do
-      start_journey_from_category_and_go_to_question(category: "long-text-question.json")
+      start_journey_from_category_and_go_to_first_section(category: "long-text-question.json")
       journey = Journey.last
 
       fill_in "answer[response]", with: "This is my long answer"
@@ -472,7 +472,7 @@ feature "Anyone can start a journey" do
 
   context "when a task has more than 1 question" do
     scenario "the user is taken straight to the next question" do
-      start_journey_from_category_and_go_to_question(category: "task-with-multiple-steps.json")
+      start_journey_from_category_and_go_to_first_section(category: "task-with-multiple-steps.json")
       journey = Journey.last
       task = journey.sections.first.tasks.first
 
@@ -492,6 +492,17 @@ feature "Anyone can start a journey" do
 
       expect(page).to have_content("Task with multiple steps")
       expect(page).to have_current_path(journey_task_url(journey, task))
+    end
+  end
+
+  context "when a task that has no answers is opened" do
+    scenario "takes the user straight to the first question" do
+      start_journey_from_category(category: "task-with-multiple-steps.json")
+
+      click_first_link_in_section_list
+
+      expect(page).not_to have_content("Task with multiple steps")
+      expect(page).to have_content("Catering")
     end
   end
 end

--- a/spec/features/school_buying_professionals/complete_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/complete_a_journey_spec.rb
@@ -476,8 +476,6 @@ feature "Anyone can start a journey" do
       journey = Journey.last
       task = journey.sections.first.tasks.first
 
-      click_first_link_in_task_list
-
       choose("Catering")
       click_on(I18n.t("generic.button.next"))
 

--- a/spec/features/school_buying_professionals/download_their_catering_specification_spec.rb
+++ b/spec/features/school_buying_professionals/download_their_catering_specification_spec.rb
@@ -3,7 +3,7 @@ feature "Users can see their catering specification" do
 
   context "when the journey has been completed" do
     scenario "HTML" do
-      start_journey_from_category_and_go_to_question(category: "category-with-liquid-template.json")
+      start_journey_from_category_and_go_to_first_section(category: "category-with-liquid-template.json")
 
       common_specification_html = "<article id='specification'><h1>Liquid </h1></article>"
       expect(Htmltoword::Document)

--- a/spec/features/school_buying_professionals/edit_their_answers_spec.rb
+++ b/spec/features/school_buying_professionals/edit_their_answers_spec.rb
@@ -85,7 +85,7 @@ feature "Users can edit their answers" do
 
   context "when Contentful entry includes a 'show additional question' rule" do
     scenario "an additional question is shown" do
-      start_journey_from_category_and_go_to_question(category: "show-one-additional-question.json")
+      start_journey_from_category_and_go_to_first_section(category: "show-one-additional-question.json")
 
       choose("School expert")
       click_on(I18n.t("generic.button.next"))

--- a/spec/features/school_buying_professionals/see_their_catering_specification_spec.rb
+++ b/spec/features/school_buying_professionals/see_their_catering_specification_spec.rb
@@ -2,7 +2,7 @@ feature "Users can see their catering specification" do
   before { user_is_signed_in }
 
   scenario "HTML" do
-    start_journey_from_category_and_go_to_question(category: "category-with-dynamic-liquid-template.json")
+    start_journey_from_category_and_go_to_first_section(category: "category-with-dynamic-liquid-template.json")
 
     choose("Catering")
     click_on(I18n.t("generic.button.next"))
@@ -28,7 +28,7 @@ feature "Users can see their catering specification" do
   end
 
   scenario "renders radio responses that have futher information" do
-    start_journey_from_category_and_go_to_question(category: "extended-radio-question.json")
+    start_journey_from_category_and_go_to_first_section(category: "extended-radio-question.json")
 
     choose("Catering")
     fill_in "answer[catering_further_information]", with: "The school needs the kitchen cleaned once a day"
@@ -44,7 +44,7 @@ feature "Users can see their catering specification" do
   end
 
   scenario "renders checkbox responses that have further information" do
-    start_journey_from_category_and_go_to_question(category: "extended-checkboxes-question.json")
+    start_journey_from_category_and_go_to_first_section(category: "extended-checkboxes-question.json")
 
     check("Yes")
     fill_in "answer[yes_further_information]", with: "More info for yes"
@@ -65,7 +65,7 @@ feature "Users can see their catering specification" do
   end
 
   scenario "questions that are skipped can be identified" do
-    start_journey_from_category_and_go_to_question(category: "skippable-checkboxes-question.json")
+    start_journey_from_category_and_go_to_first_section(category: "skippable-checkboxes-question.json")
 
     click_on("None of the above")
     click_on(I18n.t("journey.specification.button"))
@@ -86,7 +86,7 @@ feature "Users can see their catering specification" do
 
   context "when the spec template is configured using multiple sections" do
     it "renders both parts in the spec" do
-      start_journey_from_category_and_go_to_question(category: "multiple-specification-templates.json")
+      start_journey_from_category_and_go_to_first_section(category: "multiple-specification-templates.json")
 
       choose("Catering")
       click_on(I18n.t("generic.button.next"))

--- a/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_list_of_tasks_spec.rb
@@ -30,6 +30,10 @@ feature "Users can view the task list" do
       click_on "Task with multiple steps"
     end
 
+    # Back to the Task page
+    click_on(I18n.t("generic.button.back"))
+
+    # Back to the Journey page
     click_on(I18n.t("generic.button.back"))
 
     expect(page).to have_content(I18n.t("specifying.start_page.page_title"))
@@ -74,7 +78,6 @@ feature "Users can view the task list" do
         click_on "Task with multiple steps"
       end
 
-      click_on "Everyday services that are required and need to be considered"
       click_on(I18n.t("generic.button.back"))
 
       expect(page).to have_content("Task with multiple steps")
@@ -175,6 +178,7 @@ feature "Users can view the task list" do
         Step.find_by(title: "What colour is the sky?").update(created_at: 1.days.ago)
 
         click_on("One additional question task")
+        click_on(I18n.t("generic.button.back"))
 
         steps = find_all(".app-task-list__item.step__item")
         within(".app-task-list") do

--- a/spec/features/school_buying_professionals/view_a_task_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_task_spec.rb
@@ -5,14 +5,31 @@ feature "Users can view a task" do
   before { user_is_signed_in(user: user) }
 
   context "When there is a task with multiple steps" do
-    it "the Task title takes you to a Task page" do
+    it "the Task title takes you to the first step" do
       start_journey_with_tasks_from_category(category: "section-with-multiple-tasks.json")
 
       within(".app-task-list") do
         click_on "Task with multiple steps"
       end
 
-      expect(page).to have_content "Task with multiple steps"
+      expect(page).to have_content "Which service do you need?"
+    end
+
+    context "when a task has at least one answered step" do
+      it "takes the user to the task page" do
+        start_journey_with_tasks_from_category(category: "section-with-multiple-tasks.json")
+
+        task = Task.find_by(title: "Task with multiple steps")
+        step = task.steps.first
+        create(:radio_answer, step: step)
+
+        within(".app-task-list") do
+          click_on "Task with multiple steps"
+        end
+
+        expect(page).to have_content("Task with multiple steps")
+        expect(page).to have_content("Which service do you need?")
+      end
     end
 
     it "the back link takes you to the journey page" do
@@ -22,18 +39,19 @@ feature "Users can view a task" do
         click_on "Task with multiple steps"
       end
 
-      expect(page).to have_content "Back"
-
-      click_on "Back"
+      click_on I18n.t("generic.button.back")
       expect(page).to have_content "Task with multiple steps"
     end
 
-    it "shows a list of the task's steps" do
+    it "shows a list of the task steps" do
       start_journey_with_tasks_from_category(category: "section-with-multiple-tasks.json")
 
       within(".app-task-list") do
         click_on "Task with multiple steps"
       end
+
+      # Unstarded tasks take the user straight to the first step so we have to go back
+      click_on(I18n.t("generic.button.back"))
 
       expect(page).to have_content "Which service do you need?"
       expect(page).to have_content "Everyday services that are required and need to be considered"
@@ -57,8 +75,7 @@ feature "Users can view a task" do
         click_on "Task with multiple steps"
       end
 
-      click_on "Which service do you need?"
-      click_on "Back"
+      click_on(I18n.t("generic.button.back"))
 
       expect(page).to have_content "Task with multiple steps"
     end
@@ -69,8 +86,6 @@ feature "Users can view a task" do
       within(".app-task-list") do
         click_on "Task with multiple steps"
       end
-
-      click_on "Which service do you need?"
 
       choose "Catering"
       click_on(I18n.t("generic.button.next"))
@@ -84,8 +99,6 @@ feature "Users can view a task" do
       within(".app-task-list") do
         click_on "Task with multiple steps"
       end
-
-      click_on "Which service do you need?"
 
       choose "Catering"
       click_on(I18n.t("generic.button.next"))

--- a/spec/support/journey_helpers.rb
+++ b/spec/support/journey_helpers.rb
@@ -1,6 +1,12 @@
 module JourneyHelpers
+  def click_first_link_in_section_list
+    within("ol.app-task-list.sections") do
+      first("a").click
+    end
+  end
+
   def click_first_link_in_task_list
-    within("ol.app-task-list") do
+    within("ol.app-task-list.tasks") do
       first("a").click
     end
   end
@@ -23,9 +29,8 @@ module JourneyHelpers
     user_signs_in_and_starts_the_journey
   end
 
-  def start_journey_from_category_and_go_to_question(category:)
+  def start_journey_from_category_and_go_to_first_section(category:)
     start_journey_from_category(category: category)
-
-    click_first_link_in_task_list
+    click_first_link_in_section_list
   end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

Before this change, when a user viewed a task for the first time, they were taken to that tasks page. From there they could choose which question they wanted to answer.

This was mildly problematic because if a user wanted to get on with answering the task they had to make an initial click. It is likely to be the case that when a user opens a task they want to start answering questions.

We don't behave the same for tasks that have been started. We define started as having at least one step that has been answered. When this happens the previous behaviour is still in affect: the user is taken to the task page where they can review what they've done and what they haven't, deciding which question they'd like to answer next.

## Changes in this PR

- refactor the test suite so the test helpers we have make room for this change in behaviour. "Clicking the first link in a task list" is not always what needs to happen as we're automating it.
- redirect users to the first step of a task that has no answered steps when the user opens it

## Screenshots of UI changes

### 1️⃣ We open a task that we haven't yet answered (as before)
![Screenshot 2021-05-20 at 15 11 59](https://user-images.githubusercontent.com/912473/118993945-d5908180-b97d-11eb-9b92-cc2a4a233107.png)

### 2️⃣ We provide an answer (making some progress) before backing out
![Screenshot 2021-05-20 at 15 12 04](https://user-images.githubusercontent.com/912473/118993949-d6c1ae80-b97d-11eb-86ce-c99be70385b4.png)

### 3️⃣ We open the task that's now in progress
![Screenshot 2021-05-20 at 15 12 21](https://user-images.githubusercontent.com/912473/118993952-d7f2db80-b97d-11eb-9a87-a18b855534be.png)

### 4️⃣ We are now taken to the task page (as before) where we can select the next question
![Screenshot 2021-05-20 at 15 12 27](https://user-images.githubusercontent.com/912473/118993955-d9240880-b97d-11eb-9c1d-7f232b67fdf0.png)


## Next steps

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->
