### PR TITLE
Refactor CreateJourney to accept and store category ID

### DIFF
--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -24,7 +24,7 @@ class JourneysController < ApplicationController
   end
 
   def new
-    journey = CreateJourney.new(category_name: "catering", user: current_user).call
+    journey = CreateJourney.new(category_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"], user: current_user).call
     redirect_to journey_path(journey)
   end
 

--- a/app/controllers/preview/entries_controller.rb
+++ b/app/controllers/preview/entries_controller.rb
@@ -3,7 +3,8 @@ class Preview::EntriesController < ApplicationController
 
   def show
     @journey = Journey.create(
-      category: "catering",
+      category: "Preview",
+      contentful_id: 0,
       user: current_user,
       liquid_template: "<p>N/A</p>"
     )

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -5,7 +5,7 @@ class Journey < ApplicationRecord
   has_many :steps, through: :tasks, class_name: "Step"
   belongs_to :user
 
-  validates :category, :liquid_template, presence: true
+  validates :category, :contentful_id, :liquid_template, presence: true
 
   def visible_steps
     steps.where(hidden: false)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -56,12 +56,12 @@ class Task < ApplicationRecord
   def eager_loaded_visible_steps
     @eager_loaded_visible_steps ||= visible_steps.includes(
       %i[short_text_answer
-         long_text_answer
-         radio_answer
-         checkbox_answers
-         currency_answer
-         number_answer
-         single_date_answer]
+        long_text_answer
+        radio_answer
+        checkbox_answers
+        currency_answer
+        number_answer
+        single_date_answer]
     ).ordered
   end
 end

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -1,16 +1,16 @@
 class CreateJourney
-  attr_accessor :category_name, :user
+  attr_accessor :category_id, :user
 
-  def initialize(category_name:, user:)
-    self.category_name = category_name
+  def initialize(category_id:, user:)
+    self.category_id = category_id
     self.user = user
   end
 
   def call
-    category = GetCategory.new(category_entry_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"]).call
+    category = GetCategory.new(category_entry_id: category_id).call
     contentful_sections = GetSectionsFromCategory.new(category: category).call
     journey = Journey.new(
-      category: category_name,
+      category: category.title,
       user: user,
       started: true,
       last_worked_on: Time.zone.now,

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -11,6 +11,7 @@ class CreateJourney
     contentful_sections = GetSectionsFromCategory.new(category: category).call
     journey = Journey.new(
       category: category.title,
+      contentful_id: category.id,
       user: user,
       started: true,
       last_worked_on: Time.zone.now,

--- a/db/migrate/20210520155735_add_category_id_to_journey.rb
+++ b/db/migrate/20210520155735_add_category_id_to_journey.rb
@@ -1,0 +1,5 @@
+class AddCategoryIdToJourney < ActiveRecord::Migration[6.1]
+  def change
+    add_column :journeys, :contentful_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_18_084959) do
+ActiveRecord::Schema.define(version: 2021_05_20_155735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2021_05_18_084959) do
     t.uuid "user_id"
     t.boolean "started", default: true
     t.datetime "last_worked_on"
+    t.string "contentful_id"
     t.index ["last_worked_on"], name: "index_journeys_on_last_worked_on"
     t.index ["started"], name: "index_journeys_on_started"
     t.index ["user_id"], name: "index_journeys_on_user_id"

--- a/spec/factories/journey.rb
+++ b/spec/factories/journey.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :journey do
     category { "catering" }
+    contentful_id { "12345678" }
     liquid_template { "Your answer was {{ answer_47EI2X2T5EDTpJX9WjRR9p }}" }
     started { true }
     last_worked_on { Time.zone.now }

--- a/spec/fixtures/contentful/001-categories/category-with-no-title.json
+++ b/spec/fixtures/contentful/001-categories/category-with-no-title.json
@@ -1,0 +1,36 @@
+{
+    "sys": {
+        "space": {
+            "sys": {
+                "type": "Link",
+                "linkType": "Space",
+                "id": "rwl7tyzv9sys"
+            }
+        },
+        "id": "contentful-category-entry",
+        "type": "Entry",
+        "createdAt": "2021-01-20T12:19:10.220Z",
+        "updatedAt": "2021-01-20T15:06:12.067Z",
+        "environment": {
+            "sys": {
+                "id": "develop",
+                "type": "Link",
+                "linkType": "Environment"
+            }
+        },
+        "revision": 2,
+        "contentType": {
+            "sys": {
+                "type": "Link",
+                "linkType": "ContentType",
+                "id": "category"
+            }
+        },
+        "locale": "en-US"
+    },
+    "fields": {
+        "title": null,
+        "sections": [],
+        "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>"
+    }
+}

--- a/spec/requests/entry_preview_spec.rb
+++ b/spec/requests/entry_preview_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Entry previews", type: :request do
       entry_id = "123"
       fake_journey = create(:journey)
       expect(Journey).to receive(:create)
-        .with(category: anything, user: anything, liquid_template: anything)
+        .with(category: anything, contentful_id: anything, user: anything, liquid_template: anything)
         .and_return(fake_journey)
 
       fake_get_contentful_entry = instance_double(Contentful::Entry)

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe CreateJourney do
       )
       expect { described_class.new(category_id: "contentful-category-entry", user: build(:user)).call }
         .to change { Journey.count }.by(1)
-      expect(Journey.last.category).to eql("Catering")
+      last_journey = Journey.last
+      expect(last_journey.category).to eql("Catering")
+      expect(last_journey.contentful_id).to eql("contentful-category-entry")
     end
 
     it "associates the new journey with the given user" do

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe CreateJourney do
       stub_contentful_category(
         fixture_filename: "category-with-no-steps.json"
       )
-      expect { described_class.new(category_name: "catering", user: build(:user)).call }
+      expect { described_class.new(category_id: "contentful-category-entry", user: build(:user)).call }
         .to change { Journey.count }.by(1)
-      expect(Journey.last.category).to eql("catering")
+      expect(Journey.last.category).to eql("Catering")
     end
 
     it "associates the new journey with the given user" do
@@ -25,7 +25,7 @@ RSpec.describe CreateJourney do
       )
       user = create(:user)
 
-      described_class.new(category_name: "catering", user: user).call
+      described_class.new(category_id: "contentful-category-entry", user: user).call
 
       expect(Journey.last.user).to eq(user)
     end
@@ -34,7 +34,7 @@ RSpec.describe CreateJourney do
       stub_contentful_category(
         fixture_filename: "category-with-no-steps.json"
       )
-      described_class.new(category_name: "catering", user: build(:user)).call
+      described_class.new(category_id: "contentful-category-entry", user: build(:user)).call
       expect(Journey.last.started).to eq(true)
     end
 
@@ -44,7 +44,7 @@ RSpec.describe CreateJourney do
         fixture_filename: "category-with-no-steps.json"
       )
 
-      described_class.new(category_name: "catering", user: build(:user)).call
+      described_class.new(category_id: "contentful-category-entry", user: build(:user)).call
 
       expect(Journey.last.last_worked_on).to eq(Time.zone.now)
     end
@@ -54,7 +54,7 @@ RSpec.describe CreateJourney do
         fixture_filename: "category-with-liquid-template.json"
       )
 
-      described_class.new(category_name: "catering", user: build(:user)).call
+      described_class.new(category_id: "contentful-category-entry", user: build(:user)).call
 
       expect(Journey.last.liquid_template)
         .to eql("<article id='specification'><h1>Liquid {{templating}}</h1></article>")
@@ -63,12 +63,12 @@ RSpec.describe CreateJourney do
     context "when the journey cannot be saved" do
       it "raises an error" do
         stub_contentful_category(
-          fixture_filename: "category-with-liquid-template.json",
+          fixture_filename: "category-with-no-title.json",
           stub_sections: true
         )
 
-        # Force a validation error by not providing a category_name
-        expect { described_class.new(category_name: nil, user: build(:user)).call }
+        # Force a validation error by not providing an invalid category ID
+        expect { described_class.new(category_id: "contentful-category-entry", user: build(:user)).call }
           .to raise_error(ActiveRecord::RecordInvalid)
       end
     end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -160,6 +160,7 @@ module ContentfulHelpers
     category_double = double(
       Contentful::Entry,
       id: hash_response.dig("sys", "id"),
+      title: hash_response.dig("fields", "title"),
       sections: sections,
       specification_template: hash_response.dig("fields", "specificationTemplate"),
       specification_template_part2: hash_response.dig("fields", "specificationTemplatePart2"),


### PR DESCRIPTION
## Changes in this PR

- Change behaviour of `CreateJourney` to accept a category ID and derive the name from that, rather than accept a name and rely on the category ID being defined in the class.
- Store the Contentful category ID with newly created journeys, in case we need it later (eg for activity logging)