### PR TITLE
Use a single definition for eager loading steps and their answers

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,16 +3,8 @@ class TasksController < ApplicationController
 
   def show
     @journey = current_journey
-    @task = task
-    steps = @task.visible_steps.includes([
-      :short_text_answer,
-      :long_text_answer,
-      :radio_answer,
-      :checkbox_answers,
-      :currency_answer,
-      :number_answer,
-      :single_date_answer
-    ])
+    @task = Task.find(task_id)
+    steps = @task.eager_loaded_visible_steps
     @steps = steps.map { |step| StepPresenter.new(step) }
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -58,8 +58,6 @@ class Task < ApplicationRecord
     remaining_ids.first
   end
 
-  private
-
   def eager_loaded_visible_steps
     @eager_loaded_visible_steps ||= visible_steps.includes(
       %i[short_text_answer


### PR DESCRIPTION
We have a method on task, let's reuse it and consolitate the codebase with a single definition.