### PR TITLE
(656) Stop using default_scope for steps

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   def show
     @journey = current_journey
     @task = Task.find(task_id)
-    steps = @task.eager_loaded_visible_steps
+    steps = @task.eager_loaded_visible_steps.ordered
     @steps = steps.map { |step| StepPresenter.new(step) }
   end
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,6 +1,5 @@
 class Step < ApplicationRecord
   self.implicit_order_column = "order"
-  default_scope { order(:order) }
 
   belongs_to :task
 
@@ -13,6 +12,7 @@ class Step < ApplicationRecord
   has_one :currency_answer
 
   scope :that_are_questions, -> { where(contentful_model: "question") }
+  scope :ordered, -> { order(:order) }
 
   def answer
     @answer ||=

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -62,6 +62,6 @@ class Task < ApplicationRecord
          currency_answer
          number_answer
          single_date_answer]
-    )
+    ).ordered
   end
 end


### PR DESCRIPTION
Before this change, the following tasks fail:

```
rake db:drop
rake db:create
rake db:migrate
```

```
== 20201202150359 AddContentfulModelToStep: migrating =========================
-- add_column(:steps, :contentful_model, :string)
   -> 0.0012s
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:
PG::UndefinedColumn: ERROR:  column "order" does not exist
LINE 1: ...id" IN (SELECT "steps"."id" FROM "steps" ORDER BY "order" AS...
```

I believe this is because Step now has this code: `default_scope { order(:order) }`.  Given that the `order` column doesn't exist when these earlier updates to the Step table are called, we get an error for missing column.

This changes moves us away from this troublesome `default_scope` method by switching to a plain old `scope`. We plumb this into our methods for getting steps and their answers out so it doesn't need to be added all over.
