### PR TITLE
Implement dynamic validation defined in Contentful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ The format is based on [Keep a Changelog 1.0.0].
 - add additional developer tools to optional `Brewfile`
 - remove unused `GetAllContentfulEntries` service object
 
-**Non-question steps**
+**Steps**
 - implement __interrupt pattern__ which introduces a step that is not semantically a question but a statement
 - remove `staticContent` entity and add `Statement` entity in Contentful (currently only in develop)
+- add custom answer validation logic which can be controlled in Contentful
 
 **Multiple Categories**
 - remove references to `CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID`
@@ -37,9 +38,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - drop `Journey.last_worked_on` in favour of `updated_at`
 - allow user to (soft) delete a specification
 
-
 ## Diary Studies using the live environment
-
 
 ## [release-015] - 2021-06-17
 

--- a/app/models/currency_answer.rb
+++ b/app/models/currency_answer.rb
@@ -8,8 +8,11 @@ class CurrencyAnswer < ApplicationRecord
             presence: true,
             numericality: {
               greater_than_or_equal_to: 0,
+              # Use locale for this validation message
               message: "does not accept £ signs or other non numerical characters",
             }
+
+  validates_with RangeValidator
 
   # Ensure no commas are present in the currency value
   #

--- a/app/models/number_answer.rb
+++ b/app/models/number_answer.rb
@@ -9,4 +9,6 @@ class NumberAnswer < ApplicationRecord
             numericality: {
               only_integer: true,
             }
+
+  validates_with RangeValidator
 end

--- a/app/models/single_date_answer.rb
+++ b/app/models/single_date_answer.rb
@@ -1,4 +1,5 @@
-# SingleDateAnswer is used to capture a single date answer to a {Step}.
+# Persist {Step} response for questions of type 'single_date'
+#
 class SingleDateAnswer < ApplicationRecord
   include TaskCounters
 
@@ -8,4 +9,6 @@ class SingleDateAnswer < ApplicationRecord
             presence: {
               message: I18n.t("activerecord.errors.models.single_date_answer.attributes.response"),
             }
+
+  validates_with RangeValidator
 end

--- a/app/validators/range_validator.rb
+++ b/app/validators/range_validator.rb
@@ -1,0 +1,50 @@
+# Dynamic validation for {SingleDateAnswer}, {NumberAnswer} and {CurrencyAnswer}
+#
+# @example
+#   ContentfulType: Question
+#   "fields": {
+#     "type": "single_date"
+#     "criteria": {
+#       "upper": "",
+#       "lower": "",
+#       "message": "out of bounds"
+#     }
+#   }
+#
+class RangeValidator < ActiveModel::Validator
+  # @param record [Mixed] answer types
+  #
+  # @return [Nil, ActiveModel::Error]
+  def validate(record)
+    # model specs don't bother building the step
+    return unless record.step&.criteria?
+
+    criteria = record.step.criteria.with_indifferent_access
+
+    bounds = range(
+      type: record.step.contentful_type,
+      lower: criteria[:lower],
+      upper: criteria[:upper],
+    )
+
+    record.errors.add(:response, criteria[:message]) unless bounds.cover?(record.response)
+  end
+
+private
+
+  # @param type [String]
+  # @param lower [String]
+  # @param upper [String]
+  #
+  # @return [Range]
+  def range(type:, lower:, upper:)
+    case type
+    when "single_date"
+      Range.new(Time.zone.local(lower), Time.zone.local(upper))
+    when "number"
+      Range.new(lower.to_i, upper.to_i)
+    when "currency"
+      Range.new(lower.to_f, upper.to_f)
+    end
+  end
+end

--- a/db/migrate/20210721115748_add_validation_criteria_to_steps.rb
+++ b/db/migrate/20210721115748_add_validation_criteria_to_steps.rb
@@ -1,0 +1,5 @@
+class AddValidationCriteriaToSteps < ActiveRecord::Migration[6.1]
+  def change
+    add_column :steps, :criteria, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_05_160257) do
+ActiveRecord::Schema.define(version: 2021_07_21_115748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 2021_07_05_160257) do
     t.string "skip_call_to_action_text"
     t.uuid "task_id"
     t.integer "order"
+    t.jsonb "criteria"
     t.index ["order"], name: "index_steps_on_order"
     t.index ["task_id"], name: "index_steps_on_task_id"
   end

--- a/spec/factories/step.rb
+++ b/spec/factories/step.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     skip_call_to_action_text { nil }
     options { nil }
     body { nil }
+    criteria { nil }
 
     association :task, factory: :task
 

--- a/spec/features/landing/body_spec.rb
+++ b/spec/features/landing/body_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Users can see a start page for specifying their purchase" do
       # generic.button.start
       expect(page).to have_button "Start", class: "govuk-button"
 
-      click_on "Start"
+      click_start
     end
 
     # FIXME: DfE Sign In should appear here

--- a/spec/features/steps/answer_validation_spec.rb
+++ b/spec/features/steps/answer_validation_spec.rb
@@ -1,0 +1,134 @@
+RSpec.feature "Validation criteria is question specific" do
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+  let(:journey) { create(:journey, category: category, user: user) }
+  let(:section) { create(:section, journey: journey) }
+  let(:task) { create(:task, section: section) }
+
+  before do
+    user_is_signed_in(user: user)
+    create(:step, question_type, task: task, title: title, criteria: criteria)
+    visit_journey
+    within ".app-task-list" do
+      click_on "Task title"
+    end
+  end
+
+  describe "number" do
+    let(:question_type) { :number }
+    let(:title) { "count" }
+    let(:criteria) do
+      {
+        "message": "too few/many",
+        "lower": "69",
+        "upper": "70",
+      }
+    end
+
+    specify do
+      expect(find("label.govuk-label--l")).to have_content "count"
+    end
+
+    context "when criteria ar omitted" do
+      let(:criteria) { nil }
+
+      it "ignores validation" do
+        fill_in "answer[response]", with: "69"
+        click_continue
+
+        expect(find("strong.app-task-list__tag")).to have_text "Completed"
+      end
+    end
+
+    context "when within bounds" do
+      it "passes validation" do
+        fill_in "answer[response]", with: "69"
+        click_continue
+
+        expect(find("strong.app-task-list__tag")).to have_text "Completed"
+      end
+    end
+
+    context "when out of bounds" do
+      it "renders the custom error message" do
+        fill_in "answer[response]", with: "123"
+        click_continue
+
+        expect(find("span.govuk-error-message")).to have_text "too few/many"
+      end
+    end
+  end
+
+  describe "currency" do
+    let(:question_type) { :currency }
+    let(:title) { "cost" }
+    let(:criteria) do
+      {
+        "message": "too cheap/expensive",
+        "lower": "1000.0",
+        "upper": "1999.01",
+      }
+    end
+
+    specify do
+      expect(find("label.govuk-label--l")).to have_content "cost"
+    end
+
+    context "when within bounds" do
+      it "passes validation" do
+        fill_in "answer[response]", with: "1001"
+        click_continue
+
+        expect(find("strong.app-task-list__tag")).to have_text "Completed"
+      end
+    end
+
+    context "when out of bounds" do
+      it "renders the custom error message" do
+        fill_in "answer[response]", with: "2001"
+        click_continue
+
+        expect(find("span.govuk-error-message")).to have_text "too cheap/expensive"
+      end
+    end
+  end
+
+  # TODO: Use Chronic gem for "18 years from now"
+  describe "single_date" do
+    let(:question_type) { :single_date }
+    let(:title) { "date of birth" }
+    let(:criteria) do
+      {
+        "message": "too young/old",
+        "lower": "1900-01-01 12:34",
+        "upper": "2000-01-01 00:01",
+      }
+    end
+
+    specify do
+      expect(find("legend.govuk-fieldset__legend--l")).to have_content "date of birth"
+    end
+
+    context "when within bounds" do
+      it "passes validation" do
+        fill_in "answer[response(3i)]", with: "30"
+        fill_in "answer[response(2i)]", with: "6"
+        fill_in "answer[response(1i)]", with: "1981"
+        click_continue
+
+        expect(find("strong.app-task-list__tag")).to have_text "Completed"
+      end
+    end
+
+    context "when out of bounds" do
+      it "renders the custom error message" do
+        fill_in "answer[response(3i)]", with: "30"
+        fill_in "answer[response(2i)]", with: "6"
+        fill_in "answer[response(1i)]", with: "3001"
+        click_continue
+
+        expect(find("span.govuk-error-message")).to have_text "too young/old"
+      end
+    end
+  end
+end

--- a/spec/fixtures/contentful/002-sections/single-date-section.json
+++ b/spec/fixtures/contentful/002-sections/single-date-section.json
@@ -37,6 +37,13 @@
                   "linkType": "Entry",
                   "id": "single-date-task"
               }
+            },
+            {
+              "sys": {
+                  "type": "Link",
+                  "linkType": "Entry",
+                  "id": "single-date-validation-task"
+              }
             }
         ]
     }

--- a/spec/fixtures/contentful/003-tasks/single-date-validation-task.json
+++ b/spec/fixtures/contentful/003-tasks/single-date-validation-task.json
@@ -1,0 +1,46 @@
+{
+  "metadata": {
+    "tags": []
+  },
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "rwl7tyzv9sys"
+      }
+    },
+    "id": "single-date-validation-task",
+    "type": "Entry",
+    "createdAt": "2021-04-12T09:38:48.990Z",
+    "updatedAt": "2021-04-12T10:11:05.670Z",
+    "environment": {
+      "sys": {
+        "id": "develop",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 3,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "task"
+      }
+    },
+    "locale": "en-US"
+  },
+  "fields": {
+    "title": "Task with date validation",
+    "steps": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "single-date-in-past-question"
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/contentful/004-steps/single-date-in-past-question.json
+++ b/spec/fixtures/contentful/004-steps/single-date-in-past-question.json
@@ -1,0 +1,49 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "rwl7tyzv9sys"
+      }
+    },
+    "id": "single-date-in-past-question",
+    "type": "Entry",
+    "createdAt": "2020-12-08T10:43:19.102Z",
+    "updatedAt": "2020-12-08T10:43:19.102Z",
+    "environment": {
+      "sys": {
+        "id": "develop",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "question"
+      }
+    },
+    "locale": "en-US"
+  },
+  "fields": {
+    "slug": "/past-date",
+    "type": "single date",
+    "title": "When were you born?",
+    "helpText": "must be in the past",
+    "criteria": {
+      "message": "Are you a time traveller!",
+      "lower": "1947-10-13 12:34",
+      "upper": "2000-01-01 00:01)"
+    },
+    "next": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Entry",
+        "id": "contentful-checkboxes-question"
+      }
+    }
+  }
+}

--- a/spec/models/currency_answer_spec.rb
+++ b/spec/models/currency_answer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CurrencyAnswer, type: :model do
       expect(answer.response).to eq(1000.01)
     end
 
-    it "returns a number" do
+    it "returns a float" do
       answer = build(:currency_answer, response: "1000.01")
       expect(answer.response).to eq(1000.01)
     end

--- a/spec/models/single_date_answer_spec.rb
+++ b/spec/models/single_date_answer_spec.rb
@@ -1,25 +1,30 @@
 require "rails_helper"
 
 RSpec.describe SingleDateAnswer, type: :model do
+  let(:answer) { build(:single_date_answer, response: date) }
+
   it { is_expected.to belong_to(:step) }
 
+  describe "#update_task_counters" do
+    it_behaves_like "task_counters", :single_date, :single_date_answer
+  end
+
   describe "#response" do
+    let(:date) { Date.new(2020, 10, 1) }
+
     it "returns a date" do
-      answer = build(:single_date_answer, response: Date.new(2020, 10, 1))
-      expect(answer.response).to eq(Date.new(2020, 10, 1))
+      expect(answer.response).to eq date
     end
   end
 
   describe "validations" do
+    let(:date) { nil }
+
     it "validates missing response" do
-      answer = build(:single_date_answer, response: nil)
+      expect(answer.valid?).to be false
 
-      expect(answer.valid?).to eq(false)
-      expect(answer.errors.full_messages.first).to include(I18n.t("activerecord.errors.models.single_date_answer.attributes.response"))
+      # activerecord.errors.models.single_date_answer.attributes.response
+      expect(answer.errors.full_messages.first).to end_with "Provide a real date for this answer"
     end
-  end
-
-  describe "#update_task_counters" do
-    it_behaves_like "task_counters", :single_date, :single_date_answer
   end
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -162,4 +162,22 @@ RSpec.describe Step, type: :model do
       expect(step.options).to eql([{ "value" => "foo", "other_config" => false }])
     end
   end
+
+  describe "#criteria" do
+    it "returns a hash of validation criteria" do
+      step = build(:step,
+                   :single_date,
+                   criteria: {
+                     "message": "Are you a time traveller!",
+                     "lower": "1947-10-13 12:34",
+                     "upper": "2000-01-01 00:01)",
+                   })
+
+      expect(step.criteria).to eql({
+        "message" => "Are you a time traveller!",
+        "upper" => "2000-01-01 00:01)",
+        "lower" => "1947-10-13 12:34",
+      })
+    end
+  end
 end

--- a/spec/services/create_step_spec.rb
+++ b/spec/services/create_step_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe CreateStep do
       let(:fixture) { "statement-step" }
 
       it "updates the step with the body" do
-        step, _answer = service.call
+        step = service.call
 
         expect(step.body).to eq "#### Heading 4"
       end
@@ -104,7 +104,7 @@ RSpec.describe CreateStep do
       let(:fixture) { "primary-button" }
 
       it "updates the step with the body" do
-        step, _answer = service.call
+        step = service.call
 
         expect(step.primary_call_to_action_text).to eq "Go onwards!"
       end
@@ -114,7 +114,7 @@ RSpec.describe CreateStep do
       let(:fixture) { "no-primary-button" }
 
       it "default copy is used for the button" do
-        step, _answer = service.call
+        step = service.call
 
         expect(step.primary_call_to_action_text).to eq "Continue"
       end
@@ -124,7 +124,7 @@ RSpec.describe CreateStep do
       let(:fixture) { "skippable-checkboxes-question" }
 
       it "default copy is used for the button" do
-        step, _answer = service.call
+        step = service.call
 
         expect(step.skip_call_to_action_text).to eq "None of the above"
       end
@@ -134,7 +134,7 @@ RSpec.describe CreateStep do
       let(:fixture) { "no-hidden-field" }
 
       it "default hidden to true" do
-        step, _answer = service.call
+        step = service.call
 
         expect(step.hidden).to be false
       end
@@ -144,7 +144,7 @@ RSpec.describe CreateStep do
       let(:fixture) { "show-one-additional-question" }
 
       it "stores the rule as JSON" do
-        step, _answer = service.call
+        step = service.call
 
         expect(step.additional_step_rules).to eql([
           {
@@ -198,6 +198,20 @@ RSpec.describe CreateStep do
                 allowed_step_types: "long_text, short_text, checkboxes, radios, currency, number, single_date, markdown")
           .and_call_original
         expect { service.call }.to raise_error(CreateStep::UnexpectedContentfulStepType)
+      end
+    end
+
+    context "when the step has validation criteria" do
+      let(:fixture) { "single-date-in-past-question" }
+
+      it "creates a step with the criteria" do
+        step = service.call
+
+        expect(step.criteria).to eq({
+          "message" => "Are you a time traveller!",
+          "lower" => "1947-10-13 12:34",
+          "upper" => "2000-01-01 00:01)",
+        })
       end
     end
   end

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -2,6 +2,8 @@
 # Mock Contentful data loaded from JSON fixtures
 #
 module ContentfulHelpers
+  # TODO: replace "contentful_fixture_filename"/"fixture_filename" with the more succinct "fixture" param
+  #
   def stub_contentful_entry(
     entry_id: "radio-question",
     fixture_filename: "radio-question-example.json",
@@ -172,9 +174,9 @@ module ContentfulHelpers
     task = double(
       Contentful::Entry,
       id: hash_response.dig("sys", "id"),
-      title: hash_response.dig("fields", "title"),
-      raw: hash_response,
       content_type: double(id: hash_response.dig("sys", "contentType", "sys", "id")),
+      raw: hash_response,
+      title: hash_response.dig("fields", "title"),
     )
 
     steps = hash_response.dig("fields", "steps").map { |step_hash| double(id: step_hash.dig("sys", "id")) }
@@ -190,11 +192,11 @@ module ContentfulHelpers
     double(
       Contentful::Entry,
       id: hash_response.dig("sys", "id"),
-      title: hash_response.dig("fields", "title"),
-      type: hash_response.dig("fields", "type"),
       content_type: double(id: hash_response.dig("sys", "contentType", "sys", "id")),
       raw: hash_response,
       fields: hash_response["fields"].dup.transform_keys!(&:underscore).symbolize_keys!,
+      title: hash_response.dig("fields", "title"),
+      type: hash_response.dig("fields", "type"),
     )
   end
 end


### PR DESCRIPTION
## Changes in this PR

Use an optional JSON field to define custom validations for questions.
<https://dfedigital.atlassian.net/wiki/spaces/GHBFS/pages/3261825072/Error+Messages>

- define a custom error message rendered to the user
- use an upper/lower bound to set a range the value must fall within to be considered valid

## Next steps

- cater for open-ended bounds (no upper limit for example)