### PR TITLE
Add user action tracking

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -17,6 +17,19 @@ class AnswersController < ApplicationController
     result = SaveAnswer.new(answer: @step.answer).call(params: prepared_params(step: @step))
     @answer = result.object
 
+    RecordAction.new(
+      action: "save_answer",
+      journey_id: @journey.id,
+      user_id: current_user.id,
+      contentful_category_id: @journey.contentful_id,
+      contentful_section_id: @step.task.section.contentful_id,
+      contentful_task_id: @step.task.contentful_id,
+      contentful_step_id: @step.contentful_id,
+      data: {
+        success: result.success?
+      }
+    ).call
+
     if result.success?
       if parent_task.has_single_visible_step?
         redirect_to journey_path(@journey, anchor: @step.id)
@@ -37,6 +50,19 @@ class AnswersController < ApplicationController
 
     result = SaveAnswer.new(answer: @step.answer).call(params: prepared_params(step: @step))
     @answer = result.object
+
+    RecordAction.new(
+      action: "update_answer",
+      journey_id: @journey.id,
+      user_id: current_user.id,
+      contentful_category_id: @journey.contentful_id,
+      contentful_section_id: @step.task.section.contentful_id,
+      contentful_task_id: @step.task.contentful_id,
+      contentful_step_id: @step.contentful_id,
+      data: {
+        success: result.success?
+      }
+    ).call
 
     if result.success?
       if parent_task.has_single_visible_step?

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -21,11 +21,24 @@ class JourneysController < ApplicationController
 
   def new
     journey = CreateJourney.new(category_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"], user: current_user).call
+    RecordAction.new(
+      action: "begin_journey",
+      journey_id: journey.id,
+      user_id: current_user.id,
+      contentful_category_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"]
+    ).call
     redirect_to journey_path(journey)
   end
 
   def show
     @journey = current_journey
     @sections = @journey.sections.includes(:tasks)
+
+    RecordAction.new(
+      action: "view_journey",
+      journey_id: @journey.id,
+      user_id: current_user.id,
+      contentful_category_id: @journey.contentful_id
+    ).call
   end
 end

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -13,6 +13,17 @@ class SpecificationsController < ApplicationController
       answers: GetAnswersForSteps.new(visible_steps: @visible_steps).call
     )
 
+    RecordAction.new(
+      action: "view_specification",
+      journey_id: @journey.id,
+      user_id: current_user.id,
+      contentful_category_id: @journey.contentful_id,
+      data: {
+        format: request.format.symbol,
+        all_steps_completed: @journey.all_steps_completed?
+      }
+    ).call
+
     @specification_html = specification_renderer.to_html
 
     respond_to do |format|

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -16,6 +16,18 @@ class StepsController < ApplicationController
       journey_task_path(@journey, parent_task, back_link: true)
     end
 
+    RecordAction.new(
+      action: "begin_step",
+      journey_id: @journey.id,
+      user_id: current_user.id,
+      contentful_category_id: @journey.contentful_id,
+      # We safe navigate here because in preview we don't have sections or
+      # tasks. This saves us from having to implement extra logic.
+      contentful_section_id: @step.task&.section&.contentful_id,
+      contentful_task_id: @step&.task&.contentful_id,
+      contentful_step_id: @step.contentful_id
+    ).call
+
     render @step.contentful_type, locals: {layout: "steps/new_form_wrapper"}
   end
 
@@ -31,6 +43,16 @@ class StepsController < ApplicationController
     else
       journey_task_path(@journey, parent_task, back_link: true)
     end
+
+    RecordAction.new(
+      action: "view_step",
+      journey_id: @journey.id,
+      user_id: current_user.id,
+      contentful_category_id: @journey.contentful_id,
+      contentful_section_id: @step.task.section.contentful_id,
+      contentful_task_id: @step.task.contentful_id,
+      contentful_step_id: @step.contentful_id
+    ).call
 
     render "steps/#{@step.contentful_type}", locals: {layout: "steps/edit_form_wrapper"}
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,6 +6,15 @@ class TasksController < ApplicationController
     @task = Task.find(task_id)
     steps = @task.eager_loaded_visible_steps.ordered
     @steps = steps.map { |step| StepPresenter.new(step) }
+
+    RecordAction.new(
+      action: "view_task",
+      journey_id: @journey.id,
+      user_id: current_user.id,
+      contentful_category_id: @journey.contentful_id,
+      contentful_section_id: task.section.contentful_id,
+      contentful_task_id: task.id
+    ).call
   end
 
   private
@@ -21,6 +30,17 @@ class TasksController < ApplicationController
   def redirect_to_first_step_if_task_has_no_answers
     return unless task.answered_questions_count.zero?
     return if params.fetch(:back_link, nil).present?
+
+    @journey = current_journey
+
+    RecordAction.new(
+      action: "begin_task",
+      journey_id: @journey.id,
+      user_id: current_user.id,
+      contentful_category_id: @journey.contentful_id,
+      contentful_section_id: task.section.contentful_id,
+      contentful_task_id: task.id
+    ).call
 
     redirect_to journey_step_path(current_journey, task.next_unanswered_step_id)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -13,7 +13,12 @@ class TasksController < ApplicationController
       user_id: current_user.id,
       contentful_category_id: @journey.contentful_id,
       contentful_section_id: task.section.contentful_id,
-      contentful_task_id: task.id
+      contentful_task_id: task.contentful_id,
+      data: {
+        task_status: task.status,
+        task_total_steps: task.visible_steps_count,
+        task_answered_questions: task.answered_questions_count
+      }
     ).call
   end
 
@@ -39,7 +44,12 @@ class TasksController < ApplicationController
       user_id: current_user.id,
       contentful_category_id: @journey.contentful_id,
       contentful_section_id: task.section.contentful_id,
-      contentful_task_id: task.id
+      contentful_task_id: task.contentful_id,
+      data: {
+        task_status: task.status,
+        task_total_steps: task.visible_steps_count,
+        task_answered_questions: task.answered_questions_count
+      }
     ).call
 
     redirect_to journey_step_path(current_journey, task.next_unanswered_step_id)

--- a/app/services/record_action.rb
+++ b/app/services/record_action.rb
@@ -5,6 +5,7 @@ class RecordAction
 
   ALLOWED_ACTION_TYPES = %w[
     begin_journey
+    view_journey
   ].freeze
 
   def initialize(

--- a/app/services/record_action.rb
+++ b/app/services/record_action.rb
@@ -8,6 +8,8 @@ class RecordAction
     view_journey
     begin_task
     view_task
+    begin_step
+    view_step
     view_specification
   ].freeze
 

--- a/app/services/record_action.rb
+++ b/app/services/record_action.rb
@@ -10,6 +10,8 @@ class RecordAction
     view_task
     begin_step
     view_step
+    save_answer
+    update_answer
     view_specification
   ].freeze
 

--- a/app/services/record_action.rb
+++ b/app/services/record_action.rb
@@ -6,6 +6,8 @@ class RecordAction
   ALLOWED_ACTION_TYPES = %w[
     begin_journey
     view_journey
+    begin_task
+    view_task
   ].freeze
 
   def initialize(

--- a/app/services/record_action.rb
+++ b/app/services/record_action.rb
@@ -8,6 +8,7 @@ class RecordAction
     view_journey
     begin_task
     view_task
+    view_specification
   ].freeze
 
   def initialize(

--- a/spec/features/school_buying_professionals/blank_field_spec.rb
+++ b/spec/features/school_buying_professionals/blank_field_spec.rb
@@ -19,5 +19,4 @@ feature "Back link works after failed form validations" do
 
     expect(page).to have_content "Describe what you need"
   end
-
 end

--- a/spec/features/school_buying_professionals/complete_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/complete_a_journey_spec.rb
@@ -554,4 +554,24 @@ feature "Anyone can start a journey" do
       expect(last_logged_event.contentful_step_id).to eq(step.contentful_id)
     end
   end
+
+  context "when a user answers a question" do
+    scenario "an action is recorded" do
+      start_journey_from_category_and_go_to_first_section(category: "long-text-question.json")
+      journey = Journey.last
+
+      fill_in "answer[response]", with: "This is my long answer"
+
+      click_on(I18n.t("generic.button.next"))
+
+      save_answer_logged_event = ActivityLogItem.where(action: "save_answer").first
+      expect(save_answer_logged_event.journey_id).to eq(journey.id)
+      expect(save_answer_logged_event.user_id).to eq(User.last.id)
+      expect(save_answer_logged_event.contentful_category_id).to eq("contentful-category-entry")
+      expect(save_answer_logged_event.contentful_section_id).to eq(Section.last.contentful_id)
+      expect(save_answer_logged_event.contentful_task_id).to eq(Task.last.contentful_id)
+      expect(save_answer_logged_event.contentful_step_id).to eq(Step.last.contentful_id)
+      expect(save_answer_logged_event.data["success"]).to eq true
+    end
+  end
 end

--- a/spec/features/school_buying_professionals/complete_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/complete_a_journey_spec.rb
@@ -515,4 +515,43 @@ feature "Anyone can start a journey" do
       expect(first_logged_event.contentful_category_id).to eq(ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"])
     end
   end
+
+  context "when a user views a step which has not been answered" do
+    scenario "an action is recorded" do
+      start_journey_from_category_and_go_to_first_section(category: "radio-question.json")
+
+      step = Step.last
+
+      last_logged_event = ActivityLogItem.last
+      expect(last_logged_event.action).to eq("begin_step")
+      expect(last_logged_event.journey_id).to eq(Journey.last.id)
+      expect(last_logged_event.user_id).to eq(User.last.id)
+      expect(last_logged_event.contentful_category_id).to eq("contentful-category-entry")
+      expect(last_logged_event.contentful_section_id).to eq(step.task.section.contentful_id)
+      expect(last_logged_event.contentful_task_id).to eq(step.task.contentful_id)
+      expect(last_logged_event.contentful_step_id).to eq(step.contentful_id)
+    end
+  end
+
+  context "when a user views a previously answered step" do
+    scenario "an action is recorded" do
+      start_journey_with_tasks_from_category(category: "radio-question.json")
+
+      journey = Journey.last
+      task = Task.find_by(title: "Radio task")
+      step = task.steps.first
+      create(:radio_answer, step: step)
+
+      visit edit_journey_step_path(journey, step)
+
+      last_logged_event = ActivityLogItem.last
+      expect(last_logged_event.action).to eq("view_step")
+      expect(last_logged_event.journey_id).to eq(journey.id)
+      expect(last_logged_event.user_id).to eq(User.last.id)
+      expect(last_logged_event.contentful_category_id).to eq("contentful-category-entry")
+      expect(last_logged_event.contentful_section_id).to eq(step.task.section.contentful_id)
+      expect(last_logged_event.contentful_task_id).to eq(step.task.contentful_id)
+      expect(last_logged_event.contentful_step_id).to eq(step.contentful_id)
+    end
+  end
 end

--- a/spec/features/school_buying_professionals/complete_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/complete_a_journey_spec.rb
@@ -503,4 +503,16 @@ feature "Anyone can start a journey" do
       expect(page).to have_content("Catering")
     end
   end
+
+  context "when a new journey is begun" do
+    scenario "records that action in the event log" do
+      start_journey_from_category(category: "radio-question.json")
+
+      last_logged_event = ActivityLogItem.last
+      expect(last_logged_event.action).to eq("begin_journey")
+      expect(last_logged_event.journey_id).to eq(Journey.last.id)
+      expect(last_logged_event.user_id).to eq(User.last.id)
+      expect(last_logged_event.contentful_category_id).to eq(ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"])
+    end
+  end
 end

--- a/spec/features/school_buying_professionals/complete_a_journey_spec.rb
+++ b/spec/features/school_buying_professionals/complete_a_journey_spec.rb
@@ -508,11 +508,11 @@ feature "Anyone can start a journey" do
     scenario "records that action in the event log" do
       start_journey_from_category(category: "radio-question.json")
 
-      last_logged_event = ActivityLogItem.last
-      expect(last_logged_event.action).to eq("begin_journey")
-      expect(last_logged_event.journey_id).to eq(Journey.last.id)
-      expect(last_logged_event.user_id).to eq(User.last.id)
-      expect(last_logged_event.contentful_category_id).to eq(ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"])
+      first_logged_event = ActivityLogItem.first
+      expect(first_logged_event.action).to eq("begin_journey")
+      expect(first_logged_event.journey_id).to eq(Journey.last.id)
+      expect(first_logged_event.user_id).to eq(User.last.id)
+      expect(first_logged_event.contentful_category_id).to eq(ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"])
     end
   end
 end

--- a/spec/features/school_buying_professionals/download_their_catering_specification_spec.rb
+++ b/spec/features/school_buying_professionals/download_their_catering_specification_spec.rb
@@ -51,4 +51,38 @@ feature "Users can see their catering specification" do
       expect(page.response_headers["Content-Disposition"]).to match(/filename="specification-incomplete.docx"/)
     end
   end
+
+  context "when viewing a journey" do
+    let(:user) { create(:user) }
+    before { user_is_signed_in(user: user) }
+
+    scenario "requesting the HTML version records an action" do
+      start_journey_from_category(category: "category-with-liquid-template.json")
+
+      click_on(I18n.t("journey.specification.button"))
+
+      journey = Journey.last
+      last_logged_event = ActivityLogItem.last
+      expect(last_logged_event.action).to eq("view_specification")
+      expect(last_logged_event.journey_id).to eq(journey.id)
+      expect(last_logged_event.user_id).to eq(user.id)
+      expect(last_logged_event.contentful_category_id).to eq("contentful-category-entry")
+      expect(last_logged_event.data["format"]).to eq("html")
+    end
+
+    scenario "requesting the .docx version records an action" do
+      start_journey_from_category(category: "category-with-liquid-template.json")
+
+      click_on(I18n.t("journey.specification.button"))
+      click_on("Download (.docx)")
+
+      journey = Journey.last
+      last_logged_event = ActivityLogItem.last
+      expect(last_logged_event.action).to eq("view_specification")
+      expect(last_logged_event.journey_id).to eq(journey.id)
+      expect(last_logged_event.user_id).to eq(user.id)
+      expect(last_logged_event.contentful_category_id).to eq("contentful-category-entry")
+      expect(last_logged_event.data["format"]).to eq("docx")
+    end
+  end
 end

--- a/spec/features/school_buying_professionals/edit_their_answers_spec.rb
+++ b/spec/features/school_buying_professionals/edit_their_answers_spec.rb
@@ -132,5 +132,24 @@ feature "Users can edit their answers" do
 
       expect(page).to have_current_path(journey_url(answer.step.journey, anchor: answer.step.id))
     end
+
+    scenario "an action is recorded" do
+      visit journey_path(answer.step.journey)
+
+      click_on(title)
+
+      fill_in "answer[response]", with: "email@example.com"
+
+      click_on(I18n.t("generic.button.update"))
+
+      update_answer_logged_event = ActivityLogItem.where(action: "update_answer").first
+      expect(update_answer_logged_event.journey_id).to eq(answer.step.journey.id)
+      expect(update_answer_logged_event.user_id).to eq(user.id)
+      expect(update_answer_logged_event.contentful_category_id).to eq("12345678")
+      expect(update_answer_logged_event.contentful_section_id).to eq(answer.step.task.section.contentful_id)
+      expect(update_answer_logged_event.contentful_task_id).to eq(answer.step.task.contentful_id)
+      expect(update_answer_logged_event.contentful_step_id).to eq(answer.step.contentful_id)
+      expect(update_answer_logged_event.data["success"]).to eq true
+    end
   end
 end

--- a/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
@@ -53,4 +53,18 @@ feature "Anyone can view a dashboard" do
     expect(page).to have_content("Radio task")
     expect(page).to have_content("Not started")
   end
+
+  scenario "when a user revisits an existing journey an action is recorded in the event log" do
+    user = create(:user)
+    user_is_signed_in(user: user)
+    journey = create(:journey, user: user, created_at: Time.local(2021, 2, 15, 12, 0, 0), contentful_id: "12345678")
+
+    visit journey_path(journey)
+
+    last_logged_event = ActivityLogItem.last
+    expect(last_logged_event.action).to eq("view_journey")
+    expect(last_logged_event.journey_id).to eq(journey.id)
+    expect(last_logged_event.user_id).to eq(user.id)
+    expect(last_logged_event.contentful_category_id).to eq("12345678")
+  end
 end

--- a/spec/features/school_buying_professionals/view_a_task_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_task_spec.rb
@@ -32,6 +32,9 @@ feature "Users can view a task" do
       expect(last_logged_event.contentful_category_id).to eq("contentful-category-entry")
       expect(last_logged_event.contentful_section_id).to eq("tasks-section")
       expect(last_logged_event.contentful_task_id).to eq(task.id)
+      expect(last_logged_event.data["task_status"]).to eq(Task::NOT_STARTED)
+      expect(last_logged_event.data["task_total_steps"]).to eq(4)
+      expect(last_logged_event.data["task_answered_questions"]).to eq(0)
     end
 
     context "when a task has at least one answered step" do
@@ -69,7 +72,46 @@ feature "Users can view a task" do
         expect(last_logged_event.user_id).to eq(user.id)
         expect(last_logged_event.contentful_category_id).to eq("contentful-category-entry")
         expect(last_logged_event.contentful_section_id).to eq("tasks-section")
-        expect(last_logged_event.contentful_task_id).to eq(task.id)
+        expect(last_logged_event.contentful_task_id).to eq(task.contentful_id)
+        expect(last_logged_event.data["task_status"]).to eq(Task::IN_PROGRESS)
+        expect(last_logged_event.data["task_total_steps"]).to eq(4)
+        expect(last_logged_event.data["task_answered_questions"]).to eq(1)
+      end
+    end
+
+    context "when all questions in a task have been answered" do
+      it "records an action in the event log that a completed task has been revisited" do
+        start_journey_with_tasks_from_category(category: "section-with-multiple-tasks.json")
+
+        within(".app-task-list") do
+          click_on "Task with multiple steps"
+        end
+
+        choose "Catering"
+        click_on(I18n.t("generic.button.next"))
+
+        fill_in "answer[response]", with: "This is my short answer"
+        click_on(I18n.t("generic.button.next"))
+
+        fill_in "answer[response]", with: "This is my long answer"
+        click_on(I18n.t("generic.button.next"))
+
+        check("Breakfast")
+        click_on(I18n.t("generic.button.next"))
+
+        task = Task.find_by(title: "Task with multiple steps")
+        journey = Journey.first
+
+        last_logged_event = ActivityLogItem.last
+        expect(last_logged_event.action).to eq("view_task")
+        expect(last_logged_event.journey_id).to eq(journey.id)
+        expect(last_logged_event.user_id).to eq(user.id)
+        expect(last_logged_event.contentful_category_id).to eq("contentful-category-entry")
+        expect(last_logged_event.contentful_section_id).to eq("tasks-section")
+        expect(last_logged_event.contentful_task_id).to eq(task.contentful_id)
+        expect(last_logged_event.data["task_status"]).to eq(Task::COMPLETED)
+        expect(last_logged_event.data["task_total_steps"]).to eq(4)
+        expect(last_logged_event.data["task_answered_questions"]).to eq(4)
       end
     end
 

--- a/spec/features/school_buying_professionals/view_a_task_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_task_spec.rb
@@ -25,16 +25,18 @@ feature "Users can view a task" do
       journey = Journey.first
       task = Task.find_by(title: "Task with multiple steps")
 
-      last_logged_event = ActivityLogItem.last
-      expect(last_logged_event.action).to eq("begin_task")
-      expect(last_logged_event.journey_id).to eq(journey.id)
-      expect(last_logged_event.user_id).to eq(user.id)
-      expect(last_logged_event.contentful_category_id).to eq("contentful-category-entry")
-      expect(last_logged_event.contentful_section_id).to eq("tasks-section")
-      expect(last_logged_event.contentful_task_id).to eq(task.id)
-      expect(last_logged_event.data["task_status"]).to eq(Task::NOT_STARTED)
-      expect(last_logged_event.data["task_total_steps"]).to eq(4)
-      expect(last_logged_event.data["task_answered_questions"]).to eq(0)
+      # The process of starting a task also records entering the first step. We
+      # explicitly select the event with the "begin_task" action and check it
+      # matches our expectations.
+      begin_task_logged_event = ActivityLogItem.where(action: "begin_task").first
+      expect(begin_task_logged_event.journey_id).to eq(journey.id)
+      expect(begin_task_logged_event.user_id).to eq(user.id)
+      expect(begin_task_logged_event.contentful_category_id).to eq("contentful-category-entry")
+      expect(begin_task_logged_event.contentful_section_id).to eq("tasks-section")
+      expect(begin_task_logged_event.contentful_task_id).to eq(task.contentful_id)
+      expect(begin_task_logged_event.data["task_status"]).to eq(Task::NOT_STARTED)
+      expect(begin_task_logged_event.data["task_total_steps"]).to eq(4)
+      expect(begin_task_logged_event.data["task_answered_questions"]).to eq(0)
     end
 
     context "when a task has at least one answered step" do


### PR DESCRIPTION
Add recording of key user actions throughout the journey:

- Starting a journey
- Revisiting a previously started journey
- Viewing a task for the first time
- Returning to a task which is either in progress or completed
- Looking at a step for the first time
- Returning to look at a previously completed step
- Answering a question for the first time
- Updating a previously answered question