### PR TITLE
Store a hash of step counts on the task

### DIFF
--- a/app/models/checkbox_answers.rb
+++ b/app/models/checkbox_answers.rb
@@ -6,10 +6,16 @@ class CheckboxAnswers < ActiveRecord::Base
     presence: true,
     unless: proc { |answer| answer.step.skippable? && answer.skipped }
 
+  after_commit :update_task_counters
+
   def response=(args)
     return if args.blank?
     args.reject!(&:blank?) if args.is_a?(Array)
 
     super(args)
+  end
+
+  private def update_task_counters
+    step.update_task_counters
   end
 end

--- a/app/models/currency_answer.rb
+++ b/app/models/currency_answer.rb
@@ -4,11 +4,17 @@ class CurrencyAnswer < ActiveRecord::Base
 
   validates :response, presence: true, numericality: {greater_than_or_equal_to: 0, message: "does not accept £ signs or other non numerical characters"}
 
+  after_commit :update_task_counters
+
   def response=(value)
     if value.is_a?(String)
       super(value.delete(","))
       return
     end
     super(value)
+  end
+
+  private def update_task_counters
+    step.update_task_counters
   end
 end

--- a/app/models/long_text_answer.rb
+++ b/app/models/long_text_answer.rb
@@ -3,4 +3,10 @@ class LongTextAnswer < ActiveRecord::Base
   belongs_to :step
 
   validates :response, presence: true
+
+  after_commit :update_task_counters
+
+  private def update_task_counters
+    step.update_task_counters
+  end
 end

--- a/app/models/number_answer.rb
+++ b/app/models/number_answer.rb
@@ -3,4 +3,10 @@ class NumberAnswer < ActiveRecord::Base
   belongs_to :step
 
   validates :response, presence: true, numericality: {only_integer: true}
+
+  after_commit :update_task_counters
+
+  private def update_task_counters
+    step.update_task_counters
+  end
 end

--- a/app/models/radio_answer.rb
+++ b/app/models/radio_answer.rb
@@ -3,4 +3,10 @@ class RadioAnswer < ActiveRecord::Base
   belongs_to :step
 
   validates :response, presence: true
+
+  after_commit :update_task_counters
+
+  private def update_task_counters
+    step.update_task_counters
+  end
 end

--- a/app/models/short_text_answer.rb
+++ b/app/models/short_text_answer.rb
@@ -3,4 +3,10 @@ class ShortTextAnswer < ActiveRecord::Base
   belongs_to :step
 
   validates :response, presence: true
+
+  after_commit :update_task_counters
+
+  private def update_task_counters
+    step.update_task_counters
+  end
 end

--- a/app/models/single_date_answer.rb
+++ b/app/models/single_date_answer.rb
@@ -3,4 +3,10 @@ class SingleDateAnswer < ActiveRecord::Base
   belongs_to :step
 
   validates :response, presence: {message: I18n.t("activerecord.errors.models.single_date_answer.attributes.response")}
+
+  after_commit :update_task_counters
+
+  private def update_task_counters
+    step.update_task_counters
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -14,6 +14,8 @@ class Step < ApplicationRecord
   scope :that_are_questions, -> { where(contentful_model: "question") }
   scope :ordered, -> { order(:order) }
 
+  after_save :update_task_counters
+
   def answer
     @answer ||=
       case contentful_type
@@ -42,5 +44,9 @@ class Step < ApplicationRecord
 
   def journey
     task.section.journey
+  end
+
+  def update_task_counters
+    task.save
   end
 end

--- a/db/migrate/20210621124139_add_step_tally_to_tasks.rb
+++ b/db/migrate/20210621124139_add_step_tally_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStepTallyToTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :step_tally, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_21_085254) do
+ActiveRecord::Schema.define(version: 2021_06_21_124139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -149,6 +149,7 @@ ActiveRecord::Schema.define(version: 2021_06_21_085254) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "order"
+    t.jsonb "step_tally"
     t.index ["order"], name: "index_tasks_on_order"
     t.index ["section_id"], name: "index_tasks_on_section_id"
   end

--- a/spec/models/checkbox_answers_spec.rb
+++ b/spec/models/checkbox_answers_spec.rb
@@ -46,4 +46,20 @@ RSpec.describe CheckboxAnswers, type: :model do
       end
     end
   end
+
+  describe "#update_task_counters" do
+    it "increments the task tally via callback" do
+      task = create(:task)
+      expect(task.step_tally["answered"]).to eq 0
+
+      step_1 = create(:step, :checkbox_answers, hidden: false, task: task)
+      answer_1 = create(:checkbox_answers, step: step_1)
+
+      expect(task.step_tally["answered"]).to eq 1
+
+      answer_1.destroy
+
+      expect(task.step_tally["answered"]).to eq 0
+    end
+  end
 end

--- a/spec/models/currency_answer_spec.rb
+++ b/spec/models/currency_answer_spec.rb
@@ -18,4 +18,20 @@ RSpec.describe CurrencyAnswer, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:response) }
   end
+
+  describe "#update_task_counters" do
+    it "increments the task tally via callback" do
+      task = create(:task)
+      expect(task.step_tally["answered"]).to eq 0
+
+      step_1 = create(:step, :currency, hidden: false, task: task)
+      answer_1 = create(:currency_answer, step: step_1)
+
+      expect(task.step_tally["answered"]).to eq 1
+
+      answer_1.destroy
+
+      expect(task.step_tally["answered"]).to eq 0
+    end
+  end
 end

--- a/spec/models/long_text_answer_spec.rb
+++ b/spec/models/long_text_answer_spec.rb
@@ -11,4 +11,20 @@ RSpec.describe LongTextAnswer, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:response) }
   end
+
+  describe "#update_task_counters" do
+    it "increments the task tally via callback" do
+      task = create(:task)
+      expect(task.step_tally["answered"]).to eq 0
+
+      step_1 = create(:step, :long_text, hidden: false, task: task)
+      answer_1 = create(:long_text_answer, step: step_1)
+
+      expect(task.step_tally["answered"]).to eq 1
+
+      answer_1.destroy
+
+      expect(task.step_tally["answered"]).to eq 0
+    end
+  end
 end

--- a/spec/models/radio_answer_spec.rb
+++ b/spec/models/radio_answer_spec.rb
@@ -11,4 +11,20 @@ RSpec.describe RadioAnswer, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:response) }
   end
+
+  describe "#update_task_counters" do
+    it "increments the task tally via callback" do
+      task = create(:task)
+      expect(task.step_tally["answered"]).to eq 0
+
+      step_1 = create(:step, :radio, hidden: false, task: task)
+      answer_1 = create(:radio_answer, step: step_1)
+
+      expect(task.step_tally["answered"]).to eq 1
+
+      answer_1.destroy
+
+      expect(task.step_tally["answered"]).to eq 0
+    end
+  end
 end

--- a/spec/models/short_text_answer_spec.rb
+++ b/spec/models/short_text_answer_spec.rb
@@ -11,4 +11,20 @@ RSpec.describe ShortTextAnswer, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:response) }
   end
+
+  describe "#update_task_counters" do
+    it "increments the task tally via callback" do
+      task = create(:task)
+      expect(task.step_tally["answered"]).to eq 0
+
+      step_1 = create(:step, :short_text, hidden: false, task: task)
+      answer_1 = create(:short_text_answer, step: step_1)
+
+      expect(task.step_tally["answered"]).to eq 1
+
+      answer_1.destroy
+
+      expect(task.step_tally["answered"]).to eq 0
+    end
+  end
 end

--- a/spec/models/single_date_answer_spec.rb
+++ b/spec/models/single_date_answer_spec.rb
@@ -18,4 +18,20 @@ RSpec.describe SingleDateAnswer, type: :model do
       expect(answer.errors.full_messages.first).to include(I18n.t("activerecord.errors.models.single_date_answer.attributes.response"))
     end
   end
+
+  describe "#update_task_counters" do
+    it "increments the task tally via callback" do
+      task = create(:task)
+      expect(task.step_tally["answered"]).to eq 0
+
+      step_1 = create(:step, :single_date, hidden: false, task: task)
+      answer_1 = create(:single_date_answer, step: step_1)
+
+      expect(task.step_tally["answered"]).to eq 1
+
+      answer_1.destroy
+
+      expect(task.step_tally["answered"]).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- record numbers of total, visible, hidden and answered steps
- save counters as an extensible hash in JSONB
- use callbacks when answers are committed or steps revealed
- use the persisted tally to calculate task state in other methods
- remove memoisation in Task#eager_loaded_visible_steps which caused issues
- remove dedicated counting methods
- enable the TaskController to find the next_unanswered_task
- add a guard clause to Task#next_unanswered_step_id
- reduce the use of expensive relation loading

## Next steps

- add utility predicate methods to the task to query state
- use answer model class inheritance

<!-- - [] Document this change in [Confluence](https://dfedigital.atlassian.net/wiki/spaces/GHBFS) -->
