### PR TITLE
release-015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+## [release-015] - 2021-06-17
+
 - always show task title even if it contains a single step
 - replace journeys_path with a unified dashboard
 - replace back to task list button with a link
@@ -185,7 +187,8 @@ The format is based on [Keep a Changelog 1.0.0].
 - Contentful can redirect users to preview endpoints
 - users can be asked to answer a long text question
 
-[unreleased]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-014...HEAD
+[unreleased]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-015...HEAD
+[release-015]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-014...release-015
 [release-014]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-013...release-014
 [release-013]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-012...release-013
 [release-012]: https://github.com/DFE-Digital/buy-for-your-school/compare/release-011...release-012


### PR DESCRIPTION
- always show task title even if it contains a single step
- replace journeys_path with a unified dashboard
- replace back to task list button with a link
- add button to continue completing the current task
- add button to continue to the next incomplete task if the current is complete
- track key user actions throughout the journey
