### PR TITLE
#56: Make the create spec button comply with accessibility needs

### DIFF
--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -8,9 +8,10 @@
   </div>
 
   <% if @current_user.journeys.any? %>
-    <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m"><%= I18n.t("dashboard.existing.header") %></h2>
-        <p class="govuk-body"><%= I18n.t("dashboard.existing.body") %></p>
+    <div class="govuk-grid-column-full">
+      <%= link_to I18n.t("dashboard.create.button"), new_journey_path, class: "govuk-button" %>
+      <h2 class="govuk-heading-m"><%= I18n.t("dashboard.existing.header") %></h2>
+      <p class="govuk-body"><%= I18n.t("dashboard.existing.body") %></p>
 
       <table class="govuk-table">
         <thead class="govuk-table__head">
@@ -29,15 +30,12 @@
         </tbody>
       </table>
     </div>
-    <div class="govuk-grid-column-one-third">
-      <%= button_to I18n.t("dashboard.create.button"), new_journey_path, class: "govuk-button", method: :get %>
-    </div>
   <% else %>
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m"><%= I18n.t("dashboard.create.header") %></h2>
       <p class="govuk-body"><%= I18n.t("dashboard.create.body") %></p>
 
-      <%= button_to I18n.t("dashboard.create.button"), new_journey_path, class: "govuk-button", method: :get %>
+      <%= link_to I18n.t("dashboard.create.button"), new_journey_path, class: "govuk-button" %>
     </div>
   <% end %>
 

--- a/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
+++ b/spec/features/school_buying_professionals/view_a_dashboard_spec.rb
@@ -27,6 +27,10 @@ feature "Anyone can view a dashboard" do
     expect(page).to have_content(I18n.t("dashboard.existing.header"))
     expect(page).to have_content(I18n.t("dashboard.existing.body"))
 
+    expect(page).to have_link(I18n.t("dashboard.create.button"))
+    link_div = find_link(I18n.t("dashboard.create.button")).find(:xpath, "..")
+    expect(link_div[:class]).to eq("govuk-grid-column-full")
+
     expect(page).to have_content("15 February 2021")
   end
 
@@ -39,7 +43,7 @@ feature "Anyone can view a dashboard" do
     expect(page).to have_content(I18n.t("dashboard.create.header"))
     expect(page).to have_content(I18n.t("dashboard.create.body"))
 
-    expect(page).to have_button(I18n.t("dashboard.create.button"))
+    expect(page).to have_link(I18n.t("dashboard.create.button"))
   end
 
   scenario "user can start a new specification from the dashboard" do

--- a/spec/support/sign_in_helpers.rb
+++ b/spec/support/sign_in_helpers.rb
@@ -15,7 +15,7 @@ module SignInHelpers
   def user_starts_the_journey
     visit root_path
     click_button I18n.t("generic.button.start")
-    click_button I18n.t("dashboard.create.button")
+    click_on I18n.t("dashboard.create.button")
   end
 
   def user_signs_in_and_starts_the_journey


### PR DESCRIPTION
## Changes in this PR

- Move the **Create new specification** button to the top-left of the dashboard in order to comply with accessibility requirements by removing the containing `div` and changing the dashboard layout class to `govuk-grid-column-full`.
- Update the **Create new specification** button to be a link.
- Update the `view_a_dashboard_spec` scenario `user can view existing specifications` by checking for the presence of the button and ensuring its containing class is`govuk-grid-column-full`.
- Update other relevant tests now that the button is a link.

## Screenshots of UI changes

### Before

<img width="947" alt="image" src="https://user-images.githubusercontent.com/12530193/122400386-94d35a80-cf73-11eb-870f-6f1fec73f88f.png">

### After

<img width="992" alt="image" src="https://user-images.githubusercontent.com/12530193/122733221-e2520f00-d274-11eb-9b8b-45068395ab24.png">

