### PR TITLE
Add ordering to tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [Unreleased]
 
+- add explicit ordering to the task model to allow continuing to the next unanswered task
+
 ## [release-015] - 2021-06-17
 
 - always show task title even if it contains a single step

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -34,8 +34,7 @@ class TasksController < ApplicationController
   end
 
   def next_task
-    next_task_id = current_journey.tasks.find_index { |t| t.id == task_id } + 1
-    current_journey.tasks[next_task_id]
+    current_journey.tasks.order(:section_id, :order).reject(&:all_steps_answered?).last
   end
 
   def redirect_to_first_step_if_task_has_no_answers

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -28,13 +28,21 @@ class CreateJourney
       ).call
 
       contentful_tasks = GetTasksFromSection.new(section: contentful_section).call
-      contentful_tasks.each do |contentful_task|
-        task = CreateTask.new(section: section, contentful_task: contentful_task).call
+      contentful_tasks.each_with_index do |contentful_task, index|
+
+        task = CreateTask.new(
+          section: section,
+          contentful_task: contentful_task,
+          order: index
+        ).call
 
         question_entries = GetStepsFromTask.new(task: contentful_task).call
+
         question_entries.each_with_index do |entry, index|
           CreateStep.new(
-            contentful_entry: entry, task: task, order: index
+            contentful_entry: entry,
+            task: task,
+            order: index
           ).call
         end
       end

--- a/app/services/create_task.rb
+++ b/app/services/create_task.rb
@@ -1,15 +1,21 @@
 class CreateTask
   class UnexpectedContentfulModel < StandardError; end
 
-  attr_accessor :section, :contentful_task
+  attr_accessor :section, :contentful_task, :order
 
-  def initialize(section:, contentful_task:)
+  def initialize(section:, contentful_task:, order:)
     @section = section
     @contentful_task = contentful_task
+    @order = order
   end
 
   def call
-    task = Task.new(section: section, title: contentful_task.title, contentful_id: contentful_task.id)
+    task = Task.new(
+      section: section,
+      title: contentful_task.title,
+      contentful_id: contentful_task.id,
+      order: order
+      )
     begin
       task.save!
       task

--- a/db/migrate/20210621085254_add_order_to_tasks.rb
+++ b/db/migrate/20210621085254_add_order_to_tasks.rb
@@ -1,0 +1,6 @@
+class AddOrderToTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :order, :integer
+    add_index :tasks, :order
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_20_155735) do
+ActiveRecord::Schema.define(version: 2021_06_21_085254) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -148,6 +148,8 @@ ActiveRecord::Schema.define(version: 2021_05_20_155735) do
     t.string "contentful_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "order"
+    t.index ["order"], name: "index_tasks_on_order"
     t.index ["section_id"], name: "index_tasks_on_section_id"
   end
 

--- a/spec/services/create_task_spec.rb
+++ b/spec/services/create_task_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe CreateTask do
 
   describe "#call" do
     it "creates a new task" do
-      expect { described_class.new(section: section, contentful_task: contentful_task).call }
+      expect { described_class.new(section: section, contentful_task: contentful_task, order: 0).call }
         .to change { Task.count }.by(1)
       expect(Task.last.title).to eql("Task 1")
       expect(Task.last.contentful_id).to eql("5m26U35YLau4cOaJq6FXZA")
       expect(Task.last.section).to eql(section)
+      expect(Task.last.order).to eql(0)
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Add task ordering which is required to reliably find the next unanswered task.

