### PR TITLE
Redirect to prototypes (temporary)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
       who_for_title: Who this service is for
       who_for_can_use_body: "You can use this service if you:"
       who_for_can_use_list:
-        - are responsible for <a href="/planning" class="govuk-link">procuring a new catering service for a school</a>
+        - are responsible for <a href="https://buy-for-your-school-prototypes.herokuapp.com/beta/phase-5/catering" class="govuk-link">procuring a new catering service for a school</a>
         - are procuring for one school – either a local authority maintained school or an academy in a single or multi-academy trust
         - intend to run your own procurement process or choose a supplier from a framework – read more about the different procurement routes you can take
       who_for_cannot_use_body: "You currently cannot use this service to create a specification for any of the following:"

--- a/spec/features/visitors/see_a_planning_start_page_spec.rb
+++ b/spec/features/visitors/see_a_planning_start_page_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Users can see a start page for planning their purchase" do
-  scenario "Start page content is shown on the root path" do
+  xscenario "Start page content is shown on the root path" do
     visit root_path
 
     click_on("procuring a new catering service for a school")
@@ -43,7 +43,7 @@ feature "Users can see a start page for planning their purchase" do
     expect(page).to have_link("get help with buying for schools", href: "https://www.gov.uk/guidance/buying-for-schools/get-help-with-buying-for-schools")
   end
 
-  scenario "can navigate back to the home page" do
+  xscenario "can navigate back to the home page" do
     visit root_path
 
     click_on("procuring a new catering service for a school")

--- a/spec/features/visitors/see_a_specification_start_page_spec.rb
+++ b/spec/features/visitors/see_a_specification_start_page_spec.rb
@@ -14,7 +14,7 @@ feature "Users can see a start page for specifying their purchase" do
     expect(page).to have_content(I18n.t("specifying.start_page.who_for_can_use_body"))
 
     expect(page).to have_content("are responsible for procuring a new catering service for a school")
-    expect(page).to have_link("procuring a new catering service", href: "/planning")
+    expect(page).to have_link("procuring a new catering service", href: "https://buy-for-your-school-prototypes.herokuapp.com/beta/phase-5/catering")
     expect(page).to have_content(I18n.t("specifying.start_page.who_for_can_use_list")[1])
     expect(page).to have_content(I18n.t("specifying.start_page.who_for_can_use_list")[2])
 


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- skip existing spec coverage for the `/planning` endpoint during diary studies
- link to phase 5

