### PR TITLE
Refactored update_task_counters into concern

### DIFF
--- a/app/models/checkbox_answers.rb
+++ b/app/models/checkbox_answers.rb
@@ -1,4 +1,6 @@
 class CheckboxAnswers < ActiveRecord::Base
+  include TaskCounters
+
   self.implicit_order_column = "created_at"
   belongs_to :step
 
@@ -6,16 +8,10 @@ class CheckboxAnswers < ActiveRecord::Base
     presence: true,
     unless: proc { |answer| answer.step.skippable? && answer.skipped }
 
-  after_commit :update_task_counters
-
   def response=(args)
     return if args.blank?
     args.reject!(&:blank?) if args.is_a?(Array)
 
     super(args)
-  end
-
-  private def update_task_counters
-    step.update_task_counters
   end
 end

--- a/app/models/concerns/task_counters.rb
+++ b/app/models/concerns/task_counters.rb
@@ -1,0 +1,12 @@
+module TaskCounters
+  extend ActiveSupport::Concern
+  included do
+    after_commit :update_task_counters
+
+    private
+
+    def update_task_counters
+      step.update_task_counters
+    end
+  end
+end

--- a/app/models/currency_answer.rb
+++ b/app/models/currency_answer.rb
@@ -1,10 +1,10 @@
 class CurrencyAnswer < ActiveRecord::Base
+  include TaskCounters
+
   self.implicit_order_column = "created_at"
   belongs_to :step
 
   validates :response, presence: true, numericality: {greater_than_or_equal_to: 0, message: "does not accept £ signs or other non numerical characters"}
-
-  after_commit :update_task_counters
 
   def response=(value)
     if value.is_a?(String)
@@ -12,9 +12,5 @@ class CurrencyAnswer < ActiveRecord::Base
       return
     end
     super(value)
-  end
-
-  private def update_task_counters
-    step.update_task_counters
   end
 end

--- a/app/models/long_text_answer.rb
+++ b/app/models/long_text_answer.rb
@@ -1,12 +1,8 @@
 class LongTextAnswer < ActiveRecord::Base
+  include TaskCounters
+
   self.implicit_order_column = "created_at"
   belongs_to :step
 
   validates :response, presence: true
-
-  after_commit :update_task_counters
-
-  private def update_task_counters
-    step.update_task_counters
-  end
 end

--- a/app/models/number_answer.rb
+++ b/app/models/number_answer.rb
@@ -1,12 +1,8 @@
 class NumberAnswer < ActiveRecord::Base
+  include TaskCounters
+
   self.implicit_order_column = "created_at"
   belongs_to :step
 
   validates :response, presence: true, numericality: {only_integer: true}
-
-  after_commit :update_task_counters
-
-  private def update_task_counters
-    step.update_task_counters
-  end
 end

--- a/app/models/radio_answer.rb
+++ b/app/models/radio_answer.rb
@@ -1,12 +1,8 @@
 class RadioAnswer < ActiveRecord::Base
+  include TaskCounters
+
   self.implicit_order_column = "created_at"
   belongs_to :step
 
   validates :response, presence: true
-
-  after_commit :update_task_counters
-
-  private def update_task_counters
-    step.update_task_counters
-  end
 end

--- a/app/models/short_text_answer.rb
+++ b/app/models/short_text_answer.rb
@@ -1,12 +1,8 @@
 class ShortTextAnswer < ActiveRecord::Base
+  include TaskCounters
+
   self.implicit_order_column = "created_at"
   belongs_to :step
 
   validates :response, presence: true
-
-  after_commit :update_task_counters
-
-  private def update_task_counters
-    step.update_task_counters
-  end
 end

--- a/app/models/single_date_answer.rb
+++ b/app/models/single_date_answer.rb
@@ -1,12 +1,8 @@
 class SingleDateAnswer < ActiveRecord::Base
+  include TaskCounters
+
   self.implicit_order_column = "created_at"
   belongs_to :step
 
   validates :response, presence: {message: I18n.t("activerecord.errors.models.single_date_answer.attributes.response")}
-
-  after_commit :update_task_counters
-
-  private def update_task_counters
-    step.update_task_counters
-  end
 end

--- a/spec/models/checkbox_answers_spec.rb
+++ b/spec/models/checkbox_answers_spec.rb
@@ -48,18 +48,6 @@ RSpec.describe CheckboxAnswers, type: :model do
   end
 
   describe "#update_task_counters" do
-    it "increments the task tally via callback" do
-      task = create(:task)
-      expect(task.step_tally["answered"]).to eq 0
-
-      step_1 = create(:step, :checkbox_answers, hidden: false, task: task)
-      answer_1 = create(:checkbox_answers, step: step_1)
-
-      expect(task.step_tally["answered"]).to eq 1
-
-      answer_1.destroy
-
-      expect(task.step_tally["answered"]).to eq 0
-    end
+    it_behaves_like "task_counters", :checkbox_answers, :checkbox_answers
   end
 end

--- a/spec/models/currency_answer_spec.rb
+++ b/spec/models/currency_answer_spec.rb
@@ -20,18 +20,6 @@ RSpec.describe CurrencyAnswer, type: :model do
   end
 
   describe "#update_task_counters" do
-    it "increments the task tally via callback" do
-      task = create(:task)
-      expect(task.step_tally["answered"]).to eq 0
-
-      step_1 = create(:step, :currency, hidden: false, task: task)
-      answer_1 = create(:currency_answer, step: step_1)
-
-      expect(task.step_tally["answered"]).to eq 1
-
-      answer_1.destroy
-
-      expect(task.step_tally["answered"]).to eq 0
-    end
+    it_behaves_like "task_counters", :currency, :currency_answer
   end
 end

--- a/spec/models/long_text_answer_spec.rb
+++ b/spec/models/long_text_answer_spec.rb
@@ -13,18 +13,6 @@ RSpec.describe LongTextAnswer, type: :model do
   end
 
   describe "#update_task_counters" do
-    it "increments the task tally via callback" do
-      task = create(:task)
-      expect(task.step_tally["answered"]).to eq 0
-
-      step_1 = create(:step, :long_text, hidden: false, task: task)
-      answer_1 = create(:long_text_answer, step: step_1)
-
-      expect(task.step_tally["answered"]).to eq 1
-
-      answer_1.destroy
-
-      expect(task.step_tally["answered"]).to eq 0
-    end
+    it_behaves_like "task_counters", :long_text, :long_text_answer
   end
 end

--- a/spec/models/radio_answer_spec.rb
+++ b/spec/models/radio_answer_spec.rb
@@ -13,18 +13,6 @@ RSpec.describe RadioAnswer, type: :model do
   end
 
   describe "#update_task_counters" do
-    it "increments the task tally via callback" do
-      task = create(:task)
-      expect(task.step_tally["answered"]).to eq 0
-
-      step_1 = create(:step, :radio, hidden: false, task: task)
-      answer_1 = create(:radio_answer, step: step_1)
-
-      expect(task.step_tally["answered"]).to eq 1
-
-      answer_1.destroy
-
-      expect(task.step_tally["answered"]).to eq 0
-    end
+    it_behaves_like "task_counters", :radio, :radio_answer
   end
 end

--- a/spec/models/short_text_answer_spec.rb
+++ b/spec/models/short_text_answer_spec.rb
@@ -13,18 +13,6 @@ RSpec.describe ShortTextAnswer, type: :model do
   end
 
   describe "#update_task_counters" do
-    it "increments the task tally via callback" do
-      task = create(:task)
-      expect(task.step_tally["answered"]).to eq 0
-
-      step_1 = create(:step, :short_text, hidden: false, task: task)
-      answer_1 = create(:short_text_answer, step: step_1)
-
-      expect(task.step_tally["answered"]).to eq 1
-
-      answer_1.destroy
-
-      expect(task.step_tally["answered"]).to eq 0
-    end
+    it_behaves_like "task_counters", :short_text, :short_text_answer
   end
 end

--- a/spec/models/single_date_answer_spec.rb
+++ b/spec/models/single_date_answer_spec.rb
@@ -20,18 +20,6 @@ RSpec.describe SingleDateAnswer, type: :model do
   end
 
   describe "#update_task_counters" do
-    it "increments the task tally via callback" do
-      task = create(:task)
-      expect(task.step_tally["answered"]).to eq 0
-
-      step_1 = create(:step, :single_date, hidden: false, task: task)
-      answer_1 = create(:single_date_answer, step: step_1)
-
-      expect(task.step_tally["answered"]).to eq 1
-
-      answer_1.destroy
-
-      expect(task.step_tally["answered"]).to eq 0
-    end
+    it_behaves_like "task_counters", :single_date, :single_date_answer
   end
 end

--- a/spec/support/concerns/task_counters.rb
+++ b/spec/support/concerns/task_counters.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+shared_examples_for "task_counters" do |step, answer|
+  let (:model) {create (described_class.to_s.underscore)}
+
+  it "calls update_task_counters after commit" do
+    expect(model).to receive(:update_task_counters)
+    model.save
+  end
+
+  it "increments the task tally via callback" do
+    task = create(:task)
+    expect(task.step_tally["answered"]).to eq 0
+
+    step_1 = create(:step, step, hidden: false, task: task)
+    answer_1 = create(answer, step: step_1)
+
+    expect(task.step_tally["answered"]).to eq 1
+
+    answer_1.destroy
+
+    expect(task.step_tally["answered"]).to eq 0
+  end
+end


### PR DESCRIPTION
Refactored update_task_counters callback from the answer models into a concern to 'DRY' them up and updated specs to used a shared concern.
