### PR TITLE
#87: YARD dependency and initial documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ db/*.sqlite3
 **.war
 *.rbc
 *.sassc
+.yardoc
 .redcar/
 .sass-cache
 /config/config.yml
@@ -39,8 +40,9 @@ db/*.sqlite3
 /db/*.sqlite3
 /doc/api/
 /doc/app/
-/doc/features.html
-/doc/specs.html
+/doc/css/
+/doc/js/
+/doc/**/*.html
 /public/cache
 /public/stylesheets/compiled
 /public/system/*

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development do
   gem "rails-erd"
   gem "rails_layout"
   gem "spring-commands-rspec"
+  gem "yard-junk"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     aes_key_wrap (1.1.0)
     ast (2.4.2)
     attr_required (1.0.1)
+    backports (3.21.0)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -445,6 +446,11 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.26)
+    yard-junk (0.0.9)
+      backports (>= 3.18)
+      rainbow
+      yard
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -507,6 +513,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webmock
+  yard-junk
 
 RUBY VERSION
    ruby 3.0.1p64

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -6,6 +6,13 @@ class AnswersController < ApplicationController
   include DateHelper
   include AnswerHelper
 
+  # Creates and persists an answer for the specified {Step}.
+  #
+  # The action of saving an answer is recorded.
+  #
+  # On success, redirects to the next available step, the parent {Task} or {Journey} views.
+  #
+  # @see SaveAnswer
   def create
     @journey = current_journey
     @step = Step.find(step_id)
@@ -43,6 +50,13 @@ class AnswersController < ApplicationController
     end
   end
 
+  # Updates an answer for the specified {Step}.
+  #
+  # The action of updating an answer is recorded.
+  #
+  # On success, redirects the parent {Task} or {Journey} views.
+  #
+  # @see SaveAnswer
   def update
     @journey = current_journey
     @step = Step.find(step_id)
@@ -77,14 +91,25 @@ class AnswersController < ApplicationController
 
 private
 
+  # @return [Task]
   def parent_task
     @step.task
   end
 
+  # @return [String]
   def step_id
     params[:step_id]
   end
 
+  # Fetches the necessary parameters depending on the {Step} type.
+  #
+  # @param [Step] step
+  #
+  # @see further_information_params
+  # @see date_params
+  # @see answer_params
+  #
+  # @return [Mixed]
   def prepared_params(step:)
     case step.contentful_type
     when "checkboxes", "radios"
@@ -96,10 +121,21 @@ private
     end
   end
 
+  # Retrieves the `response` and `further_information` for answer types other
+  # than `checkboxes`, `radios` and `single_date`.
+  #
+  # @return [Object]
   def answer_params
     params.require(:answer).permit(:response, :further_information)
   end
 
+  # Retrieves the `reponse` with special handling for `checkboxes` and
+  # `radios` types to ensure their `further_information` values are stored
+  # correctly.
+  #
+  # @see AnswerHelper
+  #
+  # @return [Object]
   def further_information_params
     return { skipped: true, response: [""], further_information: nil } if skip_answer?
 
@@ -125,6 +161,11 @@ private
     all_params
   end
 
+  # Converts `single_date` responses into Dates.
+  #
+  # @see DateHelper
+  #
+  # @return [Object]
   def date_params
     answer = params.require(:answer).permit(:response)
     date_hash = { day: answer["response(3i)"], month: answer["response(2i)"], year: answer["response(1i)"] }

--- a/app/controllers/journey_maps_controller.rb
+++ b/app/controllers/journey_maps_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# JourneyMapsController is responsible for providing a map of specification steps to their Contentful answer tags.
 class JourneyMapsController < ApplicationController
   unless Rails.env.development?
     rescue_from GetStepsFromTask::RepeatEntryDetected do |exception|

--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -25,6 +25,11 @@ class JourneysController < ApplicationController
     end
   end
 
+  # Creates a new {Journey} under the default Contentful category.
+  #
+  # The action of creating a new journey is recorded.
+  #
+  # @see CreateJourney
   def new
     journey = CreateJourney.new(
       category_id: ENV["CONTENTFUL_DEFAULT_CATEGORY_ENTRY_ID"],
@@ -40,6 +45,9 @@ class JourneysController < ApplicationController
     redirect_to journey_path(journey)
   end
 
+  # Retrieves the specified {Journey} and its sections.
+  #
+  # The action of viewing a journey is recorded.
   def show
     @journey = current_journey
     @sections = @journey.sections.includes(:tasks).map do |section|

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,9 @@ class SessionsController < ApplicationController
   skip_before_action :authenticate_user!
   protect_from_forgery except: :bypass_callback
 
+  # Creates a user session with DfE Sign-in claim.
+  #
+  # @see UserSession
   def create
     user_session = UserSession.new(session: session)
     user_session.persist_successful_dfe_sign_in_claim!(omniauth_hash: auth_hash)
@@ -17,6 +20,9 @@ class SessionsController < ApplicationController
     Rollbar.error("Sign in failed unexpectedly")
   end
 
+  # Ends the current user session.
+  #
+  # @see UserSession
   def destroy
     user_session = UserSession.new(session: session)
     sign_out_url_copy = user_session.sign_out_url.dup

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -3,6 +3,9 @@
 class SpecificationsController < ApplicationController
   before_action :check_user_belongs_to_journey?
 
+  # Puts together a specification view in HTML and .docx.
+  #
+  # The action of viewing a specification is recorded.
   def show
     @journey = current_journey
     @visible_steps = @journey.visible_steps

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -3,6 +3,9 @@
 class StepsController < ApplicationController
   before_action :check_user_belongs_to_journey?
 
+  # Retrieves the specified step.
+  #
+  # The action of beginning a step is recorded.
   def show
     @journey = current_journey
 
@@ -32,6 +35,9 @@ class StepsController < ApplicationController
     render @step.contentful_type, locals: { layout: "steps/new_form_wrapper" }
   end
 
+  # Allows for step editing.
+  #
+  # The action of viewing a step is recorded.
   def edit
     @journey = current_journey
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,9 @@
 class TasksController < ApplicationController
   before_action :redirect_to_first_step_if_task_has_no_answers, only: [:show]
 
+  # Renders the task with its steps.
+  #
+  # The action fo viewing a task is recorded.
   def show
     @journey = current_journey
 
@@ -28,18 +31,22 @@ class TasksController < ApplicationController
 
 private
 
+  # @return [Task]
   def task
     @task ||= Task.find(task_id)
   end
 
+  # @return [String]
   def task_id
     params[:id]
   end
 
+  # @return [Task, nil]
   def next_unanswered_task
     current_journey.tasks.order(:section_id, :order).reject(&:all_steps_answered?).last
   end
 
+  # This is recorded as the beginning of a task.
   def redirect_to_first_step_if_task_has_no_answers
     return unless task.step_tally["answered"].zero?
     return if params.fetch(:back_link, nil).present?

--- a/app/helpers/answer_helper.rb
+++ b/app/helpers/answer_helper.rb
@@ -1,10 +1,24 @@
 # frozen_string_literal: true
 
+# AnswerHelper provides utility methods to convert further information keys between
+# human-readable and machine-readable representations.
+#
+# e.g. `name="answer[No thank you]"` to `name="answer[no_thank_you_further_information]"`
 module AnswerHelper
+  # Converts a key with underscores to a human-readable representation.
+  #
+  # @param [String] string
+  #
+  # @return [String]
   def human_readable_option(string:)
     string.tr("_", " ").capitalize
   end
 
+  # Converts a human-readable string to a machine-readable representation with underscores.
+  #
+  # @param [String] string
+  #
+  # @return [String]
   def machine_readable_option(string:)
     string.parameterize(separator: "_")
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# ApplicationHelper provides banner and footer tags.
 module ApplicationHelper
   def custom_banner_tag_class
     return "preview-tag" if ENV["CONTENTFUL_PREVIEW_APP"].eql?("true")

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,4 +1,10 @@
+# DateHelper provides string to date conversion functionality.
 module DateHelper
+  # Converts a hash with `day`, `month` and `year` values into a Date.
+  #
+  # @param [Hash<Symbol, String>] params
+  #
+  # @return [Date, nil]
   def format_date(params)
     date_parts = params.values_at(:day, :month, :year)
     return unless date_parts.all?(&:present?)

--- a/app/helpers/step_helper.rb
+++ b/app/helpers/step_helper.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
 module StepHelper
+  # Constructs OpenStruct objects for checkbox form elements.
+  #
+  # @param [Array<String>] array_of_options
+  #
+  # @return [Array<OpenStruct>]
   def checkbox_options(array_of_options:)
     array_of_options.map do |option|
       OpenStruct.new(id: option.downcase, name: option)
     end
   end
 
+  # Modifies the form object when displayed to the user.
+  #
+  # Dynamically adds attributes to the object so that the form object can work with unique further information fields.
+  #
+  # @return [Object]
   def monkey_patch_form_object_with_further_information_field(
     form_object:,
     associated_choice:

--- a/app/models/activity_log_item.rb
+++ b/app/models/activity_log_item.rb
@@ -1,3 +1,8 @@
+# ActivityLogItem captures user actions with contextual information, such as `user_id`, `journey_id`, etc.
+#
+# This is used to keep track of actions taken on {Journey}s, {Task}s, {Step}s, and others.
+#
+# @see RecordAction
 class ActivityLogItem < ApplicationRecord
   self.table_name = "activity_log"
 end

--- a/app/models/checkbox_answers.rb
+++ b/app/models/checkbox_answers.rb
@@ -1,3 +1,4 @@
+# CheckboxAnswers is used to capture a checkbox value answer to a {Step}.
 class CheckboxAnswers < ApplicationRecord
   include TaskCounters
 
@@ -7,6 +8,11 @@ class CheckboxAnswers < ApplicationRecord
             presence: true,
             unless: proc { |answer| answer.step.skippable? && answer.skipped }
 
+  # Overridden response accessor that ensures no blank checkbox values are set.
+  #
+  # @param [Array] args
+  #
+  # @return [Array, nil] array of answers or nil.
   def response=(args)
     return if args.blank?
 

--- a/app/models/concerns/task_counters.rb
+++ b/app/models/concerns/task_counters.rb
@@ -1,3 +1,7 @@
+# This module is used on {Step} answers (e.g. {NumberAnswer}) to update {Task} tallies.
+#
+# @see Step#update_task_counters
+# @see Task#tally_steps
 module TaskCounters
   extend ActiveSupport::Concern
   included do

--- a/app/models/currency_answer.rb
+++ b/app/models/currency_answer.rb
@@ -1,3 +1,4 @@
+# CurrencyAnswer is used to capture a currency answer to a {Step}.
 class CurrencyAnswer < ApplicationRecord
   include TaskCounters
 
@@ -10,6 +11,11 @@ class CurrencyAnswer < ApplicationRecord
               message: "does not accept £ signs or other non numerical characters",
             }
 
+  # Overridden response accessor that ensures no commas are present in the currency value.
+  #
+  # @param [Float, String] value
+  #
+  # @return [Float]
   def response=(value)
     if value.is_a?(String)
       super(value.delete(","))

--- a/app/models/journey.rb
+++ b/app/models/journey.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# A Journey belongs to a {User} and consists of {Section}s.
 class Journey < ApplicationRecord
   self.implicit_order_column = "created_at"
 
@@ -10,6 +11,7 @@ class Journey < ApplicationRecord
 
   validates :category, :contentful_id, :liquid_template, presence: true
 
+  # @return [Step::ActiveRecord_AssociationRelation]
   def visible_steps
     steps.where(hidden: false)
   end
@@ -18,6 +20,11 @@ class Journey < ApplicationRecord
     visible_steps.all? { |step| step.answer.present? }
   end
 
+  # Updates the `last_worked_on` and `started` attributes to indicate that a journey has been started.
+  #
+  # This ensures started journeys are not removed during automated clean up.
+  #
+  # @return [Boolean]
   def freshen!
     attributes = {}
     attributes[:last_worked_on] = Time.zone.now

--- a/app/models/long_text_answer.rb
+++ b/app/models/long_text_answer.rb
@@ -1,3 +1,4 @@
+# LongTextAnswer is used to capture a long text answer to a {Step}.
 class LongTextAnswer < ApplicationRecord
   include TaskCounters
 

--- a/app/models/number_answer.rb
+++ b/app/models/number_answer.rb
@@ -1,3 +1,4 @@
+# NumberAnswer is used to capture a number answer to a {Step}.
 class NumberAnswer < ApplicationRecord
   include TaskCounters
 

--- a/app/models/radio_answer.rb
+++ b/app/models/radio_answer.rb
@@ -1,3 +1,4 @@
+# RadioAnswer is used to capture a radio button answer to a {Step}.
 class RadioAnswer < ApplicationRecord
   include TaskCounters
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# A Section belongs to a {Journey} and consists of {Task}s.
 class Section < ApplicationRecord
   self.implicit_order_column = "order"
 

--- a/app/models/short_text_answer.rb
+++ b/app/models/short_text_answer.rb
@@ -1,3 +1,4 @@
+# ShortTextAnswer is used to capture a short text answer to a {Step}.
 class ShortTextAnswer < ApplicationRecord
   include TaskCounters
 

--- a/app/models/single_date_answer.rb
+++ b/app/models/single_date_answer.rb
@@ -1,3 +1,4 @@
+# SingleDateAnswer is used to capture a single date answer to a {Step}.
 class SingleDateAnswer < ApplicationRecord
   include TaskCounters
 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# A Step belongs to a {Task} and may have one of
+# {RadioAnswer}, {ShortTextAnswer}, {LongTextAnswer}, {SingleDateAnswer}, {CheckboxAnswers}, {NumberAnswer}, {CurrencyAnswer}.
 class Step < ApplicationRecord
   self.implicit_order_column = "order"
 
@@ -18,6 +20,9 @@ class Step < ApplicationRecord
 
   after_save :update_task_counters
 
+  # Returns the answer to this step.
+  #
+  # @return [Mixed]
   def answer
     @answer ||=
       case contentful_type
@@ -35,6 +40,10 @@ class Step < ApplicationRecord
     !answer.nil?
   end
 
+  # Returns the text for the primary call-to-action button.
+  # @see https://design-system.service.gov.uk/components/button/
+  #
+  # @return [String]
   def primary_call_to_action_text
     return I18n.t("generic.button.next") if super.blank?
 
@@ -45,10 +54,19 @@ class Step < ApplicationRecord
     skip_call_to_action_text.present?
   end
 
+  # This method fetches the {Journey} associated to this step's {Task}'s {Section}.
+  #
+  # @return [Journey]
   def journey
     task.section.journey
   end
 
+  # This method calls the owning {Task}'s save method to update its step tallies.
+  #
+  # This is used by the {TaskCounters} concern as a callback for when step answers
+  # are committed.
+  #
+  # @return [Boolean]
   def update_task_counters
     task.save
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# A User may have many {Journey}s.
 class User < ApplicationRecord
   has_many :journeys
 end

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,3 +1,6 @@
+# UserSession is used to store and maintain DfE sign-in details on the session for the current user.
+#
+# @see SessionsController
 class UserSession
   include Rails.application.routes.url_helpers
 
@@ -7,11 +10,19 @@ class UserSession
     self.session = session
   end
 
+  # Stores user sign-in information in the session.
+  #
+  # @param [Hash] omniauth_hash
+  #
+  # @return [String]
   def persist_successful_dfe_sign_in_claim!(omniauth_hash:)
     session[:dfe_sign_in_uid] = omniauth_hash.fetch("uid")
     session[:dfe_sign_in_sign_out_token] = omniauth_hash.dig("credentials", "id_token")
   end
 
+  # Removes user sign-in information from the session.
+  #
+  # @return [String]
   def repudiate!
     session.delete(:dfe_sign_in_uid)
     session.delete(:dfe_sign_in_sign_out_token)
@@ -21,6 +32,7 @@ class UserSession
     session.key?(:dfe_sign_in_sign_out_token) && session[:dfe_sign_in_sign_out_token].present?
   end
 
+  # @return [String]
   def sign_out_url
     return root_path unless should_be_signed_out_of_dsi?
 

--- a/app/services/answer_factory.rb
+++ b/app/services/answer_factory.rb
@@ -1,3 +1,4 @@
+# AnswerFactory is responsible for determining the right answer type for a {Step}.
 class AnswerFactory
   class UnexpectedQuestionType < StandardError; end
 
@@ -7,6 +8,9 @@ class AnswerFactory
     self.step = step
   end
 
+  # Returns the right answer type based on the provided {Step} `contentful_type`.
+  #
+  # @return [Mixed]
   def call
     case step.contentful_type
     when "radios" then RadioAnswer.new

--- a/app/services/cache.rb
+++ b/app/services/cache.rb
@@ -1,3 +1,4 @@
+# Cache provides the functionality for managing the Redis cache.
 class Cache
   attr_accessor :enabled, :key, :ttl
 

--- a/app/services/concerns/cacheable_entry.rb
+++ b/app/services/concerns/cacheable_entry.rb
@@ -1,3 +1,4 @@
+# A concern to allow the caching of Contentful entries.
 module CacheableEntry
   extend ActiveSupport::Concern
 

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -1,3 +1,4 @@
+# CreateJourney service is responsible for constructing a {Journey} for the given user and category.
 class CreateJourney
   attr_accessor :category_id, :user
 
@@ -6,6 +7,16 @@ class CreateJourney
     self.user = user
   end
 
+  # Creates and persists a new Journey for the given category.
+  #
+  # This relies on additional services to construct the sections, tasks, and steps
+  # within this journey.
+  #
+  # @see CreateSection
+  # @see CreateTask
+  # @see CreateStep
+  #
+  # @return [Journey]
   def call
     category = GetCategory.new(category_entry_id: category_id).call
     contentful_sections = GetSectionsFromCategory.new(category: category).call

--- a/app/services/create_section.rb
+++ b/app/services/create_section.rb
@@ -1,3 +1,4 @@
+# CreateSection service is responsible for constructing a {Section} for the given journey.
 class CreateSection
   attr_accessor :journey, :contentful_section, :order
 
@@ -7,6 +8,9 @@ class CreateSection
     @order = order
   end
 
+  # Creates and persists a new Section.
+  #
+  # @return [Section]
   def call
     section = Section.new(
       journey: journey,

--- a/app/services/create_step.rb
+++ b/app/services/create_step.rb
@@ -1,3 +1,4 @@
+# CreateStep service is responsible for constructing a {Step} for the given task.
 class CreateStep
   class UnexpectedContentfulModel < StandardError; end
 
@@ -23,6 +24,11 @@ class CreateStep
     self.order = order
   end
 
+  # Creates and persists a new Step.
+  #
+  # This relies on the passed-in `contentful_entry` to construct the object.
+  #
+  # @return [Step]
   def call
     if unexpected_contentful_model?
       send_rollbar_warning
@@ -104,12 +110,14 @@ private
     contentful_entry.type.tr(" ", "_")
   end
 
+  # @see https://design-system.service.gov.uk/components/button/
   def primary_call_to_action_text
     return nil unless contentful_entry.respond_to?(:primary_call_to_action)
 
     contentful_entry.primary_call_to_action
   end
 
+  # @see https://design-system.service.gov.uk/components/button/
   def skip_call_to_action_text
     return nil unless contentful_entry.respond_to?(:skip_call_to_action)
 

--- a/app/services/create_task.rb
+++ b/app/services/create_task.rb
@@ -1,14 +1,24 @@
+# Build and persist a {Task}
 class CreateTask
   class UnexpectedContentfulModel < StandardError; end
 
   attr_accessor :section, :contentful_task, :order
 
+  # @param [Section] section the section this task belongs to
+  # @param [Hash<Symbol, String>] contentful_task task attributes provided by Contentful
+  # @param [Integer] order task order
   def initialize(section:, contentful_task:, order:)
     @section = section
     @contentful_task = contentful_task
     @order = order
   end
 
+  # This relies on the passed-in `contentful_task` to construct the object.
+  #
+  # @raise UnexpectedContentfulModel
+  # @see CreateJourney#call
+  #
+  # @return [Task]
   def call
     task = Task.new(
       section: section,

--- a/app/services/delete_stale_journeys.rb
+++ b/app/services/delete_stale_journeys.rb
@@ -1,3 +1,4 @@
+# DeleteStaleJourneys service performs a clean-up of {Journey}s that have not been started for over a month.
 class DeleteStaleJourneys
   def call
     qualifying_journeys = Journey.where(started: false)
@@ -7,6 +8,7 @@ class DeleteStaleJourneys
 
 private
 
+  # @return [Date]
   def date_a_journey_can_be_inactive_until
     return 1.month.ago if ENV["DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR"].blank?
 

--- a/app/services/get_all_contentful_entries.rb
+++ b/app/services/get_all_contentful_entries.rb
@@ -1,5 +1,6 @@
 require "contentful"
 
+# GetAllContentfulEntries service fetches all Contentful entries via the ContentfulConnector.
 class GetAllContentfulEntries
   class NoEntriesFound < StandardError; end
 

--- a/app/services/get_category.rb
+++ b/app/services/get_category.rb
@@ -2,6 +2,7 @@ class Contentful::Entry
   attr_accessor :combined_specification_template
 end
 
+# GetCategory service fetches a Contentful category and validates its Liquid template.
 class GetCategory
   class InvalidLiquidSyntax < StandardError; end
 

--- a/app/services/get_entry.rb
+++ b/app/services/get_entry.rb
@@ -1,3 +1,4 @@
+# GetEntry service is responsible for fetching and caching Contentful entries.
 class GetEntry
   class EntryNotFound < StandardError; end
   include CacheableEntry

--- a/app/services/get_sections_from_category.rb
+++ b/app/services/get_sections_from_category.rb
@@ -1,3 +1,4 @@
+# GetSectionsFromCategory retrieves the {Section}s under the given category.
 class GetSectionsFromCategory
   attr_accessor :category
 

--- a/app/services/get_steps_from_task.rb
+++ b/app/services/get_steps_from_task.rb
@@ -1,3 +1,4 @@
+# GetStepsFromTask service retrieves the {Step}s associated to the given {Task}.
 class GetStepsFromTask
   class RepeatEntryDetected < StandardError; end
 

--- a/app/services/get_tasks_from_section.rb
+++ b/app/services/get_tasks_from_section.rb
@@ -1,3 +1,4 @@
+# GetTasksFromSection service retrieves the {Task}s associated with the given {Section}.
 class GetTasksFromSection
   attr_accessor :section
 

--- a/app/services/record_action.rb
+++ b/app/services/record_action.rb
@@ -1,3 +1,4 @@
+# RecordAction service is responsible for the functionality to create {ActivityLogItem}s for various user actions.
 class RecordAction
   class UnexpectedActionType < StandardError; end
 
@@ -35,6 +36,7 @@ class RecordAction
     self.data = data
   end
 
+  # @return [ActivityLogItem]
   def call
     if unexpected_action_type?
       send_rollbar_warning

--- a/app/services/string_sanitiser.rb
+++ b/app/services/string_sanitiser.rb
@@ -1,3 +1,4 @@
+# StringSanitiser service is responsible for sanitising user answers to ensure they are safe to be persisted.
 class StringSanitiser
   attr_accessor :args
 

--- a/app/services/toggle_additional_steps.rb
+++ b/app/services/toggle_additional_steps.rb
@@ -1,3 +1,4 @@
+# ToggleAdditionalSteps service is responsible for showing and hiding additional steps.
 class ToggleAdditionalSteps
   attr_accessor :journey, :step
 

--- a/lib/tasks/yard.rake
+++ b/lib/tasks/yard.rake
@@ -1,0 +1,6 @@
+require "yard"
+
+YARD::Rake::YardocTask.new do |t|
+  t.files   = ["app/**/*.rb", "-", "CHANGELOG.md"]
+  t.options = ["--plugin", "junk", "--protected", "--private", "--markup", "markdown"]
+end


### PR DESCRIPTION
## Changes in this PR

- Added `yard` and `yard-junk` dependencies.
- Added new Rake task to generate the documentation .
- Documented the models, controllers and services to evaluate the documentation.
- Updated `.gitignore` to ignore the generated documentation.

## Next steps

Document the rest of the codebase.