### PR TITLE
Fix sequential numbering and clashes in Architecture Decision Records

### DIFF
--- a/doc/architecture/decisions/0002-use-pull-request-templates.md
+++ b/doc/architecture/decisions/0002-use-pull-request-templates.md
@@ -1,4 +1,4 @@
-# 1. use-pull-request-templates
+# 2. use-pull-request-templates
 
 Date: 2019-08-16
 

--- a/doc/architecture/decisions/0004-use-a-changelog-for-tracking-changes-in-a-release.md
+++ b/doc/architecture/decisions/0004-use-a-changelog-for-tracking-changes-in-a-release.md
@@ -1,4 +1,4 @@
-# 2. Use a changelog for tracking changes in a release
+# 4. Use a changelog for tracking changes in a release
 
 Date: 2019-09-13
 

--- a/doc/architecture/decisions/0005-use-bullet-to-catch-nplus1-queries.md
+++ b/doc/architecture/decisions/0005-use-bullet-to-catch-nplus1-queries.md
@@ -1,4 +1,4 @@
-# 2. use-bullet-to-catch-nplus1-queries
+# 5. use-bullet-to-catch-nplus1-queries
 
 Date: 2019-09-19
 

--- a/doc/architecture/decisions/0006-use-dotenv-for-managing-environment-variables.md
+++ b/doc/architecture/decisions/0006-use-dotenv-for-managing-environment-variables.md
@@ -1,4 +1,4 @@
-# 3. use-dotenv-for-managing-environment-variables
+# 6. use-dotenv-for-managing-environment-variables
 
 Date: 2019-09-19
 

--- a/doc/architecture/decisions/0007-add-rollbar-for-application-monitoring.md
+++ b/doc/architecture/decisions/0007-add-rollbar-for-application-monitoring.md
@@ -1,4 +1,4 @@
-# 4. add-rollbar-for-application-monitoring
+# 7. add-rollbar-for-application-monitoring
 
 Date: 2019-09-20
 

--- a/doc/architecture/decisions/0008-use-brakeman-for-security-analysis.md
+++ b/doc/architecture/decisions/0008-use-brakeman-for-security-analysis.md
@@ -1,4 +1,4 @@
-# 5. use-brakeman-for-security-analysis
+# 8. use-brakeman-for-security-analysis
 
 Date: 2020-04-03
 

--- a/doc/architecture/decisions/0009-use-simplecov-to-monitor-code-test-coverage.md
+++ b/doc/architecture/decisions/0009-use-simplecov-to-monitor-code-test-coverage.md
@@ -1,4 +1,4 @@
-# 6. use-coveralls-to-monitor-test-coverage
+# 9. use-coveralls-to-monitor-test-coverage
 
 Date: 2020-10-09
 

--- a/doc/architecture/decisions/0010-use-redis-for-a-read-cache.md
+++ b/doc/architecture/decisions/0010-use-redis-for-a-read-cache.md
@@ -1,4 +1,4 @@
-# 7. use-redis-for-a-read-cache
+# 10. use-redis-for-a-read-cache
 
 Date: 2020-11-25
 

--- a/doc/architecture/decisions/0011-use-sidekiq-for-asynchronous-tasks.md
+++ b/doc/architecture/decisions/0011-use-sidekiq-for-asynchronous-tasks.md
@@ -1,4 +1,4 @@
-# 8. use sidekiq for asynchronous tasks
+# 11. use sidekiq for asynchronous tasks
 
 Date: 2020-11-30
 

--- a/doc/architecture/decisions/0012-create-infrastructure-on-gpaas-cloud-foundry-with-terraform.md
+++ b/doc/architecture/decisions/0012-create-infrastructure-on-gpaas-cloud-foundry-with-terraform.md
@@ -1,4 +1,4 @@
-# 9. Create infrastructure on GPaas Cloud Foundry with Terraform
+# 12. Create infrastructure on GPaas Cloud Foundry with Terraform
 
 Date: 2021-03-09
 

--- a/doc/architecture/decisions/0013-use-dfe-sign-in-as-auth-provider.md
+++ b/doc/architecture/decisions/0013-use-dfe-sign-in-as-auth-provider.md
@@ -1,4 +1,4 @@
-# 10. use-dfe-sign-in-as-auth-provider
+# 13. use-dfe-sign-in-as-auth-provider
 
 Date: 2021-03-22
 

--- a/doc/architecture/decisions/0014-use-logit-for-application-logs.md
+++ b/doc/architecture/decisions/0014-use-logit-for-application-logs.md
@@ -1,4 +1,4 @@
-# 12. use-logit-for-application-logs
+# 14. use-logit-for-application-logs
 
 Date: 2021-04-19
 

--- a/doc/architecture/decisions/0015-store-user-activity-in-app.md
+++ b/doc/architecture/decisions/0015-store-user-activity-in-app.md
@@ -1,4 +1,4 @@
-# 13. store-user-activity-in-app
+# 15. store-user-activity-in-app
 
 Date: 2021-05-18
 


### PR DESCRIPTION
Tidy `/doc/architecture/decisions` so `adr-tools` doesn't become confused.