### PR TITLE
Bump NodeJS to version 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ db/*.sqlite3
 # add /config/database.yml if it contains passwords
 # /config/database.yml
 
-# various artifacts
+# various artefacts
 **.war
 *.rbc
 *.sassc
@@ -38,11 +38,7 @@ db/*.sqlite3
 /coverage/
 /db/*.javadb/
 /db/*.sqlite3
-/doc/api/
-/doc/app/
-/doc/css/
-/doc/js/
-/doc/**/*.html
+/public/assets/*
 /public/cache
 /public/stylesheets/compiled
 /public/system/*
@@ -89,7 +85,7 @@ pickle-email-*.html
 # tilde files are usually backup files from a text editor
 *~
 
-# Remove the master key added in Rails 5.2 incase it is used
+# Remove the master key added in Rails 5.2 in case it is used
 config/master.key
 
 .env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@
 FROM ruby:3.0.1 as base
 MAINTAINER dxw <rails@dxw.com>
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
-RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
 RUN apt-get update && apt-get install -qq -y \
   build-essential \
   libpq-dev \
@@ -28,7 +24,9 @@ FROM base AS dependencies
 RUN mkdir -p ${DEPS_HOME}
 WORKDIR $DEPS_HOME
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get install -y nodejs
 
 # Install Javascript dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.0.1"
 
 gem "bootsnap", ">= 1.1.0", require: false
 gem "climate_control"
+# Remove coffee-rails, only used for google analytics
 gem "coffee-rails", "~> 5.0"
 gem "contentful", "~> 2.16"
 gem "govuk_design_system_formbuilder", "~> 2.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rails-template",
+  "name": "sct-buy-for-your-school",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rails-template",
+  "name": "sct-buy-for-your-school",
   "private": true,
   "dependencies": {
     "govuk-frontend": "^3.13.0"


### PR DESCRIPTION
## Changes in this PR

Support for Node version 10 has reached End-of-Life, upgrade to v16.