### PR TITLE
Permit designers to preview entries in the staging environment

### DIFF
--- a/app/controllers/preview/entries_controller.rb
+++ b/app/controllers/preview/entries_controller.rb
@@ -1,34 +1,14 @@
 # rubocop:disable Rails/SaveBang
 class Preview::EntriesController < ApplicationController
-  before_action :check_app_is_running_in_preview_env
-
   def show
     category = Category.create(title: "Preview", contentful_id: 0, liquid_template: "<p>N/A</p>")
-    @journey = Journey.create(
-      category: category,
-      user: current_user,
-    )
+    @journey = Journey.create(category: category, user: current_user)
     section = Section.create(title: "Preview Section", journey: @journey)
     task = Task.create(title: "Preview Task", section: section)
-
-    contentful_entry = GetEntry.new(entry_id: entry_id).call
-    @step = CreateStep.new(
-      task: task, contentful_entry: contentful_entry, order: 0,
-    ).call
+    contentful_entry = GetEntry.new(entry_id: params[:id]).call
+    @step = CreateStep.new(task: task, contentful_entry: contentful_entry, order: 0).call
 
     redirect_to journey_step_path(@journey, @step)
-  end
-
-private
-
-  def entry_id
-    params[:id]
-  end
-
-  def check_app_is_running_in_preview_env
-    return if ENV["CONTENTFUL_PREVIEW_APP"].eql?("true")
-
-    render "errors/not_found", status: :not_found
   end
 end
 # rubocop:enable Rails/SaveBang

--- a/spec/features/journey_mapping/preview_step_spec.rb
+++ b/spec/features/journey_mapping/preview_step_spec.rb
@@ -1,7 +1,6 @@
-# @see ContentfulHelpers
-
 RSpec.feature "Content Designers can preview a journey step" do
   before do
+    # @see ContentfulHelpers
     stub_contentful_entry(
       entry_id: "radio-question",
       fixture_filename: "steps/radio-question.json",
@@ -9,21 +8,23 @@ RSpec.feature "Content Designers can preview a journey step" do
 
     user_is_signed_in
 
+    # OPTIMIZE: would this endpoint be better under "/design"?
     visit "/preview/entries/radio-question"
   end
 
-  context "when they are NOT on the preview environment" do
+  # TODO: revisit the usefulness of the "Preview"
+  xcontext "when they are NOT on the preview environment" do
     scenario "a 404 error is returned" do
       expect(find("h2.govuk-heading-xl")).to have_text "Page not found"
     end
   end
 
   context "when they are on the preview environment" do
-    around do |example|
-      ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "true") do
-        example.run
-      end
-    end
+    # around do |example|
+    #   ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "true") do
+    #     example.run
+    #   end
+    # end
 
     scenario "the appropriate step is displayed" do
       expect(find("legend.govuk-fieldset__legend--l")).to have_text "Which service do you need?"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+# TODO: invert this so context is only used twice
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe "#custom_banner_tag_class" do

--- a/spec/requests/entry_preview_spec.rb
+++ b/spec/requests/entry_preview_spec.rb
@@ -3,12 +3,13 @@ require "rails_helper"
 RSpec.describe "Entry previews", type: :request do
   before { user_is_signed_in }
 
+  # TODO: revisit the usefulness of the "Preview"
   context "when PREVIEW_APP is configured to true" do
-    around do |example|
-      ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "true") do
-        example.run
-      end
-    end
+    # around do |example|
+    #   ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "true") do
+    #     example.run
+    #   end
+    # end
 
     it "creates a dummy journey and redirects to the question creation flow" do
       entry_id = "123"
@@ -31,12 +32,13 @@ RSpec.describe "Entry previews", type: :request do
     end
   end
 
-  context "when PREVIEW_APP is configured to false" do
-    around do |example|
-      ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "false") do
-        example.run
-      end
-    end
+  # TODO: revisit the usefulness of the "Preview"
+  xcontext "when PREVIEW_APP is configured to false" do
+    # around do |example|
+    #   ClimateControl.modify(CONTENTFUL_PREVIEW_APP: "false") do
+    #     example.run
+    #   end
+    # end
 
     it "does not create a dummy journey and shows not_found" do
       get "/preview/entries/123"


### PR DESCRIPTION
Content and model changes for multiple categories now exist in Contentful's staging environment, these are only compatible with our staging environment which breaks the preview link. Previews per environment seem preferable going forward.
 
## Changes in this PR

- disable the `Preview::EntriesController` before action `check_app_is_running_in_preview_env`

## Screenshots of Contentful changes

![Screenshot 2021-07-22 at 08 11 34](https://user-images.githubusercontent.com/3261/126606371-20ff46d5-7618-43e5-bf96-a7716d2c4454.png)
![Screenshot 2021-07-22 at 08 13 22](https://user-images.githubusercontent.com/3261/126606385-cb9f2574-f61b-44eb-ba77-df0c3deb5bef.png)

## Next steps

https://trello.com/c/cQuVkrQK

- remove need for dedicated environment
- move the `preview` endpoint under `/design` and protect this with RBAC when roles and rich sign-in functionality is added 
