### PR TITLE
List element has direct children that are not allowed inside list item elements

### DIFF
--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -7,8 +7,8 @@
 
 <ol class="app-task-list sections">
   <% @sections.each do |section| %>
-    <h2 class="app-task-list__section"><%= section.title %></h2>
     <li>
+      <h2 class="app-task-list__section"><%= section.title %></h2>
       <ul class="app-task-list__items">
         <% section.tasks.each do |task| %>
           <% if task.one_step? %>
@@ -17,7 +17,6 @@
               <li class="app-task-list__item step__item" id="<%= task.step.id %>">
 
                 <% if task.step.answered? %>
-                  <%# Accessibility - screen readers are not reading the status out %>
                   <span class="app-task-list__task-name">
                     <%= link_to task.title, edit_journey_step_path(@journey, task.step), class: "govuk-link", 'aria-describedby': task.step.status_id %>
                   </span>

--- a/doc/accessibility.md
+++ b/doc/accessibility.md
@@ -1,0 +1,30 @@
+# Accessibility
+
+To ensure the application is accessible, the following rules should be followed.
+
+[Valid list structures](#valid-list-structures)
+
+## Valid list structures
+
+`ol` and `ul` elements may only contain `li` elements. Unexpected elements may negatively impact the ability of screen readers to correctly announce list items.
+
+Valid:
+```html
+<ul>
+  <li>Item X</li>
+  <li>Item Y</li>
+  <li>Item Z</li>
+</ul>
+```
+
+Invalid:
+```html
+<ul>
+  <h2>Items</h2> <!-- Unexpected element -->
+  <li>Item X</li>
+  <li>Item Y</li>
+  <li>Item Z</li>
+</ul>
+```
+
+More info: https://dequeuniversity.com/rules/axe/4.1/list


### PR DESCRIPTION
## Changes in this PR

- move task list headings into list items to ensure valid list structure
- add an accessibilty doc as a guide to prevent the same errors in the future