### PR TITLE
Use the category's title in `designs#show`

### DIFF
--- a/app/controllers/design_controller.rb
+++ b/app/controllers/design_controller.rb
@@ -32,6 +32,8 @@ class DesignController < ApplicationController
     # TODO: wrap steps in presenter and relocate the link_to Contentful url there
     @steps = tasks.flat_map { |task| GetStepsFromTask.new(task: task).call }
 
+    @category_title = contentful_category.title
+
     flash[:notice] = "#{contentful_category.environment.id.capitalize} Environment"
   end
 end

--- a/app/views/design/show.html.erb
+++ b/app/views/design/show.html.erb
@@ -1,5 +1,8 @@
-<%= content_for :title, I18n.t("design.page_title") %>
-<h1 class="govuk-heading-xl"><%= I18n.t("design.page_title") %></h1>
+<%= content_for :title, @category_title %>
+
+<h1 class="govuk-heading-xl">
+  <%= @category_title %>
+</h1>
 
 <ol class="govuk-list govuk-list--number">
   <% @steps.each do |entry| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,7 +114,6 @@ en:
       continue: Continue answering these questions
       next: Continue to the next task
   design:
-    page_title: "Template Designer"
     category_selection_header: "Choose a category"
     edit_step_link_text: "Edit step in Contentful"
     preview_step_link_text: "Preview step in service"

--- a/spec/features/design/show_spec.rb
+++ b/spec/features/design/show_spec.rb
@@ -9,9 +9,8 @@ RSpec.feature "Content Designers can view" do
 
   context "when it is valid" do
     specify "all the steps in a category" do
-      # design.page_title
-      expect(page.title).to have_text "Template Designer"
-      expect(find("h1.govuk-heading-xl")).to have_text "Template Designer"
+      expect(page.title).to have_text "Catering"
+      expect(find("h1.govuk-heading-xl")).to have_text "Catering"
 
       within("ol.govuk-list.govuk-list--number") do
         list_items = find_all("li")


### PR DESCRIPTION
## Changes in this PR

- replace generic heading text and page title with the current category's title

## Screenshots of UI changes

### Before
![Screenshot 2021-07-29 at 13 21 14](https://user-images.githubusercontent.com/3261/127490896-7aabe420-5913-4f10-8742-00837040bb86.png)

### After
![Screenshot 2021-07-29 at 13 19 54](https://user-images.githubusercontent.com/3261/127490904-d8a8852a-c221-407f-848f-569386a5ce36.png)

