### PR TITLE
Clear the session data on a failed authentication and redirect

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,13 @@ class SessionsController < ApplicationController
   alias_method :bypass_callback, :create
 
   def failure
-    Rollbar.error("Sign in failed unexpectedly")
+    Rollbar.error("Sign in failed unexpectedly", dfe_sign_in_uid: session[:dfe_sign_in_uid])
+
+    # NB: users would need to hit signout link to proceed otherwise
+    if session.destroy
+      flash[:notice] = "Sign in failed unexpectedly, please try again"
+      redirect_to root_path
+    end
   end
 
   # Ends the current user session.

--- a/spec/features/landing/dfe_sign_in_spec.rb
+++ b/spec/features/landing/dfe_sign_in_spec.rb
@@ -48,18 +48,26 @@ RSpec.feature "DfE Sign-in" do
   end
 
   context "when authentication fails" do
-    it "renders errors" do
+    it "redirects to the homepage and issues a flash message" do
       OmniAuth.config.mock_auth[:dfe] = :invalid_credentials
-      expect(Rollbar).to receive(:error).with("Sign in failed unexpectedly").and_call_original
+
+      expect(Rollbar).to receive(:error).with(
+        "Sign in failed unexpectedly",
+        dfe_sign_in_uid: anything,
+      ).and_call_original
 
       visit "/"
       click_start
 
-      # errors.sign_in.unexpected_failure.page_title
-      expect(find("h1.govuk-heading-xl")).to have_text "An unexpected error occurred"
+      expect(page).to have_current_path "/"
+      expect(page.driver.request.session.keys).to be_empty
+      expect(find("h3.govuk-notification-banner__heading")).to have_text "Sign in failed unexpectedly, please try again"
 
+      # If the session can not be cleared
+      # errors.sign_in.unexpected_failure.page_title
+      # expect(find("h1.govuk-heading-xl")).to have_text "An unexpected error occurred"
       # errors.sign_in.unexpected_failure.page_body
-      expect(find("p.govuk-body")).to have_text "The service was unable to successfully authenticate you. The team have been notified of this problem and you should be able to retry shortly."
+      # expect(find("p.govuk-body")).to have_text "The service was unable to successfully authenticate you. The team have been notified of this problem and you should be able to retry shortly."
     end
   end
 end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,5 +1,3 @@
-require "rails_helper"
-
 RSpec.describe "Authentication", type: :request do
   after do
     RedisSessions.redis.flushdb


### PR DESCRIPTION
## Changes in this PR

- login failures caused users confusion during diary studies
- alert user to the failure via a flash message rather than render an error page
- feedback suggested this was a sufficient barrier to prevent them using the service
- if this fails we render the error page as before

## Screenshots of UI changes

### Before
![Screenshot 2021-07-29 at 14 51 17](https://user-images.githubusercontent.com/3261/127504033-3e0ea80c-b701-47d1-b667-9147c5053684.png)

### After
![Screenshot 2021-07-29 at 14 49 54](https://user-images.githubusercontent.com/3261/127503882-e458733b-07e1-4f6d-91cc-c41c3a4e9d4d.png)
