### PR TITLE
Fix shared preview journey

### DIFF
--- a/app/controllers/preview/entries_controller.rb
+++ b/app/controllers/preview/entries_controller.rb
@@ -1,34 +1,33 @@
 class Preview::EntriesController < ApplicationController
   def show
-    client = Content::Client.new(:preview)
-
     contentful_step = GetEntry.new(entry_id: params[:id], client: client).call
 
-    category = Category.find_or_create_by!(title: "Designer Preview Category") do |c|
-      c.contentful_id = 0
-      c.description = "Used to demo a step before publishing"
-      c.liquid_template = "<p>N/A</p>"
-    end
+    category = Category.find_or_create_by!(
+      title: "Designer Preview Category",
+      contentful_id: 0,
+      description: "Used to demo a step before publishing",
+      liquid_template: "<p>N/A</p>",
+    )
 
-    # flagged for deletion
-    journey = Journey.find_or_create_by!(category: category) do |j|
-      j.user = current_user
-      j.state = 3
-    end
+    journey = Journey.find_or_create_by!(
+      category: category,
+      user: current_user,
+      state: 3, # flagged for deletion
+    )
 
-    section = Section.find_or_create_by!(title: "Designer Preview Section") do |s|
-      s.contentful_id = 0
-      s.order = 0
-      s.journey = journey
-    end
+    section = Section.find_or_create_by!(
+      title: "Designer Preview Section",
+      contentful_id: 0,
+      order: 0,
+      journey: journey,
+    )
 
-    task = Task.find_or_create_by!(title: "Designer Preview Task") do |t|
-      t.contentful_id = 0
-      t.order = 0
-      t.section = section
-      # TODO: add migration for step_tally to default to an empty Hash
-      t.step_tally = {}
-    end
+    task = Task.find_or_create_by!(
+      title: "Designer Preview Task",
+      contentful_id: 0,
+      order: 0,
+      section: section,
+    )
 
     step = CreateStep.new(
       task: task,
@@ -37,5 +36,11 @@ class Preview::EntriesController < ApplicationController
     ).call
 
     redirect_to journey_step_path(journey, step, preview: true)
+  end
+
+private
+
+  def client
+    Content::Client.new(:preview)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -112,9 +112,6 @@ private
   #
   # @return [Nil, Hash<Symbol, Integer>]
   def tally_steps
-    # TODO: set preview titles as constants
-    return if title == "Designer Preview Task"
-
     visible_steps = steps.visible
 
     self.step_tally = {

--- a/spec/requests/entry_preview_spec.rb
+++ b/spec/requests/entry_preview_spec.rb
@@ -1,3 +1,4 @@
+# TODO: this should be merged with features/design/preview_step_spec
 RSpec.describe "Entry previews", type: :request do
   let(:user) { create(:user) }
   let(:journey) { user.journeys.first }


### PR DESCRIPTION
## Changes in this PR

- fix `find_or_create_by` so a journey is created for each designer 
- add missing spec context for multiple designers
