### PR TITLE
(Re)define "stale" and "started" state for a journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,15 @@ The format is based on [Keep a Changelog 1.0.0].
 - add additional developer tools to optional `Brewfile`
 - remove unused `GetAllContentfulEntries` service object
 - change route to destroy a session to be DELETE
+- separate out concern for stale journeys and their removal `FlagStaleJourneysJob`,
+  currently no-op until approved
+- clean and fix deletion of stale journeys `DeleteStaleJourneysJob`, currently
+  no-op until approved
+
 
 **Steps**
-- implement __interrupt pattern__ which introduces a step that is not semantically a question but a statement
+- implement __interrupt pattern__ which introduces a step that is not semantically
+  a question but a statement
 - remove `staticContent` entity and add `Statement` entity in Contentful (staging only)
 - add custom answer validation logic which can be controlled in Contentful
 - fix progression to the next incomplete task
@@ -41,11 +47,13 @@ The format is based on [Keep a Changelog 1.0.0].
 - allow user to (soft) delete a specification
 
 **Preview functionality**
-- previously this depended upon a dedicated environment which used the main branch thereby preventing preview functionality in staging
+- previously this depended upon a dedicated environment which used the main branch
+  thereby preventing preview functionality in staging
 - a memoised client for both Contentful delivery and preview is available for any environment
 - `Content::Connector` instantiates both clients
 - `Content::Client` is used internally as an interface to the Contentful ruby gem
-- `APP_ENV_{ENV}_CONTENTFUL_ACCESS_TOKEN` is replaced by `APP_ENV_{ENV}_CONTENTFUL_DELIVERY_TOKEN` and `APP_ENV_{ENV}_CONTENTFUL_PREVIEW_TOKEN`
+- `APP_ENV_{ENV}_CONTENTFUL_ACCESS_TOKEN` is replaced by
+  `APP_ENV_{ENV}_CONTENTFUL_DELIVERY_TOKEN` and `APP_ENV_{ENV}_CONTENTFUL_PREVIEW_TOKEN`
 
 ## Diary Studies using the live environment
 

--- a/app/jobs/delete_stale_journeys_job.rb
+++ b/app/jobs/delete_stale_journeys_job.rb
@@ -6,6 +6,7 @@ class DeleteStaleJourneysJob < ApplicationJob
 
     journeys = DeleteStaleJourneys.new.call
 
+    # TODO: add journey/user params to the Rollbar payload
     Rollbar.info("Deleted #{journeys.size} stale journeys.")
   end
 end

--- a/app/jobs/delete_stale_journeys_job.rb
+++ b/app/jobs/delete_stale_journeys_job.rb
@@ -2,8 +2,10 @@ class DeleteStaleJourneysJob < ApplicationJob
   queue_as :default
 
   def perform
-    DeleteStaleJourneys.new.call
+    return unless ENV["DELETE_STALE_JOURNEYS"] # no-op until approval received
 
-    Rollbar.info("Delete stale journeys task complete.")
+    journeys = DeleteStaleJourneys.new.call
+
+    Rollbar.info("Deleted #{journeys.size} stale journeys.")
   end
 end

--- a/app/jobs/flag_stale_journeys_job.rb
+++ b/app/jobs/flag_stale_journeys_job.rb
@@ -6,6 +6,7 @@ class FlagStaleJourneysJob < ApplicationJob
 
     journeys = FlagStaleJourneys.new.call
 
+    # TODO: add journey/user params to the Rollbar payload
     Rollbar.info("Flagged #{journeys.size} journeys as stale.")
   end
 end

--- a/app/jobs/flag_stale_journeys_job.rb
+++ b/app/jobs/flag_stale_journeys_job.rb
@@ -1,0 +1,11 @@
+class FlagStaleJourneysJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    return unless ENV["FLAG_STALE_JOURNEYS"] # no-op until approval received
+
+    journeys = FlagStaleJourneys.new.call
+
+    Rollbar.info("Flagged #{journeys.size} journeys as stale.")
+  end
+end

--- a/app/services/create_journey.rb
+++ b/app/services/create_journey.rb
@@ -6,23 +6,21 @@
 # @see CreateStep#call
 #
 class CreateJourney
-  attr_accessor :category, :user
-
-  # @param user [User] current user
-  # @param category [Category] chosen category
+  # @param user [User]
+  # @param category [Category]
   #
   def initialize(user:, category:)
-    self.user = user
-    self.category = category
+    @user = user
+    @category = category
   end
 
   # @return [Journey]
   def call
-    journey = Journey.new(category: category, user: user)
+    journey = Journey.new(category: @category, user: @user)
     journey.save!
 
     # Contentful::Entry[category]
-    contentful_category = GetCategory.new(category_entry_id: category.contentful_id).call
+    contentful_category = GetCategory.new(category_entry_id: @category.contentful_id).call
     # Contentful::Entry[section]
     contentful_sections = GetSectionsFromCategory.new(category: contentful_category).call
 

--- a/app/services/delete_stale_journeys.rb
+++ b/app/services/delete_stale_journeys.rb
@@ -1,24 +1,24 @@
-# Perform purge of {Journey}s that have not been started.
-# Defaults to a one month grace period.
-#
-# @example
-#   DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR=60
+# Purge a {Journey} that has not been started or edited for X days
 #
 class DeleteStaleJourneys
-  # TODO: move qualifying_journeys method to the Journey model
+  # @return [Array<Journey>]
+  #
   def call
-    qualifying_journeys = Journey.where(started: false)
-      .where("updated_at < ?", date_a_journey_can_be_inactive_until)
-    qualifying_journeys.destroy_all
+    journeys.destroy_all
   end
 
 private
 
-  # @return [Date]
-  def date_a_journey_can_be_inactive_until
-    return 1.month.ago if ENV["DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR"].blank?
+  # Journeys that were marked as stale and still untouched after 30 days
+  #
+  def journeys
+    Journey.stale.not_started.unedited_since(grace_period)
+  end
 
-    day_count = ENV["DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR"].to_i
-    day_count.days.ago
+  # Defaults to 30 days
+  #
+  # @return [Date]
+  def grace_period
+    30.days.ago
   end
 end

--- a/app/services/flag_stale_journeys.rb
+++ b/app/services/flag_stale_journeys.rb
@@ -1,0 +1,27 @@
+# Flag a {Journey} as stale that has not been started or edited for X days
+#
+# DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR=
+class FlagStaleJourneys
+  # @return [Array<Journey>]
+  #
+  def call
+    flagged = journeys
+    journeys.update_all(state: :stale)
+    flagged
+  end
+
+private
+
+  # Unstarted and abandoned journeys
+  #
+  def journeys
+    Journey.initial.not_started.unedited_since(grace_period)
+  end
+
+  # Defaults to 30 days
+  #
+  # @return [Date]
+  def grace_period
+    ENV.fetch("DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR", 30).to_i.days.ago
+  end
+end

--- a/app/services/flag_stale_journeys.rb
+++ b/app/services/flag_stale_journeys.rb
@@ -2,11 +2,14 @@
 #
 # DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR=
 class FlagStaleJourneys
+  # Flip journey state and explicitly touch updated_at
+  #
   # @return [Array<Journey>]
   #
   def call
-    flagged = journeys
-    journeys.update_all(state: :stale)
+    flagged = journeys.to_a # NB: to_a is required
+    # NB: update_all returns the number of rows
+    journeys.update_all(state: :stale, updated_at: Time.zone.now)
     flagged
   end
 

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -7,9 +7,17 @@ warm_contentful_entry_cache:
     service is used infrequently by real users, we automatically update the
     cache.
 
+flag_stale_journeys:
+  cron: "0 2 * * *"
+  class: "FlagStaleJourneysJob"
+  description: Change the state of a Journey to stale when it has not had any
+    steps completed and has not been edited for a number of days. A stale Journey
+    is one believed to be abandoned and cluttering the database.
+
 delete_stale_journeys:
   cron: "0 2 * * *"
   class: "DeleteStaleJourneysJob"
-  description: Automatically remove Journey and associated child records when
-    we identify it as having become stale. This is intended to free up unused
-    database rows given every new specification generates 100-200 rows.
+  description: Automatically delete a stale Journey and associated child records
+    after 30 days. This grace period gives a user the opportunity to prevent the
+    deletion.
+

--- a/db/migrate/20210805130832_change_journey_started_to_false.rb
+++ b/db/migrate/20210805130832_change_journey_started_to_false.rb
@@ -1,0 +1,5 @@
+class ChangeJourneyStartedToFalse < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :journeys, :started, from: true, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_30_083035) do
+ActiveRecord::Schema.define(version: 2021_08_05_130832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 2021_07_30_083035) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "user_id"
-    t.boolean "started", default: true
+    t.boolean "started", default: false
     t.uuid "category_id"
     t.integer "state", default: 0
     t.index ["category_id"], name: "index_journeys_on_category_id"

--- a/spec/factories/journey.rb
+++ b/spec/factories/journey.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :journey do
-    started { true } # TODO: default journey factory to started=false
+    started { false }
     state { :initial }
 
     association :user, factory: :user

--- a/spec/fixtures/contentful/001-categories/category-peter.json
+++ b/spec/fixtures/contentful/001-categories/category-peter.json
@@ -1,0 +1,60 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "space_id"
+      }
+    },
+    "id": "category-peter",
+    "type": "Entry",
+    "createdAt": "2021-01-20T12:19:10.220Z",
+    "updatedAt": "2021-01-20T15:06:12.067Z",
+    "environment": {
+      "sys": {
+        "id": "test",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "category"
+      }
+    },
+    "locale": "en-GB"
+  },
+  "fields": {
+    "title": "Category Title",
+    "slug": "Category Slug",
+    "description": "Category Description",
+    "specificationTemplate": "<article id='specification'><h1>Liquid {{templating}}</h1></article>",
+    "sections": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "section-1-peter"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "section-2-peter"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "section-3-peter"
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/contentful/002-sections/section-1-peter.json
+++ b/spec/fixtures/contentful/002-sections/section-1-peter.json
@@ -1,0 +1,57 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "space_id"
+      }
+    },
+    "id": "section-1-peter",
+    "type": "Entry",
+    "createdAt": "2021-04-12T10:41:36.073Z",
+    "updatedAt": "2021-04-12T10:42:51.119Z",
+    "environment": {
+      "sys": {
+        "id": "test",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "section"
+      }
+    },
+    "locale": "en-GB"
+  },
+  "fields": {
+    "title": "Section 1",
+    "tasks": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/contentful/002-sections/section-2-peter.json
+++ b/spec/fixtures/contentful/002-sections/section-2-peter.json
@@ -1,0 +1,57 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "space_id"
+      }
+    },
+    "id": "section-2-peter",
+    "type": "Entry",
+    "createdAt": "2021-04-12T10:41:36.073Z",
+    "updatedAt": "2021-04-12T10:42:51.119Z",
+    "environment": {
+      "sys": {
+        "id": "test",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "section"
+      }
+    },
+    "locale": "en-GB"
+  },
+  "fields": {
+    "title": "Section 2",
+    "tasks": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      }
+    ]
+  }
+}

--- a/spec/fixtures/contentful/002-sections/section-3-peter.json
+++ b/spec/fixtures/contentful/002-sections/section-3-peter.json
@@ -1,0 +1,57 @@
+{
+  "sys": {
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "space_id"
+      }
+    },
+    "id": "section-3-peter",
+    "type": "Entry",
+    "createdAt": "2021-04-12T10:41:36.073Z",
+    "updatedAt": "2021-04-12T10:42:51.119Z",
+    "environment": {
+      "sys": {
+        "id": "test",
+        "type": "Link",
+        "linkType": "Environment"
+      }
+    },
+    "revision": 1,
+    "contentType": {
+      "sys": {
+        "type": "Link",
+        "linkType": "ContentType",
+        "id": "section"
+      }
+    },
+    "locale": "en-GB"
+  },
+  "fields": {
+    "title": "Section 3",
+    "tasks": [
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      },
+      {
+        "sys": {
+          "type": "Link",
+          "linkType": "Entry",
+          "id": "every-question-type-task"
+        }
+      }
+    ]
+  }
+}

--- a/spec/jobs/flag_stale_journeys_job_spec.rb
+++ b/spec/jobs/flag_stale_journeys_job_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe FlagStaleJourneysJob, type: :job do
+  include ActiveJob::TestHelper
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  around do |example|
+    # NB: remove this when flagging stale journeys is approved
+    ClimateControl.modify(FLAG_STALE_JOURNEYS: "true") do
+      example.run
+    end
+  end
+
+  describe ".perform_later" do
+    it "enqueues a job asynchronously on the default queue" do
+      expect { described_class.perform_later }.to have_enqueued_job.on_queue("default")
+    end
+
+    it "flags journeys as stale after a grace period" do
+      before_grace_period = create(:journey, updated_at: 29.days.ago)
+      after_grace_period = create(:journey, updated_at: 31.days.ago)
+
+      # expect(Rollbar).to receive(:info).with("Flagged 1 journeys as stale.")
+
+      described_class.perform_later
+      perform_enqueued_jobs
+
+      stale_journeys = Journey.stale
+
+      expect(stale_journeys).to include after_grace_period
+      expect(stale_journeys).not_to include before_grace_period
+    end
+  end
+end

--- a/spec/jobs/flag_stale_journeys_job_spec.rb
+++ b/spec/jobs/flag_stale_journeys_job_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe FlagStaleJourneysJob, type: :job do
     end
 
     it "flags journeys as stale after a grace period" do
-      before_grace_period = create(:journey, updated_at: 29.days.ago)
-      after_grace_period = create(:journey, updated_at: 31.days.ago)
+      before_grace_period = create(:journey, state: :initial, started: false, updated_at: 29.days.ago)
+      after_grace_period = create(:journey, state: :initial, started: false, updated_at: 31.days.ago)
 
-      # expect(Rollbar).to receive(:info).with("Flagged 1 journeys as stale.")
+      expect(Rollbar).to receive(:info).with("Flagged 1 journeys as stale.")
 
       described_class.perform_later
       perform_enqueued_jobs

--- a/spec/models/journey/journey_all_tasks_completed_spec.rb
+++ b/spec/models/journey/journey_all_tasks_completed_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Journey, "#all_tasks_completed?", type: :model do
+  subject(:journey) { build(:journey, category: category) }
+
+  let(:category) { build(:category) }
+  let(:section) { create(:section, journey: journey) }
+  let(:task) { create(:task, section: section) }
+
+  context "when all steps have been completed" do
+    it "returns true" do
+      step_1 = create(:step, :radio, task: task)
+      create(:radio_answer, step: step_1)
+
+      step_2 = create(:step, :radio, task: task)
+      create(:radio_answer, step: step_2)
+
+      expect(journey.all_tasks_completed?).to be true
+    end
+  end
+
+  context "when no steps have been completed" do
+    it "returns false " do
+      create_list(:step, 2, :radio, task: task)
+
+      expect(journey.all_tasks_completed?).to be false
+    end
+  end
+
+  context "when only some steps have been completed" do
+    it "returns false" do
+      step = create(:step, :radio, task: task)
+      create(:radio_answer, step: step)
+
+      create(:step, :radio, task: task)
+      # Omit answer for step 2
+
+      expect(journey.all_tasks_completed?).to be false
+    end
+  end
+
+  context "when there are uncompleted hidden steps" do
+    it "ignores them and returns true" do
+      step = create(:step, :radio, task: task)
+      create(:radio_answer, step: step)
+
+      create(:step, :radio, task: task, hidden: true)
+      # Omit answer for step 2
+
+      expect(journey.all_tasks_completed?).to be true
+    end
+  end
+end

--- a/spec/models/journey_spec.rb
+++ b/spec/models/journey_spec.rb
@@ -1,99 +1,25 @@
 RSpec.describe Journey, type: :model do
-  it { is_expected.to have_many(:sections) }
+  subject(:journey) { build(:journey, category: category) }
 
-  it "captures the category" do
-    category = build(:category, :catering)
-    journey = build(:journey, category: category)
-    expect(journey.category.title).to eql("Catering")
-  end
+  let(:category) { build(:category) }
 
-  describe "#all_tasks_completed?" do
-    context "when all steps have been completed" do
-      it "returns true" do
-        journey = create(:journey)
-        section = create(:section, journey: journey)
-        task = create(:task, section: section)
+  it { is_expected.to belong_to :user }
+  it { is_expected.to belong_to :category }
 
-        step1 = create(:step, :radio, task: task)
-        create(:radio_answer, step: step1)
+  it { is_expected.to have_many :sections }
+  it { is_expected.to have_many :tasks }
+  it { is_expected.to have_many :steps }
 
-        step2 = create(:step, :radio, task: task)
-        create(:radio_answer, step: step2)
-
-        expect(journey.all_tasks_completed?).to be true
-      end
-    end
-
-    context "when no steps have been completed" do
-      it "returns false " do
-        journey = create(:journey)
-        section = create(:section, journey: journey)
-        task = create(:task, section: section)
-
-        create_list(:step, 2, :radio, task: task)
-
-        expect(journey.all_tasks_completed?).to be false
-      end
-    end
-
-    context "when only some steps have been completed" do
-      it "returns false" do
-        journey = create(:journey)
-        section = create(:section, journey: journey)
-        task = create(:task, section: section)
-
-        step = create(:step, :radio, task: task)
-        create(:radio_answer, step: step)
-
-        create(:step, :radio, task: task)
-        # Omit answer for step 2
-
-        expect(journey.all_tasks_completed?).to be false
-      end
-    end
-
-    context "when there are uncompleted hidden steps" do
-      it "ignores them and returns true" do
-        journey = create(:journey)
-        section = create(:section, journey: journey)
-        task = create(:task, section: section)
-
-        step = create(:step, :radio, task: task)
-        create(:radio_answer, step: step)
-
-        create(:step, :radio, task: task, hidden: true)
-        # Omit answer for step 2
-
-        expect(journey.all_tasks_completed?).to be true
-      end
+  describe "#started" do
+    it "defaults to false" do
+      expect(journey.started).to be false
     end
   end
 
   describe "#start!" do
-    it "set started to true" do
-      category = build(:category, :catering)
-      journey = build(:journey, category: category)
+    it "sets started to true" do
       journey.start!
-      expect(journey.reload.started).to eq(true)
-    end
-
-    it "sets the updated_at to now" do
-      travel_to Time.zone.local(2004, 11, 24, 1, 4, 44)
-      category = build(:category, :catering)
-      journey = build(:journey, category: category)
-
-      journey.start!
-
-      expect(journey.updated_at).to eq(Time.zone.now)
-    end
-
-    context "when started is already true" do
-      it "does not update the record" do
-        category = build(:category, :catering)
-        journey = build(:journey, category: category, started: true)
-        expect(journey).not_to receive(:update).with(started: true)
-        journey.start!
-      end
+      expect(journey.started).to be true
     end
   end
 end

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -1,68 +1,84 @@
-require "rails_helper"
-
+# CMS: CreateJourney deserves to be tested with a complex real-world scenario fixture
+# TODO: expand on category-peter.json to mirror the complexity in shared context factories
 RSpec.describe CreateJourney do
+  subject(:service) { described_class.new(category: category, user: user) }
+
+  let(:category) do
+    build(:category,
+          title: "Complex Category",
+          contentful_id: "category-peter") # contentful_id must match the stubbed fixture
+  end
+
+  let(:journey) { Journey.last }
   let(:user) { build(:user) }
-  let(:category) { build(:category, contentful_id: "contentful-category-entry") }
 
   before do
-    stub_contentful_category(fixture_filename: "#{fixture}.json")
+    # spec/fixtures/contentful/001-categories/category-peter.json
+    stub_contentful_category(fixture_filename: "category-peter.json")
+
+    service.call
   end
 
   describe "#call" do
-    let(:fixture) { "category-with-no-steps" }
-
     it "creates a new journey" do
-      expect {
-        described_class.new(category: category, user: user).call
-      }.to change(Journey, :count).by(1)
-
-      last_journey = Journey.last
-      expect(last_journey.category.title).to eql "category title"
-      expect(last_journey.category.contentful_id).to eql "contentful-category-entry"
+      expect { service.call }.to change(Journey, :count).by 1
+      expect(Journey.count).to be 2
     end
 
-    it "associates the new journey with the given user" do
-      described_class.new(category: category, user: user).call
-      expect(Journey.last.user).to eq user
+    it "associates the journey with a category" do
+      expect(journey.category.contentful_id).to eql "category-peter"
+      expect(journey.category.title).to eql "Complex Category"
     end
 
-    it "sets started to true (until questions have been answered)" do
-      described_class.new(category: category, user: user).call
-      expect(Journey.last.started).to be true
+    it "associates the journey with a user" do
+      expect(journey.user).to eq user
     end
 
-    it "sets updated_at to now" do
-      travel_to Time.zone.local(2004, 11, 24, 1, 4, 44)
-      described_class.new(category: category, user: user).call
-      expect(Journey.last.updated_at).to eq Time.zone.now
+    it "creates associated sections in order" do
+      expect(journey.sections.count).to be 3
+
+      # spec/fixtures/contentful/002-sections/section-1-peter.json
+      expect(journey.sections[0].contentful_id).to eql "section-1-peter"
+      expect(journey.sections[0].order).to be 0
+
+      # spec/fixtures/contentful/002-sections/section-2-peter.json
+      expect(journey.sections[1].contentful_id).to eql "section-2-peter"
+      expect(journey.sections[1].order).to be 1
+
+      # spec/fixtures/contentful/002-sections/section-3-peter.json
+      expect(journey.sections[2].contentful_id).to eql "section-3-peter"
+      expect(journey.sections[2].order).to be 2
     end
 
-    # TODO: move liquid template specs to the Category
-    describe "WIP multiple categories" do
-      let(:fixture) { "category-with-liquid-template" }
+    it "creates associated tasks in order" do
+      expect(journey.tasks.count).to be 9
 
-      it "stores a copy of the Liquid template" do
-        described_class.new(category: category, user: user).call
+      expect(journey.tasks[0].contentful_id).to eql "every-question-type-task"
+      expect(journey.tasks[0].order).to be 0
 
-        # From fixtures
-        # .to eql("<article id='specification'><h1>Liquid {{templating}}</h1></article>")
-        expect(Journey.last.category.liquid_template)
-          .to eql("Your answer was {{ answer_47EI2X2T5EDTpJX9WjRR9p }}") # from factory
-      end
+      expect(journey.tasks[1].contentful_id).to eql "every-question-type-task"
+      expect(journey.tasks[1].order).to be 0
 
-      # TODO: test when a journey cannot be saved
-      # context "when the journey cannot be saved" do
-      #   it "raises an error" do
-      #     stub_contentful_category(
-      #       fixture_filename: "category-with-no-title.json",
-      #       stub_sections: true,
-      #     )
-      #     # Force a validation error by not providing an invalid category ID
-      #     expect {
-      #       described_class.new(category: category, user: user).call
-      #     }.to raise_error(ActiveRecord::RecordInvalid)
-      #   end
-      # end
+      expect(journey.tasks[2].contentful_id).to eql "every-question-type-task"
+      expect(journey.tasks[2].order).to be 0
+
+      expect(journey.tasks[3].contentful_id).to eql "every-question-type-task"
+      expect(journey.tasks[3].order).to be 1
     end
+
+    # 3 sections * 3 tasks * 7 steps = 63
+    it "creates associated steps in order" do
+      expect(journey.steps.count).to be 63
+    end
+
+    # TODO: this test is applicable to the yet to be created CreateCategory service object
+    # context "when the category cannot be saved" do
+    #   # Force a validation error by not providing an invalid category ID
+    #   let(:fixture) { "category-with-no-title" }
+
+    #   it "raises an error" do
+    #     expect { service.call }.to raise_error ActiveRecord::RecordInvalid
+    #   end
+    # end
   end
 end

--- a/spec/services/create_journey_spec.rb
+++ b/spec/services/create_journey_spec.rb
@@ -50,20 +50,26 @@ RSpec.describe CreateJourney do
       expect(journey.sections[2].order).to be 2
     end
 
-    it "creates associated tasks in order" do
+    it "creates all associated tasks" do
       expect(journey.tasks.count).to be 9
-
+      # spec/fixtures/contentful/002-tasks/every-question-type-task.json
       expect(journey.tasks[0].contentful_id).to eql "every-question-type-task"
+    end
+
+    it "creates associated tasks in order" do
       expect(journey.tasks[0].order).to be 0
-
-      expect(journey.tasks[1].contentful_id).to eql "every-question-type-task"
       expect(journey.tasks[1].order).to be 0
-
-      expect(journey.tasks[2].contentful_id).to eql "every-question-type-task"
       expect(journey.tasks[2].order).to be 0
-
-      expect(journey.tasks[3].contentful_id).to eql "every-question-type-task"
       expect(journey.tasks[3].order).to be 1
+      expect(journey.tasks[4].order).to be 1
+      expect(journey.tasks[5].order).to be 1
+
+      expect(journey.sections[0].tasks[0].order).to be 0
+      expect(journey.sections[0].tasks[1].order).to be 1
+      expect(journey.sections[0].tasks[2].order).to be 2
+      expect(journey.sections[1].tasks[0].order).to be 0
+      expect(journey.sections[1].tasks[1].order).to be 1
+      expect(journey.sections[1].tasks[2].order).to be 2
     end
 
     # 3 sections * 3 tasks * 7 steps = 63

--- a/spec/services/delete_stale_journeys_spec.rb
+++ b/spec/services/delete_stale_journeys_spec.rb
@@ -12,16 +12,26 @@ RSpec.describe DeleteStaleJourneys do
       end
     end
 
+    context "when a journey not flagged as stale has passed the grace period" do
+      context "and has not been started" do
+        it "is not destroyed" do
+          create(:journey, state: :initial, updated_at: 31.days.ago)
+
+          expect(Journey.count).to be 1
+          service.call
+          expect(Journey.count).to be 1
+        end
+      end
+    end
+
     context "when a journey flagged as stale has passed the grace period" do
-      # NB: the started boolean was never realised - this test ensures existing data is not lost
       context "and has been started" do
         it "is not destroyed" do
           create(:journey, state: :stale, started: true, updated_at: 31.days.ago)
-          create(:journey, state: :initial, started: true, updated_at: 31.days.ago)
 
-          expect(Journey.count).to be 2
+          expect(Journey.count).to be 1
           service.call
-          expect(Journey.count).to be 2
+          expect(Journey.count).to be 1
         end
       end
 

--- a/spec/services/delete_stale_journeys_spec.rb
+++ b/spec/services/delete_stale_journeys_spec.rb
@@ -1,106 +1,48 @@
-require "rails_helper"
-
 RSpec.describe DeleteStaleJourneys do
-  before { travel_to Time.zone.local(2021, 4, 8, 14, 24, 0) }
-
-  after { travel_back }
+  subject(:service) { described_class.new }
 
   describe "#call" do
-    it "destroys a journey and all associated records" do
-      step = create(:step, :radio)
-      journey = step.journey
-      journey.update!(started: false, updated_at: (1.month + 1.day).ago)
-      _radio_answer = create(:radio_answer, step: step)
-      _short_text_answer = create(:short_text_answer, step: step)
+    context "when a journey flagged as stale is within the grace period" do
+      it "is not destroyed" do
+        create(:journey, state: :stale, updated_at: 29.days.ago)
 
-      described_class.new.call
-
-      expect(Journey.count).to eq(0)
-      expect(Step.count).to eq(0)
-      expect(RadioAnswer.count).to eq(0)
-      expect(ShortTextAnswer.count).to eq(0)
-    end
-
-    it "only destroys journeys we think of as stale" do
-      stale_journey = create(:journey, started: false, updated_at: 2.months.ago)
-
-      about_to_become_stale_journey = create(:journey, started: false, updated_at: 1.month.ago)
-      recently_created_journey = create(:journey, started: false, updated_at: 4.days.ago)
-      recently_active_journey = create(:journey, started: true, updated_at: 4.days.ago)
-      old_active_journey = create(:journey, started: true, updated_at: 2.months.ago)
-
-      described_class.new.call
-
-      remaining_journeys = Journey.all
-      expect(remaining_journeys).not_to include(stale_journey)
-
-      expect(remaining_journeys).to include(about_to_become_stale_journey)
-      expect(remaining_journeys).to include(recently_created_journey)
-      expect(remaining_journeys).to include(recently_active_journey)
-      expect(remaining_journeys).to include(old_active_journey)
-    end
-
-    context "when the journey is marked as started" do
-      it "is not destroyed regardless of updated_at" do
-        legacy_journey_with_no_activity = create(:journey, started: true)
-        old_journey_with_activity = create(:journey, started: true, updated_at: (1.month + 1.day).ago)
-        recent_journey_with_activity = create(:journey, started: true, updated_at: (1.month - 1.day).ago)
-
-        described_class.new.call
-
-        remaining_journeys = Journey.all
-        expect(remaining_journeys).to include(legacy_journey_with_no_activity)
-        expect(remaining_journeys).to include(old_journey_with_activity)
-        expect(remaining_journeys).to include(recent_journey_with_activity)
+        expect(Journey.count).to be 1
+        service.call
+        expect(Journey.count).to be 1
       end
     end
 
-    context "when the journey is not marked as started" do
-      context "and the journey hasn't been worked on for more than 1 month" do
-        it "is destroyed" do
-          journey = create(:journey, started: false, updated_at: (1.month + 1.day).ago)
-          described_class.new.call
-          expect { Journey.find(journey.id) }.to raise_error(ActiveRecord::RecordNotFound)
-        end
-      end
-
-      context "and the journey has been worked on in the last 1 month" do
+    context "when a journey flagged as stale has passed the grace period" do
+      # NB: the started boolean was never realised - this test ensures existing data is not lost
+      context "and has been started" do
         it "is not destroyed" do
-          journey = create(:journey, started: true, updated_at: (1.month - 1.day).ago)
-          described_class.new.call
-          expect(Journey.find(journey.id)).to eq(journey)
+          create(:journey, state: :stale, started: true, updated_at: 31.days.ago)
+          create(:journey, state: :initial, started: true, updated_at: 31.days.ago)
+
+          expect(Journey.count).to be 2
+          service.call
+          expect(Journey.count).to be 2
         end
       end
 
-      context "and the journey has been worked on exactly 1 month ago" do
-        it "is not destroyed" do
-          journey = create(:journey, started: true, updated_at: 1.month.ago)
-          described_class.new.call
-          expect(Journey.find(journey.id)).to eq(journey)
-        end
-      end
-    end
+      it "is destroyed with all associated records" do
+        step = create(:step, :radio)
+        step.journey.update!(state: :stale, updated_at: 31.days.ago)
+        create(:radio_answer, step: step)
 
-    context "when the environment variable DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR is set" do
-      around do |example|
-        ClimateControl.modify(
-          DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR: "5",
-        ) do
-          example.run
-        end
-      end
+        expect(Journey.count).to be 1
+        expect(Section.count).to be 1
+        expect(Task.count).to be 1
+        expect(Step.count).to be 1
+        expect(RadioAnswer.count).to be 1
 
-      it "only deletes unstarted journeys that were last modified more than 5 days ago" do
-        stale_journey = create(:journey, started: false, updated_at: 6.days.ago)
-        about_to_become_stale_journey = create(:journey, started: false, updated_at: 5.days.ago)
-        active_journey = create(:journey, started: false, updated_at: 4.days.ago)
+        service.call
 
-        described_class.new.call
-
-        remaining_journeys = Journey.all
-        expect(remaining_journeys).not_to include(stale_journey)
-        expect(remaining_journeys).to include(about_to_become_stale_journey)
-        expect(remaining_journeys).to include(active_journey)
+        expect(Journey.count).to be_zero
+        expect(Section.count).to be_zero
+        expect(Task.count).to be_zero
+        expect(Step.count).to be_zero
+        expect(RadioAnswer.count).to be_zero
       end
     end
   end

--- a/spec/services/flag_stale_journeys_spec.rb
+++ b/spec/services/flag_stale_journeys_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe FlagStaleJourneys do
+  subject(:service) { described_class.new }
+
+  describe "#call" do
+    context "with the default grace period" do
+      context "when a journey is within the grace period" do
+        it "is not flagged" do
+          create(:journey, updated_at: 29.days.ago)
+
+          expect(Journey.stale.count).to be_zero
+          service.call
+          expect(Journey.stale.count).to be_zero
+        end
+      end
+
+      context "when a journey has passed the grace period" do
+        it "is flagged" do
+          create(:journey, updated_at: 31.days.ago)
+
+          expect(Journey.stale.count).to be_zero
+          service.call
+          expect(Journey.stale.count).to be 1
+        end
+      end
+    end
+
+    context "with a custom grace period" do
+      around do |example|
+        ClimateControl.modify(DAYS_A_JOURNEY_CAN_BE_INACTIVE_FOR: "7") do
+          example.run
+        end
+      end
+
+      context "when a journey is within the grace period" do
+        it "is not flagged" do
+          create(:journey, updated_at: 6.days.ago)
+
+          expect(Journey.stale.count).to be_zero
+          service.call
+          expect(Journey.stale.count).to be_zero
+        end
+      end
+
+      context "when a journey has passed the grace period" do
+        it "is flagged" do
+          create(:journey, updated_at: 8.days.ago)
+
+          expect(Journey.stale.count).to be_zero
+          service.call
+          expect(Journey.stale.count).to be 1
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- a journey is not started by default, database migration added
- a `@journey#started` == true once a step is completed
- a journey's state is discrete so no two states can be applicable
- a journey is flagged as stale if it is not started or edited for X days
- a stale journey can be automatically deleted after a further 30 days
- harden specs for `Journey` and `CreateJourney` to cover associations
- add new fixtures for a complex journey (WIP)
- correct journey factory
- refactor service objects and specs
- add self-documenting scopes to `Journey`
- update CHANGELOG

## Next steps

- complete new fixtures
- activate workers
- expand test coverage for `CreateJourney` further
- test journey scopes