### PR TITLE
Second refactor of UserSession restoring registered redirect url

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,7 +18,7 @@ class SessionsController < ApplicationController
 
     # DSI: users would need to signout manually to proceed otherwise
     if session.destroy
-      redirect_to root_path, notice: "Sign in failed unexpectedly, please try again"
+      redirect_to root_path, notice: I18n.t("banner.session.failure")
     end
   end
 
@@ -26,15 +26,20 @@ class SessionsController < ApplicationController
   #
   # @see UserSession
   def destroy
-    target = user_session.sign_out_url.dup
+    issuer_url = user_session.sign_out_url.dup
     user_session.delete!
-    redirect_to target
+
+    if issuer_url
+      redirect_to issuer_url
+    else
+      redirect_to root_path, notice: I18n.t("banner.session.destroy")
+    end
   end
 
 private
 
   def user_session
-    UserSession.new(session: session)
+    UserSession.new(session: session, redirect_url: issuer_redirect_url)
   end
 
   def auth_hash

--- a/app/services/user_session.rb
+++ b/app/services/user_session.rb
@@ -3,9 +3,11 @@
 # @see SessionsController
 class UserSession
   # @param session [ActionDispatch::Request::Session]
+  # @param redirect_url [String] sessions#destroy
   #
-  def initialize(session:)
+  def initialize(session:, redirect_url:)
     @session = session
+    @redirect_url = redirect_url
   end
 
   # Stores user sign-in information in the session.
@@ -33,23 +35,18 @@ class UserSession
     @session[:dfe_sign_in_sign_out_token].present?
   end
 
-  # Redirect to the homepage after ending the issued session
+  # URL to end OpenID Connect issuer session
   #
-  # @return [String]
+  # @return [String, nil]
   def sign_out_url
-    return redirect_url unless should_be_signed_out_of_dsi?
+    return unless should_be_signed_out_of_dsi?
 
     query = {
       id_token_hint: @session[:dfe_sign_in_sign_out_token],
-      post_logout_redirect_uri: redirect_url,
+      post_logout_redirect_uri: @redirect_url,
     }
 
     "#{ENV.fetch('DFE_SIGN_IN_ISSUER')}/session/end?#{query.to_query}"
-  end
-
-  # @return [String]
-  def redirect_url
-    Rails.application.routes.url_helpers.root_url
   end
 
   # Sign out concurrent logins

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,9 @@ en:
     footer:
       message:
         For privacy information for this service, or to request the deletion of any personal data, email <a href="mailto:%{support_email}" class="govuk-footer__link">%{support_email}</a>
-
+    session:
+      failure: Sign in failed unexpectedly, please try again.
+      destroy: You have been signed out.
   planning:
     start_page:
       page_title: "Catering services"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   # DfE Sign In
   get "/auth/dfe/callback", to: "sessions#create", as: :sign_in
+  get "/auth/dfe/signout", to: "sessions#destroy", as: :issuer_redirect
   delete "/auth/dfe/signout", to: "sessions#destroy", as: :sign_out
   get "/auth/failure", to: "sessions#failure"
   post "/auth/developer/callback" => "sessions#bypass_callback" if Rails.env.development?

--- a/spec/features/auth/sign_in_spec.rb
+++ b/spec/features/auth/sign_in_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "DfE Sign-in" do
 
       expect(page).to have_current_path "/"
       expect(page.driver.request.session.keys).to be_empty
-      expect(find("h3.govuk-notification-banner__heading")).to have_text "Sign in failed unexpectedly, please try again"
+      expect(find("h3.govuk-notification-banner__heading")).to have_text "Sign in failed unexpectedly, please try again."
 
       # If the session can not be cleared
       # errors.sign_in.unexpected_failure.page_title

--- a/spec/features/auth/sign_out_spec.rb
+++ b/spec/features/auth/sign_out_spec.rb
@@ -18,7 +18,9 @@ RSpec.feature "Sign out" do
     expect(page.driver.request.session.keys).to be_empty
     expect(page).to have_current_path "/"
 
-    # FIXME: why is the signout link still visible?
+    expect(find("h3.govuk-notification-banner__heading")).to have_text "You have been signed out."
+
+    # FIXME: why is the signout link still visible in this spec?
     # within("header") do
     #   expect(page).not_to have_link "Sign out", href: "/auth/dfe/signout", class: "govuk-header__link"
     # end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -69,23 +69,23 @@ RSpec.describe "Authentication", type: :request do
   end
 
   describe "Sign out" do
-    it "asks UserSession to delete the user's session data" do
+    it "tells UserSession to delete session data" do
       user_exists_in_dfe_sign_in
       expect_any_instance_of(UserSession).to receive(:delete!)
 
       delete "/auth/dfe/signout"
 
-      expect(response).to redirect_to "http://localhost:3000/"
+      expect(response).to redirect_to "/"
     end
 
-    context "when there is no sign out token (they are already signed out from the applications point of view)" do
+    context "when there is no sign out token" do
       it "redirects the user to the root path" do
         user_exists_in_dfe_sign_in
         allow_any_instance_of(UserSession).to receive(:should_be_signed_out_of_dsi?).and_return(false)
 
         delete "/auth/dfe/signout"
 
-        expect(response).to redirect_to "http://localhost:3000/"
+        expect(response).to redirect_to "/"
       end
     end
 
@@ -96,13 +96,13 @@ RSpec.describe "Authentication", type: :request do
         end
       end
 
-      it "redirects to DSI with the users token" do
+      it "redirects to the issuer with token and return redirect params" do
         user_exists_in_dfe_sign_in
         allow_any_instance_of(UserSession).to receive(:should_be_signed_out_of_dsi?).and_return(true)
 
         delete "/auth/dfe/signout"
 
-        expect(response).to redirect_to("https://test-oidc.signin.education.gov.uk:443/session/end?id_token_hint=&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F")
+        expect(response).to redirect_to "https://test-oidc.signin.education.gov.uk:443/session/end?id_token_hint=&post_logout_redirect_uri=http%3A%2F%2Fwww.example.com%2Fauth%2Fdfe%2Fsignout"
       end
     end
   end

--- a/spec/services/user_session_spec.rb
+++ b/spec/services/user_session_spec.rb
@@ -1,5 +1,9 @@
-RSpec.describe UserSession, type: :model do
-  subject(:user_session) { described_class.new(session: session) }
+RSpec.describe UserSession do
+  subject(:user_session) do
+    described_class.new(session: session, redirect_url: redirect_url)
+  end
+
+  let(:redirect_url) { "https://ghbs-self-serve.app:123/session/end" }
 
   let(:session) { instance_double(ActionDispatch::Request::Session) }
 
@@ -37,12 +41,6 @@ RSpec.describe UserSession, type: :model do
     end
   end
 
-  describe "#redirect_url" do
-    it "returns the application root uri" do
-      expect(user_session.redirect_url).to eql "http://localhost:3000/"
-    end
-  end
-
   describe "#sign_out_url" do
     around do |example|
       ClimateControl.modify(DFE_SIGN_IN_ISSUER: "https://test-oidc.signin.education.gov.uk:443") do
@@ -52,13 +50,13 @@ RSpec.describe UserSession, type: :model do
 
     it "returns a URL that can be sent to DfE Sign-in to sign the user out of their service" do
       allow(session).to receive(:[]).with(:dfe_sign_in_sign_out_token).and_return("a-long-token")
-      expect(user_session.sign_out_url).to eq("https://test-oidc.signin.education.gov.uk:443/session/end?id_token_hint=a-long-token&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F")
+      expect(user_session.sign_out_url).to eq("https://test-oidc.signin.education.gov.uk:443/session/end?id_token_hint=a-long-token&post_logout_redirect_uri=https%3A%2F%2Fghbs-self-serve.app%3A123%2Fsession%2Fend")
     end
 
     context "when the user has no sign out token" do
-      it "redirects the user to the root uri" do
+      it "returns nil" do
         allow(session).to receive(:[]).with(:dfe_sign_in_sign_out_token).and_return(nil)
-        expect(user_session.sign_out_url).to eql "http://localhost:3000/"
+        expect(user_session.sign_out_url).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

- add sign out notice once the user returns to the home page
- pass redirect_url into `UserSession` keeping routes in controller
- move notice messages into locales

## Screenshots of UI changes

### Before
![Screenshot 2021-08-09 at 08 11 37](https://user-images.githubusercontent.com/3261/128671005-0d8d7a04-4560-4429-bbe3-2dd17e1f6eef.png)

### After


