### PR TITLE
Use category slug as an HTML identifier (bugfix)

### DIFF
--- a/db/migrate/20210825142733_add_slugs_to_existing_categories.rb
+++ b/db/migrate/20210825142733_add_slugs_to_existing_categories.rb
@@ -5,7 +5,7 @@ class AddSlugsToExistingCategories < ActiveRecord::Migration[6.1]
     categories = Category.where(slug: nil)
     categories.each do |category|
       contentful_category = Content::Client.new.by_id(category.contentful_id)
-      category.update!(slug: contentful_category.slug)
+      category.update!(slug: contentful_category.slug) unless contentful_category.nil?
     end
   end
 

--- a/spec/migrations/self-serve/add_slugs_to_existing_categories_spec.rb
+++ b/spec/migrations/self-serve/add_slugs_to_existing_categories_spec.rb
@@ -21,4 +21,20 @@ RSpec.describe AddSlugsToExistingCategories do
       expect(Category.first.slug).to eq "mfd"
     end
   end
+
+  context "when the Contentful category does not exist" do
+    before do
+      create(:category, contentful_id: "contentful-category-entry", slug: nil)
+      allow(stub_client).to receive(:by_id).with("contentful-category-entry").and_return(nil)
+    end
+
+    it "makes no changes" do
+      expect(Category.count).to eq 1
+      expect(Category.first.slug).to eq nil
+
+      expect { up }.not_to change { Category.where(slug: nil).count }.from(1)
+
+      expect(Category.first.slug).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- fix a bug where database migration would fail if the `Category.contentful_id` field had an invalid ID while running the `AddSlugsToExistingCategories` migration