### PR TITLE
Add Unique ID for a Support::Case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog 1.0.0].
 ### Supported Unreleased
 
 - Added initial models for supported case management functions.
+- Added unique 6 digit ref for cases starting with 000001.
 
 ### Specify Unreleased
 

--- a/app/models/support/case.rb
+++ b/app/models/support/case.rb
@@ -31,6 +31,15 @@ module Support
     # no_response
     enum state: { initial: 0, open: 1, resolved: 2, pending: 3, closed: 4, pipeline: 5, no_response: 6 }
 
+    before_validation :generate_ref
+    validates :ref, uniqueness: true, length: { is: 6 }, format: { with: /\A\d+\z/, message: "numbers only" }
+
+    # Called before validation to assign 6 digit incremental number (from last case or the default 000000)
+    # @return [String]
+    def generate_ref
+      self.ref = (Support::Case.last&.ref || sprintf("%06d", 0)).next
+    end
+
     # TODO: Replace with ActiveRecord association
     def interactions
       time = Time.zone.local(2020, 1, 30, 12)

--- a/db/migrate/20210909084632_add_unique_to_case_ref.rb
+++ b/db/migrate/20210909084632_add_unique_to_case_ref.rb
@@ -1,0 +1,9 @@
+class AddUniqueToCaseRef < ActiveRecord::Migration[6.1]
+  def up
+    change_column :support_cases, :ref, :string, unique: true
+  end
+
+  def down
+    change_column :support_cases, :ref, :string
+  end
+end

--- a/db/migrate/20210909090022_remove_ref_index_support_case.rb
+++ b/db/migrate/20210909090022_remove_ref_index_support_case.rb
@@ -1,0 +1,5 @@
+class RemoveRefIndexSupportCase < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :support_cases, :ref
+  end
+end

--- a/db/migrate/20210909090047_add_unique_ref_index_support_case.rb
+++ b/db/migrate/20210909090047_add_unique_ref_index_support_case.rb
@@ -1,0 +1,5 @@
+class AddUniqueRefIndexSupportCase < ActiveRecord::Migration[6.1]
+  def change
+    add_index :support_cases, :ref, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_01_071420) do
+ActiveRecord::Schema.define(version: 2021_09_09_090047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -163,7 +163,7 @@ ActiveRecord::Schema.define(version: 2021_09_01_071420) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["category_id"], name: "index_support_cases_on_category_id"
-    t.index ["ref"], name: "index_support_cases_on_ref"
+    t.index ["ref"], name: "index_support_cases_on_ref", unique: true
     t.index ["state"], name: "index_support_cases_on_state"
     t.index ["status"], name: "index_support_cases_on_status"
     t.index ["support_level"], name: "index_support_cases_on_support_level"

--- a/spec/factories/support/case.rb
+++ b/spec/factories/support/case.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :support_case, class: "Support::Case" do
-    ref { "000001" }
+    ref { "" }
     request_text { "This is an example request for support - please help!" }
     state { 0 }
     support_level { 0 }

--- a/spec/models/support/case_spec.rb
+++ b/spec/models/support/case_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Support::Case, type: :model do
       it "has generated correct ref" do
         expect(new_case.ref).to eql "000011"
       end
-
     end
   end
 end

--- a/spec/models/support/case_spec.rb
+++ b/spec/models/support/case_spec.rb
@@ -15,6 +15,27 @@ RSpec.describe Support::Case, type: :model do
     end
   end
 
-  it { is_expected.to define_enum_for(:support_level).with(%i[L1 L2 L3 L4 L5]) }
-  it { is_expected.to define_enum_for(:state).with(%i[initial open resolved pending closed pipeline no_response]) }
+  it { is_expected.to define_enum_for(:support_level).with_values(%i[L1 L2 L3 L4 L5]) }
+  it { is_expected.to define_enum_for(:state).with_values(%i[initial open resolved pending closed pipeline no_response]) }
+
+  describe "#generate_ref" do
+    context "with no existing cases" do
+      it "has generated initial ref" do
+        expect(support_case.ref).to eql "000001"
+      end
+    end
+
+    context "with existing cases" do
+      before do
+        FactoryBot.create_list(:support_case, 10)
+      end
+
+      let!(:new_case) { create(:support_case) }
+
+      it "has generated correct ref" do
+        expect(new_case.ref).to eql "000011"
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- Added generate_ref method to Support::Case
- `generate_ref` called before validation
- Added tests
- rspec define enum for with_values deprecation fix

