### PR TITLE
Fix incorrect use of `timestamps` in migration when setting new defaults

### DIFF
--- a/db/migrate/20210908131247_add_default_support_category_timestamps.rb
+++ b/db/migrate/20210908131247_add_default_support_category_timestamps.rb
@@ -1,7 +1,8 @@
 class AddDefaultSupportCategoryTimestamps < ActiveRecord::Migration[6.1]
   def change
     change_table :support_categories, bulk: true do |t|
-      t.timestamps default: -> { "CURRENT_TIMESTAMP" }
+      t.change_default :created_at, from: nil, to: -> { "CURRENT_TIMESTAMP" }
+      t.change_default :updated_at, from: nil, to: -> { "CURRENT_TIMESTAMP" }
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -171,8 +171,8 @@ ActiveRecord::Schema.define(version: 2021_09_09_113848) do
 
   create_table "support_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "slug"
     t.string "description"
     t.index ["slug"], name: "index_support_categories_on_slug", unique: true


### PR DESCRIPTION
## Changes in this PR

- correct migration [error](https://rollbar.com/dfe-digital/GHBS/items/71/occurrences/181744695606/) which caused `PG::DuplicateColumn`
- `timestamps` is a convenience for creation and cannot be repeated for making changes
