### PR TITLE
Custom rspec matcher for breadcrumbs, sentence case breadcrumbs

### DIFF
--- a/app/controllers/journeys_controller.rb
+++ b/app/controllers/journeys_controller.rb
@@ -54,7 +54,7 @@ class JourneysController < ApplicationController
   #
   # @see SectionPresenter
   def show
-    breadcrumb "Create Specification", journey_path(current_journey), match: :exact
+    breadcrumb "Create specification", journey_path(current_journey), match: :exact
 
     @journey = current_journey
 

--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -11,8 +11,8 @@ class SpecificationsController < ApplicationController
   #
   # @see SpecificationRenderer
   def show
-    breadcrumb "Create Specification", journey_path(current_journey), match: :exact
-    breadcrumb "View Specification", journey_specification_path(current_journey), match: :exact
+    breadcrumb "Create specification", journey_path(current_journey), match: :exact
+    breadcrumb "View specification", journey_specification_path(current_journey), match: :exact
     @journey = current_journey
 
     specification_renderer = SpecificationRenderer.new(

--- a/spec/features/self-serve/dashboard/new_journey_spec.rb
+++ b/spec/features/self-serve/dashboard/new_journey_spec.rb
@@ -14,8 +14,7 @@ RSpec.feature "Create a new journey" do
       click_create
       click_continue
 
-      expect(page.all("li.govuk-breadcrumbs__list-item").collect(&:text)).to eq \
-        ["Dashboard", "Create Specification"]
+      expect(page).to have_breadcrumbs ["Dashboard", "Create specification"]
 
       within "ul.app-task-list__items" do
         expect(find("a.govuk-link")).to have_text "Radio task"

--- a/spec/features/self-serve/journeys/category_spec.rb
+++ b/spec/features/self-serve/journeys/category_spec.rb
@@ -20,8 +20,7 @@ RSpec.feature "A journey page has" do
     let(:fixture) { "radio-question" }
 
     specify "breadcrumbs" do
-      expect(page.all("li.govuk-breadcrumbs__list-item").collect(&:text)).to eq \
-        ["Dashboard", "Create Specification"]
+      expect(page).to have_breadcrumbs ["Dashboard", "Create specification"]
     end
 
     specify do
@@ -42,8 +41,7 @@ RSpec.feature "A journey page has" do
     let(:fixture) { "mfd-radio-question" }
 
     specify "breadcrumbs" do
-      expect(page.all("li.govuk-breadcrumbs__list-item").collect(&:text)).to eq \
-        ["Dashboard", "Create Specification"]
+      expect(page).to have_breadcrumbs ["Dashboard", "Create specification"]
     end
 
     specify do

--- a/spec/features/self-serve/journeys/continue_spec.rb
+++ b/spec/features/self-serve/journeys/continue_spec.rb
@@ -14,8 +14,7 @@ RSpec.feature "Journey continue button behaviour" do
 
       click_continue
 
-      expect(page.all("li.govuk-breadcrumbs__list-item").collect(&:text)).to eq \
-        ["Dashboard", "Create Specification"]
+      expect(page).to have_breadcrumbs ["Dashboard", "Create specification"]
 
       answer = LongTextAnswer.last
 

--- a/spec/features/self-serve/journeys/download_spec.rb
+++ b/spec/features/self-serve/journeys/download_spec.rb
@@ -19,8 +19,7 @@ RSpec.feature "Users can see their catering specification" do
       click_continue
       click_view
 
-      expect(page.all("li.govuk-breadcrumbs__list-item").collect(&:text)).to eq \
-        ["Dashboard", "Create Specification", "View Specification"]
+      expect(page).to have_breadcrumbs ["Dashboard", "Create specification", "View specification"]
 
       # journey.specification.header
       expect(find("h1.govuk-heading-xl")).to have_text "Your specification"

--- a/spec/features/self-serve/journeys/view_spec.rb
+++ b/spec/features/self-serve/journeys/view_spec.rb
@@ -9,9 +9,7 @@ RSpec.feature "Users can see their specification" do
     click_continue
     click_view
 
-    # TODO: Create custom spec matcher for breadcrumbs
-    expect(page.all("li.govuk-breadcrumbs__list-item").collect(&:text)).to eq \
-      ["Dashboard", "Create Specification", "View Specification"]
+    expect(page).to have_breadcrumbs ["Dashboard", "Create specification", "View specification"]
 
     # TODO: remove I18n.t from specs
     expect(page).to have_content(I18n.t("journey.specification.header"))

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -66,3 +66,9 @@ RSpec::Matchers.define :have_an_edit_step_path do
     page.current_path.match? %r{^/journeys/#{UUID_REGEXP}/steps/#{UUID_REGEXP}/edit/?(?!.+)}
   end
 end
+
+RSpec::Matchers.define :have_breadcrumbs do |input|
+  match do |page|
+    page.all("li.govuk-breadcrumbs__list-item").collect(&:text) == input
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- Add custom rspec matcher to DRY breadcrumbs checks `have_breadcrumbs`
- Convert breadcrumbs to sentence case
