### PR TITLE
Abstract Update Case logic into separate service

### DIFF
--- a/app/controllers/support/cases_controller.rb
+++ b/app/controllers/support/cases_controller.rb
@@ -1,6 +1,7 @@
 module Support
   class CasesController < ApplicationController
     before_action :current_case, only: %i[show edit update]
+    before_action :agent, only: %i[update]
 
     def index
       @cases = Case.all.map { |c| CasePresenter.new(c) }
@@ -13,12 +14,7 @@ module Support
     end
 
     def update
-      # TODO: remove :nocov: and start testing
-      # :nocov:
-      @current_case.agent = Agent.find_by(id: params.dig(:support_case, :agent))
-      @current_case.state = "open"
-      @current_case.save!
-      # :nocov:
+      UpdateCase.new(current_case, agent).call
 
       redirect_to support_cases_path
     end
@@ -27,6 +23,10 @@ module Support
 
     def current_case
       @current_case ||= CasePresenter.new(Case.find_by(id: params[:id]))
+    end
+
+    def agent
+      @agent ||= Agent.find_by(id: params.dig(:support_case, :agent))
     end
   end
 end

--- a/app/controllers/support/cases_controller.rb
+++ b/app/controllers/support/cases_controller.rb
@@ -16,7 +16,7 @@ module Support
     def update
       UpdateCase.new(current_case, agent).call
 
-      redirect_to support_cases_path
+      redirect_to support_case_path(anchor: "case-history")
     end
 
   private

--- a/app/services/support/update_case.rb
+++ b/app/services/support/update_case.rb
@@ -1,0 +1,23 @@
+module Support
+  #
+  # Service to update an existing Case
+  #
+  class UpdateCase
+    # @param current_case [Support::Case] existing case to be updated
+    attr_reader :current_case, :agent
+
+    def initialize(current_case, agent)
+      @current_case = current_case
+      @agent = agent
+    end
+
+    # @return [Support::Case]
+    def call
+      current_case.tap do |cc|
+        cc.agent = agent
+        cc.state = "open"
+        cc.save!
+      end
+    end
+  end
+end

--- a/spec/features/support/case_edit_spec.rb
+++ b/spec/features/support/case_edit_spec.rb
@@ -24,10 +24,25 @@ RSpec.feature "Case Management Dashboard - edit" do
   end
 
   context "when assigning agent to case" do
-    before { find_button("Assign").click }
+    before do
+      find("label.govuk-radios__label", text: "John Lennon").click
+      find_button("Assign").click
+    end
 
     it "is redirected to the case in question" do
       expect(page).to have_a_support_case_path
+    end
+
+    context "when returning to the main page" do
+      before { visit "/support/cases#all-cases" }
+
+      specify "the case in question was in fact assigned to the agent" do
+        expect(find("#all-cases tr.govuk-table__row", text: "St.Mary")).to have_text "John Lennon"
+      end
+
+      specify "the case in question was opened" do
+        expect(find("#all-cases tr.govuk-table__row", text: "St.Mary")).to have_text "OPEN"
+      end
     end
   end
 end

--- a/spec/features/support/case_edit_spec.rb
+++ b/spec/features/support/case_edit_spec.rb
@@ -29,11 +29,11 @@ RSpec.feature "Case Management Dashboard - edit" do
       find_button("Assign").click
     end
 
-    it "is redirected to the case in question" do
+    it "redirects to the case in question" do
       expect(page).to have_a_support_case_path
     end
 
-    context "when returning to the main page" do
+    context "when on the case management dashboard" do
       before { visit "/support/cases#all-cases" }
 
       specify "the case in question was in fact assigned to the agent" do

--- a/spec/features/support/case_edit_spec.rb
+++ b/spec/features/support/case_edit_spec.rb
@@ -22,4 +22,12 @@ RSpec.feature "Case Management Dashboard - edit" do
   it "displays the submit button" do
     expect(find_button("Assign")).to be_present
   end
+
+  context "when assigning agent to case" do
+    before { find_button("Assign").click }
+
+    it "is redirected to the case in question" do
+      expect(page).to have_a_support_case_path
+    end
+  end
 end

--- a/spec/services/support/update_case_spec.rb
+++ b/spec/services/support/update_case_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Support::UpdateCase do
+  subject(:service) { described_class.new(current_case, agent) }
+
+  let(:current_case) { create(:support_case, state: state) }
+  let(:agent)  { create(:support_agent) }
+  let(:result) { service.call }
+
+  describe "#call" do
+    context "when a new case is given" do
+      let(:state) { "initial" }
+
+      it "opens the case" do
+        expect(result.state).to eq("open")
+      end
+
+      it "assigns the case to the appointed agent" do
+        expect(result.agent).to eq(agent)
+      end
+
+      it "returns the original case" do
+        expect(result).to eq(current_case)
+      end
+    end
+
+    context "when an already open case is given" do
+      let(:state) { "open" }
+
+      it "keeps the case open" do
+        expect(result.state).to eq("open")
+      end
+
+      it "assigns the case to the appointed agent" do
+        expect(result.agent).to eq(agent)
+      end
+
+      it "returns the original case" do
+        expect(result).to eq(current_case)
+      end
+    end
+  end
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -67,6 +67,19 @@ RSpec::Matchers.define :have_an_edit_step_path do
   end
 end
 
+# allowed:
+#   /support/cases/<UUID>
+#   /support/cases/<UUID>/
+#
+# disallowed:
+#   /support/cases/<UUID>/x
+#
+RSpec::Matchers.define :have_a_support_case_path do
+  match do |page|
+    page.current_path.match? %r{^/support/cases/#{UUID_REGEXP}/?(?!.+)}
+  end
+end
+
 RSpec::Matchers.define :have_breadcrumbs do |input|
   match do |page|
     page.all("li.govuk-breadcrumbs__list-item").collect(&:text) == input


### PR DESCRIPTION
## Changes in this PR

- Case Update logic was removed from the controller action and placed in [a self-contained testable unit](https://github.com/DFE-Digital/buy-for-your-school/pull/530/files#diff-d7bdf92c88afa3f7c447a24240ca7aac6c7b56132e0e8d92fd28b80b047adefdR5) (`Support::UpdateCase`)
- Redirect user to case page, after successful agent assignment
- [Added spec helper](https://github.com/DFE-Digital/buy-for-your-school/pull/530/files#diff-d35fdbf1d42c668f8f4c92df27b8d3f9151e36132faade568aff709c45044109R77) (following pattern already present elsewhere in the test suite)
