### PR TITLE
Reflect DSI profile changes

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -27,6 +27,7 @@ NOTIFY_API_KEY=development_team-12345678-1234-1234-1234-abcd12345678-12345678-12
 SUPPORT_EMAIL=email@example.gov.uk
 
 # DSI:
+DFE_SIGN_IN_IDENTIFIER=service
+DFE_SIGN_IN_ISSUER=https://test-oidc.signin.education.gov.uk
 DFE_SIGN_IN_API_ENDPOINT=https://test-api.signin.education.gov.uk
 DFE_SIGN_IN_API_SECRET=secret
-DFE_SIGN_IN_IDENTIFIER=service

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,15 +10,9 @@ class SessionsController < ApplicationController
     user_session.persist_successful_dfe_sign_in_claim!(auth: auth_hash)
     user_session.invalidate_other_user_sessions(auth: auth_hash)
 
-    # TODO: add functionality to update dsi account record
     CreateUser.new(auth: auth_hash).call
 
-    # TODO: redirect post login based on user role
-    # if current_user.buyer?
     redirect_to dashboard_path
-    # elsif current_user.agent?
-    #   redirect_to support_admin_path
-    # end
   end
   alias_method :bypass_callback, :create
 

--- a/spec/features/self-serve/auth/sign_in_spec.rb
+++ b/spec/features/self-serve/auth/sign_in_spec.rb
@@ -17,6 +17,38 @@ RSpec.feature "DfE Sign-in" do
       click_continue
     end
 
+    context "but their DSI details have changed" do
+      let!(:user) { create(:user) }
+
+      let(:updated_user) do
+        build(:user,
+              dfe_sign_in_uid: user.dfe_sign_in_uid,
+              email: user.email,
+              first_name: "first_name changed in DSI",
+              last_name: "last_name changed in DSI")
+      end
+
+      before do
+        # force signout
+        visit "/auth/failure"
+        # change DSI details
+        user_exists_in_dfe_sign_in(user: updated_user)
+        # DfE sign in
+        click_start
+        # check new details
+        # FIXME: assert changes are visible on /profile
+        # visit "/users"
+        user.reload
+      end
+
+      it "updates the user's names" do
+        expect(user.first_name).to eq "first_name changed in DSI"
+        expect(user.last_name).to eq "last_name changed in DSI"
+
+        # expect(find("dd.govuk-summary-list__value")[0]).to have_text "first_name changed in DSI last_name changed in DSI"
+      end
+    end
+
     context "and the user already exists" do
       let!(:user) { create(:user) }
 

--- a/spec/features/self-serve/auth/sign_out_spec.rb
+++ b/spec/features/self-serve/auth/sign_out_spec.rb
@@ -13,6 +13,9 @@ RSpec.feature "Sign out" do
     # generic.button.sign_out
     click_on "Sign out"
 
+    # or mimic failure
+    # visit "/auth/failure"
+
     expect(page.driver.request.session.keys).to be_empty
     expect(page).to have_current_path "/"
 

--- a/spec/services/self-serve/create_user_spec.rb
+++ b/spec/services/self-serve/create_user_spec.rb
@@ -8,16 +8,22 @@ RSpec.describe CreateUser do
   end
 
   let(:dfe_sign_in_uid) { "03f98d51-5a93-4caa-9ff2-07faff7351d2" }
+  let(:email) { "user@example.com" }
 
   let(:omniauth_hash) do
-    { "uid" => dfe_sign_in_uid }
+    {
+      "uid" => dfe_sign_in_uid,
+      "info" => {
+        "email" => email,
+      },
+    }
   end
 
   before do
     dsi_client = instance_double(::Dsi::Client)
     allow(Dsi::Client).to receive(:new).and_return(dsi_client)
-    allow(dsi_client).to receive(:roles)
-    allow(dsi_client).to receive(:orgs)
+    allow(dsi_client).to receive(:roles).and_raise(::Dsi::Client::ApiError)
+    allow(dsi_client).to receive(:orgs).and_raise(::Dsi::Client::ApiError)
   end
 
   describe "#call" do
@@ -25,13 +31,52 @@ RSpec.describe CreateUser do
       it "returns the existing user record" do
         expect(result).to eq user
       end
+
+      it "reports to Rollbar" do
+        expect(Rollbar).to receive(:info).with("Updated account for user@example.com").and_call_original
+
+        result
+      end
     end
 
     context "when a user with that DSI UUID does not exist in the database" do
       let(:dfe_sign_in_uid) { "an-unknown-uuid" }
+      let(:email) { "unknown@example.com" }
 
       it "creates a new user record" do
         expect(result).to eq User.find_by(dfe_sign_in_uid: "an-unknown-uuid")
+        # expect(result).to eq User.last
+      end
+
+      it "reports to Rollbar" do
+        expect(Rollbar).to receive(:info).with("User an-unknown-uuid has no organisation").and_call_original
+        expect(Rollbar).to receive(:info).with("User an-unknown-uuid has no roles").and_call_original
+        expect(Rollbar).to receive(:info).with("Created account for unknown@example.com").and_call_original
+
+        result
+      end
+    end
+
+    context "when the user has updated their details" do
+      let(:omniauth_hash) do
+        {
+          "uid" => dfe_sign_in_uid,
+          "info" => {
+            "first_name" => "New First",
+            "last_name" => "New Last",
+          },
+        }
+      end
+
+      it "updates the user record" do
+        expect(result.first_name).to eq "New First"
+        expect(result.last_name).to eq "New Last"
+      end
+    end
+
+    context "when a user has no roles or organisation in the DSI" do
+      it "raises no error" do
+        expect { result }.not_to raise_error ::Dsi::Client::ApiError
       end
     end
 

--- a/spec/support/sign_in_helpers.rb
+++ b/spec/support/sign_in_helpers.rb
@@ -1,4 +1,5 @@
 module SignInHelpers
+  # TODO: rename `user_exists_in_dfe_sign_in` to `mock_dsi_callback`
   def user_exists_in_dfe_sign_in(user: build(:user))
     # stub CreateUser call to DSI API for roles and orgs
     allow_any_instance_of(::Dsi::Client).to receive(:roles)


### PR DESCRIPTION
## Changes in this PR

- users who have previously used the service will have their names added
- changes to names within DSI will be propagated to the `users` table
- entries in the table are reported to via Rollbar when created and updated
- NB: profile changes in the test DSI environment may be slow to take effect
