### PR TITLE
Add case action links at the bottom of show screen

### DIFF
--- a/app/views/support/cases/show.html.erb
+++ b/app/views/support/cases/show.html.erb
@@ -61,7 +61,32 @@
 <h3 class="govuk-heading-m"><%= I18n.t("support.cases.actions") %></h3>
 
 <ul class="govuk-list">
-  <li>
-    <%= link_to I18n.t("support.cases.show.assign"), edit_support_case_path(@current_case), class: "govuk-link" %>
-  </li>
+  <% if @current_case.open? %>
+    <li>
+      <%= link_to I18n.t("support.cases.show.change_owner"), edit_support_case_path(@current_case), class: "change-owner" %>
+    </li>
+    <li>
+      <%= link_to I18n.t("support.cases.show.add_note"), "#", class: "add-note" %>
+    </li>
+    <li>
+      <%= link_to I18n.t("support.cases.show.send_email"), "#", class: "send-email" %>
+    </li>
+    <li>
+      <%= link_to I18n.t("support.cases.show.log_contact"), "#", class: "log-contact" %>
+    </li>
+  <% else %>
+    <li>
+      <%= link_to I18n.t("support.cases.show.assign"), edit_support_case_path(@current_case), class: "assign-owner" %>
+    </li>
+  <% end %>
+
+  <% if @current_case.resolved? %>
+    <li>
+      <%= link_to I18n.t("support.cases.show.reopen"), "#", class: "reopen" %>
+    </li>
+  <% else %>
+    <li>
+      <%= link_to I18n.t("support.cases.show.resolve"), "#", class: "resolve" %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/support/cases/show.html.erb
+++ b/app/views/support/cases/show.html.erb
@@ -56,7 +56,7 @@ show interactions
       <%= link_to I18n.t("support.cases.show.send_email"), "#", class: "send-email" %>
     </li>
     <li>
-      <%= link_to I18n.t("support.cases.show.add_interaction"), new_support_case_interaction_path(@current_case, option: :contact), class: "govuk-link log-contact"
+      <%= link_to I18n.t("support.cases.show.add_interaction"), new_support_case_interaction_path(@current_case, option: :contact), class: "govuk-link log-contact" %>
     </li>
   <% else %>
     <li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,6 +247,12 @@ en:
 
       show:
         requested_at: Request sent on %{time}
+        change_owner: Change case owner
+        add_note: Add a case note
+        send_email: Send email
+        log_contact: Log contact with school
+        resolve: Resolve case
+        reopen: Reopen case
         assign: Assign to case worker
         back: Back to case list
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -249,9 +249,7 @@ en:
       show:
         requested_at: Request sent on %{time}
         change_owner: Change case owner
-        add_note: Add a case note
         send_email: Send email
-        log_contact: Log contact with school
         resolve: Resolve case
         reopen: Reopen case
         assign: Assign to case worker

--- a/spec/features/support/case_show_spec.rb
+++ b/spec/features/support/case_show_spec.rb
@@ -1,7 +1,8 @@
 RSpec.feature "Case Management Dashboard - show" do
-  before do
-    support_case = create(:support_case)
+  let(:state) { "initial" }
+  let(:support_case) { create(:support_case, state: state) }
 
+  before do
     user_is_signed_in
     visit "/support/cases/#{support_case.id}"
   end
@@ -23,6 +24,42 @@ RSpec.feature "Case Management Dashboard - show" do
   it "School details section contain contact name" do
     within "#school-details" do
       expect(find(".govuk-summary-list")).to have_text "Contact name"
+    end
+  end
+
+  it "shows the assign link" do
+    expect(find("a.assign-owner")).to have_text "Assign to case worker"
+  end
+
+  it "shows the resolve link" do
+    expect(find("a.resolve")).to have_text "Resolve case"
+  end
+
+  context "when the case is open" do
+    let(:state) { "open" }
+
+    it "shows the change owner link" do
+      expect(find("a.change-owner")).to have_text "Change case owner"
+    end
+
+    it "shows the add note link" do
+      expect(find("a.add-note")).to have_text "Add a case note"
+    end
+
+    it "shows the send email link" do
+      expect(find("a.send-email")).to have_text "Send email"
+    end
+
+    it "show the log contact link" do
+      expect(find("a.log-contact")).to have_text "Log contact with school"
+    end
+  end
+
+  context "when the case is resolved" do
+    let(:state) { "resolved" }
+
+    it "shows the reopen case link" do
+      expect(find("a.reopen")).to have_text "Reopen case"
     end
   end
 end

--- a/spec/features/support/interactions/new_interaction_spec.rb
+++ b/spec/features/support/interactions/new_interaction_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature "Add new interaction to case" do
-  let(:support_case) { create(:support_case) }
+  let(:support_case) { create(:support_case, state: 1) }
   let(:agent) { create(:support_agent) }
 
   context "when agent is signed in" do


### PR DESCRIPTION
## Changes in this PR

- Added case action links at the bottom of the Cases show screen
- Links for assigning / re-assigning (case to a worker) work as the functionality is already present

## Screenshots of UI changes

<img width="697" alt="Screenshot 2021-09-24 at 08 13 53" src="https://user-images.githubusercontent.com/14028045/134633625-ce49eb24-eaf3-472f-acf7-1fc95f5ba661.png">

## Next steps

- Merge PR
