### PR TITLE
Fix running a subset of specs in the docker test env

### DIFF
--- a/script/spec
+++ b/script/spec
@@ -7,7 +7,7 @@ set -e
 COMMAND_INPUT=$1
 
 if [ -n "$COMMAND_INPUT" ]; then
-  docker-compose -f docker-compose.test.yml run --rm test bundle exec "$COMMAND_INPUT"
+  docker-compose -f docker-compose.test.yml run --rm test bundle exec rspec "$COMMAND_INPUT"
 else
   docker-compose -f docker-compose.test.yml run --rm test bundle exec rake
 fi


### PR DESCRIPTION
## Changes in this PR

A single spec can be run using `script/spec`

