### PR TITLE
Fix specification appearance

### DIFF
--- a/app/assets/stylesheets/components/_specification.scss
+++ b/app/assets/stylesheets/components/_specification.scss
@@ -16,6 +16,11 @@
     @extend .govuk-list--number;
   }
 
+  ul {
+    @extend .govuk-list;
+    @extend .govuk-list--bullet;
+  }
+
   table {
     @extend .govuk-table !optional;
   }

--- a/app/assets/stylesheets/components/_specification.scss
+++ b/app/assets/stylesheets/components/_specification.scss
@@ -1,3 +1,8 @@
+/**
+* Specification templates have no classes of their own so we're overriding the default styling to
+* keep the look consistent.
+**/
+
 #specification, .specification {
   h2 {
     @extend .govuk-heading-m;

--- a/app/presenters/long_text_answer_presenter.rb
+++ b/app/presenters/long_text_answer_presenter.rb
@@ -1,11 +1,4 @@
 class LongTextAnswerPresenter < SimpleDelegator
-  include ActionView::Helpers::TextHelper
-
-  # @return [String]
-  def response
-    simple_format(super)
-  end
-
   # @return [Hash]
   def to_param
     {

--- a/app/services/document_formatter.rb
+++ b/app/services/document_formatter.rb
@@ -1,6 +1,7 @@
 require "dry-initializer"
 require "types"
 require "pandoc-ruby"
+require "pry"
 
 # Document converter
 #
@@ -18,6 +19,7 @@ class DocumentFormatter
   #
   # @return [String]
   def call
+    # binding.pry
     PandocRuby.convert(content, "--strip-comments", from: from, to: to).to_s
   end
 end

--- a/app/services/document_formatter.rb
+++ b/app/services/document_formatter.rb
@@ -1,7 +1,6 @@
 require "dry-initializer"
 require "types"
 require "pandoc-ruby"
-require "pry"
 
 # Document converter
 #
@@ -19,7 +18,6 @@ class DocumentFormatter
   #
   # @return [String]
   def call
-    # binding.pry
     PandocRuby.convert(content, "--strip-comments", from: from, to: to).to_s
   end
 end

--- a/app/services/document_formatter.rb
+++ b/app/services/document_formatter.rb
@@ -18,6 +18,6 @@ class DocumentFormatter
   #
   # @return [String]
   def call
-    PandocRuby.convert(content, from: from, to: to).to_s
+    PandocRuby.convert(content, "--strip-comments", from: from, to: to).to_s
   end
 end

--- a/app/services/document_formatter.rb
+++ b/app/services/document_formatter.rb
@@ -14,7 +14,8 @@ class DocumentFormatter
   option :from, ReaderFormats
   option :to, WriterFormats
 
-  # Return the converted document
+  # Return the converted document.
+  # HTML comments are stripped out.
   #
   # @return [String]
   def call

--- a/app/services/document_formatter.rb
+++ b/app/services/document_formatter.rb
@@ -19,6 +19,6 @@ class DocumentFormatter
   #
   # @return [String]
   def call
-    PandocRuby.convert(content, "--strip-comments", from: from, to: to).to_s
+    PandocRuby.convert(content, "--strip-comments", from: from, to: to)
   end
 end

--- a/app/views/pages/planning_start_page.html.erb
+++ b/app/views/pages/planning_start_page.html.erb
@@ -267,7 +267,7 @@
         </span>
       </h2>
     </div>
-    <div id="accordion-default-content-6" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+    <div id="accordion-default-content-7" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
       <p class="govuk-body">Once you have your specification, you will need to decide if you will be using the open or restricted procedure.</p>
       <p class="govuk-body">You can then prepare your invitation to tender.</p>
       <p class="govuk-body">Find out what the next steps are if you are:</p>

--- a/app/views/specifications/show.html.erb
+++ b/app/views/specifications/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, @journey.category.title.capitalize %>
+<%= content_for :title, @journey.category.title %>
 
 <h1 class="govuk-heading-xl"><%= I18n.t("journey.specification.header") %></h1>
 <p class="govuk-body"><%= I18n.t("journey.specification.body") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,7 +136,7 @@ en:
 
   # /journeys#show
   journeys_title: Create a specification to procure %{category} for your school
-  journeys_body: Answer all questions in each section to build a specification to share with suppliers. You can work through the sections in any order, and come back to questions later by skipping those you can't answer yet. View your specification at any time.
+  journeys_body: Answer all questions in each section to create a specification to share with suppliers. You can work through the sections in any order, and come back to questions later by skipping those you can't answer yet. View your specification at any time.
   task_list:
     status:
       not_started: Not started

--- a/spec/features/self-serve/journeys/category_spec.rb
+++ b/spec/features/self-serve/journeys/category_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "A journey page has" do
 
     specify do
       # journeys_body
-      expect(find("p.govuk-body")).to have_text "Answer all questions in each section to build a specification to share with suppliers. You can work through the sections in any order, and come back to questions later by skipping those you can't answer yet. View your specification at any time."
+      expect(find("p.govuk-body")).to have_text "Answer all questions in each section to create a specification to share with suppliers. You can work through the sections in any order, and come back to questions later by skipping those you can't answer yet. View your specification at any time."
     end
   end
 
@@ -64,7 +64,7 @@ RSpec.feature "A journey page has" do
 
     specify do
       # journeys_body
-      expect(find("p.govuk-body")).to have_text "Answer all questions in each section to build a specification to share with suppliers. You can work through the sections in any order, and come back to questions later by skipping those you can't answer yet. View your specification at any time."
+      expect(find("p.govuk-body")).to have_text "Answer all questions in each section to create a specification to share with suppliers. You can work through the sections in any order, and come back to questions later by skipping those you can't answer yet. View your specification at any time."
     end
   end
 end

--- a/spec/features/self-serve/landing/body_spec.rb
+++ b/spec/features/self-serve/landing/body_spec.rb
@@ -15,6 +15,10 @@ RSpec.feature "Users can see a start page" do
     expect(find("h1.govuk-heading-xl")).to have_text "Create a specification to procure for your school"
   end
 
+  it "has the right content headers" do
+    expect(page).to have_xpath("//meta[@name=\"robots\" and contains(@content, \"noindex,nofollow\")]", visible: :hidden)
+  end
+
   # Who this service is for
   # How this service works
   scenario do

--- a/spec/features/self-serve/planning/start_page_spec.rb
+++ b/spec/features/self-serve/planning/start_page_spec.rb
@@ -2,45 +2,49 @@ RSpec.feature "Users can see a start page for planning their purchase" do
   scenario "Start page content is shown on the root path" do
     visit "/planning"
 
-    expect(page).to have_content("Catering services")
-    expect(page).to have_content("How to procure a catering contract for your school.")
+    expect(find("h1.govuk-heading-xl")).to have_text "Catering services"
+    expect(all("p.govuk-body")[0]).to have_text "How to procure a catering contract for your school."
 
-    expect(page).to have_content("Before you start")
-    page.find(:xpath, "//*[contains(text(),'Before you start')]").click
-    expect(page).to have_content("A catering contract typically takes between 3 to 6 months to complete.")
+    within("div.govuk-accordion") do
+      expect(all("span.govuk-accordion__section-button")[0]).to have_text "Before you start"
+      within("div#accordion-default-content-1") do
+        expect(all("p.govuk-body")[0]).to have_text "A catering contract typically takes between 3 to 6 months to complete."
+      end
 
-    expect(page).to have_content("Ways to procure a catering contract")
-    page.find(:xpath, "//*[contains(text(),'Ways to procure a catering contract')]").click
-    expect(page).to have_content("A catering contract is a high value procurement. We generally say high is over 40,000.")
+      expect(all("span.govuk-accordion__section-button")[1]).to have_text "Ways to procure a catering contract"
+      within("div#accordion-default-content-2") do
+        expect(all("p.govuk-body")[0]).to have_text "A catering contract is a high value procurement. We generally say high is over 40,000."
+      end
 
-    expect(page).to have_content("Rules, regulations and requirements")
-    page.find(:xpath, "//*[contains(text(),'Rules, regulations and requirements')]").click
-    expect(page).to have_content("You'll need to be aware of some of the rules, regulations and requirements that can apply to a catering contract.")
+      expect(all("span.govuk-accordion__section-button")[2]).to have_text "Rules, regulations and requirements"
+      within("div#accordion-default-content-3") do
+        expect(all("p.govuk-body")[0]).to have_text "You'll need to be aware of some of the rules, regulations and requirements that can apply to a catering contract."
+      end
 
-    expect(page).to have_content("In-house catering")
-    page.find(:xpath, "//*[contains(text(),'In-house catering')]").click
-    expect(page).to have_content("Running the service in-house is another option. You may want to consider whether this is right for your school before you procure a contract. There are benefits and challenges to running the service yourself.")
+      expect(all("span.govuk-accordion__section-button")[3]).to have_text "In-house catering"
+      within("div#accordion-default-content-4") do
+        expect(all("p.govuk-body")[0]).to have_text "Running the service in-house is another option. You may want to consider whether this is right for your school before you procure a contract. There are benefits and challenges to running the service yourself."
+      end
 
-    expect(page).to have_content("Starting a procurement process")
-    page.find(:xpath, "//*[contains(text(),'Starting a procurement process')]").click
-    expect(page).to have_content("Who to involve")
+      expect(all("span.govuk-accordion__section-button")[4]).to have_text "Starting a procurement process"
+      within("div#accordion-default-content-5") do
+        expect(all("h3.govuk-heading-m")[0]).to have_text "Who to involve"
+      end
 
-    expect(page).to have_content("Writing your requirements")
-    page.find(:xpath, "//*[contains(text(),'Writing your requirements')]").click
-    expect(page).to have_content("This is the document that you give to suppliers explaining what you want to buy, sometimes called a specification.")
-    expect(page).to have_link("use our tool to create a specification", href: root_path)
+      expect(all("span.govuk-accordion__section-button")[5]).to have_text "Writing your requirements"
+      within("div#accordion-default-content-6") do
+        expect(all("p.govuk-body")[0]).to have_text "This is the document that you give to suppliers explaining what you want to buy, sometimes called a specification."
+        expect(all("p.govuk-body")[3]).to have_link("use our tool to create a specification", href: "/")
+      end
 
-    expect(page).to have_content("What to do next")
-    page.find(:xpath, "//*[contains(text(),'What to do next')]").click
-    expect(page).to have_content("Once you have your specification, you will need to decide if you will be using the open or restricted procedure.")
+      expect(all("span.govuk-accordion__section-button")[6]).to have_text "What to do next"
+      within("div#accordion-default-content-7") do
+        expect(all("p.govuk-body")[0]).to have_text "Once you have your specification, you will need to decide if you will be using the open or restricted procedure."
+      end
+    end
 
-    expect(page).to have_content("Where to get help")
-    expect(page).to have_content("See where to get help with buying for schools if you need it.")
-    expect(page).to have_link("get help with buying for schools", href: "https://www.gov.uk/guidance/buying-for-schools/get-help-with-buying-for-schools")
-  end
-
-  scenario "the start page has the right content headers" do
-    visit root_path
-    expect(page).to have_xpath("//meta[@name=\"robots\" and contains(@content, \"noindex,nofollow\")]", visible: :hidden)
+    expect(find("h2.govuk-heading-m")).to have_text "Where to get help"
+    expect(all("p.govuk-body").last).to have_text "See where to get help with buying for schools if you need it."
+    expect(all("p.govuk-body").last).to have_link("get help with buying for schools", href: "https://www.gov.uk/guidance/buying-for-schools/get-help-with-buying-for-schools")
   end
 end

--- a/spec/features/self-serve/planning/start_page_spec.rb
+++ b/spec/features/self-serve/planning/start_page_spec.rb
@@ -1,9 +1,6 @@
 RSpec.feature "Users can see a start page for planning their purchase" do
-  # TODO: reinstate spec once new content is finalised
-  xscenario "Start page content is shown on the root path" do
-    visit root_path
-
-    click_on("procuring a new catering service for a school")
+  scenario "Start page content is shown on the root path" do
+    visit "/planning"
 
     expect(page).to have_content("Catering services")
     expect(page).to have_content("How to procure a catering contract for your school.")
@@ -40,18 +37,6 @@ RSpec.feature "Users can see a start page for planning their purchase" do
     expect(page).to have_content("Where to get help")
     expect(page).to have_content("See where to get help with buying for schools if you need it.")
     expect(page).to have_link("get help with buying for schools", href: "https://www.gov.uk/guidance/buying-for-schools/get-help-with-buying-for-schools")
-  end
-
-  xscenario "can navigate back to the home page" do
-    visit root_path
-
-    click_on("procuring a new catering service for a school")
-
-    expect(page).to have_content(I18n.t("planning.start_page.page_title"))
-
-    click_on(I18n.t("generic.button.back"))
-
-    expect(find("h1.govuk-heading-xl")).to have_text "Create a specification to procure something for your school"
   end
 
   scenario "the start page has the right content headers" do

--- a/spec/features/self-serve/steps/presenter_spec.rb
+++ b/spec/features/self-serve/steps/presenter_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "User answers are rendered correctly based on type" do
     fill_in "answer[response]", with: "\r\n\r\nfoo\r\n\r\n"
     click_on "Continue"
     click_on "Back"
-    expect(page.html).to include "<p></p>\n\n<p>foo</p>"
+    expect(page).to have_text "\r\r \r\r foo\r\r \r\r"
   end
 
   # CurrencyAnswerPresenter#response

--- a/spec/features/self-serve/steps/presenter_spec.rb
+++ b/spec/features/self-serve/steps/presenter_spec.rb
@@ -1,4 +1,3 @@
-# TODO: Use new custom path matchers after each page change (example given below)
 RSpec.feature "User answers are rendered correctly based on type" do
   let(:user) { create(:user) }
 
@@ -29,63 +28,94 @@ RSpec.feature "User answers are rendered correctly based on type" do
     expect(page).to have_a_step_path
     click_on "Back"
     expect(page).to have_a_task_path
-    expect(page).to have_content "Cleaning"
+    within("div.govuk-summary-list__row", text: "Which service do you need?") do
+      expect(find("dd.govuk-summary-list__value")).to have_text "Cleaning"
+    end
   end
 
   # ShortTextAnswerPresenter#response
   specify do
     click_link "short_text"
+    expect(page).to have_a_step_path
     fill_in "answer[response]", with: "hello_world@example.com"
     click_on "Continue"
+    expect(page).to have_a_step_path
     click_on "Back"
-    expect(page).to have_content "hello_world@example.com"
+    expect(page).to have_a_task_path
+    within("div.govuk-summary-list__row", text: "What email address did you use?") do
+      expect(find("dd.govuk-summary-list__value")).to have_text "hello_world@example.com"
+    end
   end
 
   # LongTextAnswerPresenter#response
   specify do
     click_link "long_text"
+    expect(page).to have_a_step_path
     fill_in "answer[response]", with: "\r\n\r\nfoo\r\n\r\n"
     click_on "Continue"
+    expect(page).to have_a_step_path
     click_on "Back"
-    expect(page).to have_text "\r\r \r\r foo\r\r \r\r"
+    expect(page).to have_a_task_path
+    within("div.govuk-summary-list__row", text: "Describe what you need") do
+      expect(find("dd.govuk-summary-list__value")).to have_text "foo"
+    end
   end
 
   # CurrencyAnswerPresenter#response
   specify do
     click_link "currency"
+    expect(page).to have_a_step_path
     fill_in "answer[response]", with: "2,999.99001"
     click_on "Continue"
+    expect(page).to have_a_step_path
     click_on "Back"
-    expect(page).to have_content "£2,999.99"
+    expect(page).to have_a_task_path
+    within("div.govuk-summary-list__row", text: "What funds does the school have available for the maintenance or replacement of heavy equipment in the coming year?") do
+      expect(find("dd.govuk-summary-list__value")).to have_text "£2,999.99"
+    end
   end
 
   # NumberAnswerPresenter#response
   specify do
     click_link "number"
+    expect(page).to have_a_step_path
     fill_in "answer[response]", with: "123"
     click_on "Continue"
+    expect(page).to have_a_step_path
     click_on "Back"
-    expect(page).to have_content "123"
+    expect(page).to have_a_task_path
+    within("div.govuk-summary-list__row", text: "How many days of the year will the service operate?") do
+      expect(find("dd.govuk-summary-list__value")).to have_text "123"
+    end
   end
 
   # SingleDateAnswerPresenter#response
   specify do
     click_link "single_date"
+    expect(page).to have_a_step_path
     fill_in "answer[response(3i)]", with: "1"
     fill_in "answer[response(2i)]", with: "6"
     fill_in "answer[response(1i)]", with: "2021"
     click_on "Continue"
-    expect(page).to have_content "1 Jun 2021"
+    expect(page).to have_a_task_path
+    within("div.govuk-summary-list__row", text: "When will this start?") do
+      expect(find("dd.govuk-summary-list__value")).to have_text "1 Jun 2021"
+    end
   end
 
   # CheckboxesAnswerPresenter#concatenated_response
   specify do
     click_link "checkboxes"
+    expect(page).to have_a_step_path
     check "Lunch"
     check "Dinner"
     click_on "Continue"
+    expect(page).to have_a_step_path
     click_on "Back"
-    expect(page).not_to have_content '["Lunch", "Dinner"]'
-    expect(page).to have_content "Lunch, Dinner"
+    expect(page).to have_a_task_path
+    within("div.govuk-summary-list__row", text: "Everyday services that are required and need to be considered") do
+      expect(find("dd.govuk-summary-list__value")).to have_text "Lunch, Dinner"
+      expect(find("dd.govuk-summary-list__value")).not_to have_text '["Lunch", "Dinner"]'
+    end
   end
 end

--- a/spec/presenters/self-serve/long_text_answer_presenter_spec.rb
+++ b/spec/presenters/self-serve/long_text_answer_presenter_spec.rb
@@ -1,26 +1,9 @@
-require "rails_helper"
-
 RSpec.describe LongTextAnswerPresenter do
-  describe "#response" do
-    it "returns the response in HTML using the Rails simple_format method" do
-      step = build(:long_text_answer, response: "Lots of text")
-      presenter = described_class.new(step)
-      expect(presenter.response).to eq "Lots of text"
-    end
-
-    context "when the text includes line breaks" do
-      it "returns 2 HTML paragraphs" do
-        step = build(:long_text_answer, response: "First line\r\nSecond line")
-        presenter = described_class.new(step)
-        expect(presenter.response).to eq "First line\r\nSecond line"
-      end
-    end
-  end
+  let(:presenter) { described_class.new(step) }
+  let(:step) { build(:long_text_answer, response: "First line\r\nSecond line") }
 
   describe "#to_param" do
     it "returns a hash of long_text_answer" do
-      step = build(:long_text_answer, response: "First line\r\nSecond line")
-      presenter = described_class.new(step)
       expect(presenter.to_param).to eql({ response: "First line\r\nSecond line" })
     end
   end

--- a/spec/presenters/self-serve/long_text_answer_presenter_spec.rb
+++ b/spec/presenters/self-serve/long_text_answer_presenter_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe LongTextAnswerPresenter do
     it "returns the response in HTML using the Rails simple_format method" do
       step = build(:long_text_answer, response: "Lots of text")
       presenter = described_class.new(step)
-      expect(presenter.response).to eq("<p>Lots of text</p>")
+      expect(presenter.response).to eq "Lots of text"
     end
 
     context "when the text includes line breaks" do
       it "returns 2 HTML paragraphs" do
         step = build(:long_text_answer, response: "First line\r\nSecond line")
         presenter = described_class.new(step)
-        expect(presenter.response).to eq("<p>First line\n<br />Second line</p>")
+        expect(presenter.response).to eq "First line\r\nSecond line"
       end
     end
   end
@@ -21,7 +21,7 @@ RSpec.describe LongTextAnswerPresenter do
     it "returns a hash of long_text_answer" do
       step = build(:long_text_answer, response: "First line\r\nSecond line")
       presenter = described_class.new(step)
-      expect(presenter.to_param).to eql({ response: "<p>First line\n<br />Second line</p>" })
+      expect(presenter.to_param).to eql({ response: "First line\r\nSecond line" })
     end
   end
 end

--- a/spec/services/self-serve/document_formatter_spec.rb
+++ b/spec/services/self-serve/document_formatter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DocumentFormatter do
 
       expect(PandocRuby)
       .to receive(:convert)
-      .with(md, { from: :markdown, to: :docx })
+      .with(md, "--strip-comments", { from: :markdown, to: :docx })
       .and_call_original
 
       formatter.call
@@ -18,7 +18,7 @@ RSpec.describe DocumentFormatter do
 
       expect(PandocRuby)
       .to receive(:convert)
-      .with(md, { from: :markdown, to: :html })
+      .with(md, "--strip-comments", { from: :markdown, to: :html })
       .and_call_original
 
       html = formatter.call
@@ -31,7 +31,7 @@ RSpec.describe DocumentFormatter do
 
       expect(PandocRuby)
       .to receive(:convert)
-      .with(md, { from: :markdown, to: :pdf })
+      .with(md, "--strip-comments", { from: :markdown, to: :pdf })
       .and_call_original
 
       formatter.call

--- a/spec/services/self-serve/get_answers_for_steps_spec.rb
+++ b/spec/services/self-serve/get_answers_for_steps_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe GetAnswersForSteps do
         result = described_class.new(visible_steps: [answer.step]).call
         assertion = {
           "answer_#{answer.step.contentful_id}" => {
-            response: "<p>Red</p>\n\n<p>Blue</p>",
+            response: "Red\r\n\r\n\r\nBlue",
           },
         }
 


### PR DESCRIPTION
## Changes in this PR

- add `govuk` styling to unordered lists
- have Pandoc strip comments when converting specifications
- other changes made in Contentful to fix Markdown

## Screenshots of UI changes

### Before

![image](https://user-images.githubusercontent.com/12530193/135068449-b5a47543-78cd-45ae-a10b-80b952902a21.png)

### After

![image](https://user-images.githubusercontent.com/12530193/135438888-7a953c93-2bd8-4670-872c-e379469011c6.png)