### PR TITLE
Error pages not working

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,8 @@ module BuyForYourSchool
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]
     config.i18n.default_locale = :en
     config.i18n.enforce_available_locales = false
+
+    # Custom exception page handling
+    config.exceptions_app = routes
   end
 end

--- a/spec/features/self-serve/errors/custom_errors_spec.rb
+++ b/spec/features/self-serve/errors/custom_errors_spec.rb
@@ -1,0 +1,38 @@
+RSpec.feature "Custom Errors" do
+  context "when the page does not exist (404)" do
+    before do
+      Rails.application.env_config["action_dispatch.show_exceptions"] = true
+      Rails.application.env_config["action_dispatch.show_detailed_exceptions"] = false
+      Rails.application.env_config["consider_all_requests_local"] = false
+    end
+
+    after do
+      Rails.application.env_config["action_dispatch.show_exceptions"] = false
+      Rails.application.env_config["consider_all_requests_local"] = true
+    end
+
+    it "shows the expected error message" do
+      visit "/foo"
+      # errors.not_found.page_title
+      expect(find("h2.govuk-heading-xl")).to have_text "Page not found"
+      # errors.not_found.page_body
+      expect(all("p.govuk-body").first).to have_text "Page not found. If you typed the web address, check it is correct. If you pasted the web address, check you copied the entire address."
+    end
+  end
+
+  it "the 500 error page shows the expected error message" do
+    visit "/500"
+    # errors.internal_server_error.page_title
+    expect(find("h2.govuk-heading-xl")).to have_text "Internal server error"
+    # errors.internal_server_error.page_body
+    expect(all("p.govuk-body").first).to have_text "Sorry, there is a problem with the service. Please try again later."
+  end
+
+  it "the 422 error page shows the expected error message" do
+    visit "/422"
+    # errors.unacceptable.page_title
+    expect(find("h2.govuk-heading-xl")).to have_text "Unacceptable request"
+    # errors.unacceptable.page_body
+    expect(all("p.govuk-body").first).to have_text "There was a problem with your request."
+  end
+end

--- a/spec/requests/self-serve/errors_spec.rb
+++ b/spec/requests/self-serve/errors_spec.rb
@@ -1,30 +1,22 @@
-require "rails_helper"
-
 RSpec.describe "Errors", type: :request do
   describe "internal_server_error" do
-    it "the 500 endpoint returns the expected status and error message" do
+    it "the 500 endpoint returns the expected status" do
       get "/500"
       expect(response).to have_http_status(:internal_server_error)
-      expect(response.body).to include(I18n.t("errors.internal_server_error.page_title"))
-      expect(response.body).to include(I18n.t("errors.internal_server_error.page_body"))
     end
   end
 
   describe "not_found" do
-    it "the 404 endpoint returns the expected status and error message" do
+    it "the 404 endpoint returns the expected status" do
       get "/404"
       expect(response).to have_http_status(:not_found)
-      expect(response.body).to include(I18n.t("errors.not_found.page_title"))
-      expect(response.body).to include(I18n.t("errors.not_found.page_body"))
     end
   end
 
   describe "unacceptable" do
-    it "the 422 endpoint returns the expected status and error message" do
+    it "the 422 endpoint returns the expected status" do
       get "/422"
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include(I18n.t("errors.unacceptable.page_title"))
-      expect(response.body).to include(I18n.t("errors.unacceptable.page_body"))
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

- use custom error page routes to handle HTTP exceptions