### PR TITLE
Relink orphaned support start page

### DIFF
--- a/app/controllers/support_requests_controller.rb
+++ b/app/controllers/support_requests_controller.rb
@@ -61,7 +61,7 @@ class SupportRequestsController < ApplicationController
       else
         support_request.update!(**support_request.attributes.symbolize_keys, **@support_form.to_h)
 
-        redirect_to support_request_path(support_request), notice: I18n.t("support_requests.flash.updated")
+        redirect_to support_request_path(support_request), notice: I18n.t("support_request.flash.updated")
       end
 
     else

--- a/app/forms/support_form_schema.rb
+++ b/app/forms/support_form_schema.rb
@@ -28,7 +28,7 @@ class SupportFormSchema < Dry::Validation::Contract
   rule(:phone_number).validate(max_size?: 11, format?: /(^$|^0\d{10,}$)/)
 
   rule(:journey_id, :category_id) do
-    key(:category_id).failure(:no_spec) if key?(:category_id) && values[:category_id].blank? && values[:journey_id].eql?("none")
+    key(:category_id).failure(:no_spec) if key?(:category_id) && values[:category_id].blank? && ["none", ""].include?(values[:journey_id])
   end
 
   rule(:message_body) do

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-xl"><%= I18n.t("dashboard.header") %></h1>
 
     <div class="govuk-inset-text">
-      <%= link_to "Request free help and support with your specification", profile_path %>
+      <%= link_to I18n.t("support_request.link"), support_requests_path, class: "govuk-link" %>
     </div>
 
     <% if @journeys.none? %>

--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -6,7 +6,7 @@
 <p class="govuk-body"><%= I18n.t("journeys_body") %></p>
 
 <div class="govuk-inset-text">
-  <%= link_to "Request free help and support with your specification", profile_path %>
+  <%= link_to I18n.t("support_request.link"), support_requests_path, class: "govuk-link" %>
 </div>
 
 <ol class="app-task-list sections">

--- a/app/views/support_requests/_form/_step_1.html.erb
+++ b/app/views/support_requests/_form/_step_1.html.erb
@@ -1,6 +1,6 @@
 <%= form.govuk_text_field :phone_number,
                           autofocus: true,
-                          caption: { text: I18n.t("support_requests.caption.phone_number"), size: "l" },
-                          label: { text: I18n.t("support_requests.label.phone_number"), size: "l" },
-                          hint:  { text: I18n.t("support_requests.hint.phone_number") }
+                          caption: { text: I18n.t("support_request.caption.phone_number"), size: "l" },
+                          label: { text: I18n.t("support_request.label.phone_number"), size: "l" },
+                          hint:  { text: I18n.t("support_request.hint.phone_number") }
                         %>

--- a/app/views/support_requests/_form/_step_2.html.erb
+++ b/app/views/support_requests/_form/_step_2.html.erb
@@ -5,9 +5,9 @@
     :id,
     :created_at,
     :description,
-    caption: { text: I18n.t("support_requests.caption.specification"), size: "l" },
-    legend: { text: I18n.t("support_requests.label.specification"), size: "l" },
-    hint: { text: I18n.t("support_requests.hint.specification") }
+    caption: { text: I18n.t("support_request.caption.specification"), size: "l" },
+    legend: { text: I18n.t("support_request.label.specification"), size: "l" },
+    hint: { text: I18n.t("support_request.hint.specification") }
 %>
 
 <%= form.govuk_radio_divider %>

--- a/app/views/support_requests/_form/_step_3.html.erb
+++ b/app/views/support_requests/_form/_step_3.html.erb
@@ -6,7 +6,7 @@
     :id,
     :title,
     :description,
-    legend: { text: I18n.t("support_requests.label.category"), size: "l" },
-    caption: { text: I18n.t("support_requests.caption.category"), size: "l" }
+    legend: { text: I18n.t("support_request.label.category"), size: "l" },
+    caption: { text: I18n.t("support_request.caption.category"), size: "l" }
 %>
 

--- a/app/views/support_requests/_form/_step_4.html.erb
+++ b/app/views/support_requests/_form/_step_4.html.erb
@@ -6,7 +6,7 @@
       autofocus: true,
       class: "govuk-textarea",
       rows: 5,
-      caption: { text: I18n.t("support_requests.caption.message"), size: "l" },
-      label: { text: I18n.t("support_requests.label.message"), size: "l" },
-      hint: { text: I18n.t("support_requests.hint.message") }
+      caption: { text: I18n.t("support_request.caption.message"), size: "l" },
+      label: { text: I18n.t("support_request.label.message"), size: "l" },
+      hint: { text: I18n.t("support_request.hint.message") }
     %>

--- a/app/views/support_requests/index.html.erb
+++ b/app/views/support_requests/index.html.erb
@@ -2,10 +2,10 @@
   <div class="govuk-grid-column-two-thirds">
 
     <h1 class="govuk-heading-xl">
-      <%= I18n.t("support_requests.heading") %>
+      <%= I18n.t("support_request.heading") %>
     </h1>
 
-    <% I18n.t("support_requests.intro").each do |paragraph| %>
+    <% I18n.t("support_request.intro").each do |paragraph| %>
       <p class="govuk-body"><%= paragraph %></p>
     <% end %>
 
@@ -18,7 +18,7 @@
     </a>
 
     <h2 class="govuk-heading-m">
-      <%= I18n.t("support_requests.subheading") %>
+      <%= I18n.t("support_request.subheading") %>
     </h2>
 
     <p class="govuk-body">You can:</p>

--- a/app/views/support_requests/show.html.erb
+++ b/app/views/support_requests/show.html.erb
@@ -8,10 +8,10 @@
     <% if @support_request.submitted? %>
       <h1 class="govuk-heading-l">Your request has been submitted</h1>
     <% else %>
-      <h1 class="govuk-heading-l"><%= I18n.t("support_requests.section.submit_request") %></h1>
+      <h1 class="govuk-heading-l"><%= I18n.t("support_request.section.submit_request") %></h1>
     <% end %>
 
-    <h2 class="govuk-heading-m"><%= I18n.t("support_requests.section.about_you") %></h2>
+    <h2 class="govuk-heading-m"><%= I18n.t("support_request.section.about_you") %></h2>
 
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
@@ -43,12 +43,14 @@
         </dd>
 
         <dd class="govuk-summary-list__actions">
-          <%= link_to I18n.t("generic.button.change_answer"), edit_support_request_path(@support_request, step: 1), class: "govuk-link", id: "edit-phone-number" %>
+          <% unless @support_request.submitted? %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_support_request_path(@support_request, step: 1), class: "govuk-link", id: "edit-phone-number" %>
+          <% end %>
         </dd>
       </div>
     </dl>
 
-    <h2 class="govuk-heading-m"><%= I18n.t("support_requests.section.request_summary") %></h2>
+    <h2 class="govuk-heading-m"><%= I18n.t("support_request.section.request_summary") %></h2>
 
     <dl class="govuk-summary-list">
 
@@ -64,7 +66,7 @@
           <% end %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <% if @current_user.journeys.any? %>
+          <% if @current_user.journeys.any? && !@support_request.submitted? %>
             <%= link_to I18n.t("generic.button.change_answer"), edit_support_request_path(@support_request, step: 2), class: "govuk-link", id: "edit-specification" %>
           <% end %>
         </dd>
@@ -72,7 +74,7 @@
 
       <div id="support-request-category" class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          <%= I18n.t("support_requests.label.category") %>
+          <%= I18n.t("support_request.label.category") %>
         </dt>
         <dd class="govuk-summary-list__value">
           <% if @support_request.journey %>
@@ -82,29 +84,33 @@
           <% end %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to I18n.t("generic.button.change_answer"), edit_support_request_path(@support_request, step: 3), class: "govuk-link", id: "edit-category" %>
+          <% unless @support_request.submitted? %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_support_request_path(@support_request, step: 3), class: "govuk-link", id: "edit-category" %>
+          <% end %>
         </dd>
       </div>
 
       <div id="support-request-message" class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Description of problem
+          <%= I18n.t("support_request.label.message") %>
         </dt>
         <dd class="govuk-summary-list__value">
           <%= @support_request.message_body %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to I18n.t("generic.button.change_answer"), edit_support_request_path(@support_request, step: 4), class: "govuk-link", id: "edit-message" %>
+          <% unless @support_request.submitted? %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_support_request_path(@support_request, step: 4), class: "govuk-link", id: "edit-message" %>
+          <% end %>
         </dd>
       </div>
     </dl>
 
     <% unless @support_request.submitted? %>
       <p class="govuk-body">
-        <%= I18n.t("support_requests.response_time") %>
+        <%= I18n.t("support_request.response_time") %>
       </p>
 
-      <%= button_to I18n.t("support_requests.button.send"), submit_request_path(id: @support_request), class: "govuk-button", method: :post, data: { disable_with: "Submitted!" } %>
+      <%= button_to I18n.t("support_request.button.send"), submit_request_path(id: @support_request), class: "govuk-button", method: :post, data: { disable_with: "Submitted!" } %>
     <% end %>
 
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,7 +171,8 @@ en:
       email: Your email address
 
   # /support-requests
-  support_requests:
+  support_request:
+    link: Request free help and support with your specification
     flash:
       created: Support request created
       updated: Support request updated

--- a/spec/features/self-serve/dashboard/dashboard_spec.rb
+++ b/spec/features/self-serve/dashboard/dashboard_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Specification dashboard" do
     end
 
     it "offers support with requests" do
-      expect(page).to have_link "Request free help and support with your specification", href: "/profile" # , class: "govuk-link"
+      expect(page).to have_link "Request free help and support with your specification", href: "/support-requests", class: "govuk-link"
     end
   end
 end

--- a/spec/features/self-serve/journeys/task_list/view_steps_spec.rb
+++ b/spec/features/self-serve/journeys/task_list/view_steps_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Users can view the task list" do # journeys#show
   it { expect(page).to have_a_journey_path }
 
   it "offers support with requests" do
-    expect(page).to have_link "Request free help and support with your specification", href: "/profile" # , class: "govuk-link"
+    expect(page).to have_link "Request free help and support with your specification", href: "/support-requests", class: "govuk-link"
   end
 
   it "tasks are grouped by their section" do

--- a/spec/features/self-serve/support_requests/create_support_request_spec.rb
+++ b/spec/features/self-serve/support_requests/create_support_request_spec.rb
@@ -38,6 +38,13 @@ RSpec.feature "Create a new support request" do
       expect(find("a.govuk-button")).to have_text "Start"
       expect(find("a.govuk-button")[:role]).to eq "button"
     end
+
+    it "confirms your identity on the profile page" do
+      click_on "Start"
+      expect(page).to have_current_path "/profile"
+      click_on "Request support"
+      expect(page).to have_current_path "/support-requests/new"
+    end
   end
 
   describe "contact details" do
@@ -171,17 +178,16 @@ RSpec.feature "Create a new support request" do
       expect(page).to have_unchecked_field "Broadband"
       expect(page).to have_unchecked_field "Maintenance"
 
-      # FIXME: category validation errors are not appearing
-      # click_continue
+      click_continue
 
-      # expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
-      # expect(page).to have_link "The type of procurement is required if you do not select an existing specification", href: "#support-form-category_id-field-error"
-      # expect(find("span.govuk-error-message")).to have_text "The type of procurement is required if you do not select an existing specification"
+      expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
+      expect(page).to have_link "The type of procurement is required if you do not select an existing specification", href: "#support-form-category-id-field-error"
+      expect(find("span.govuk-error-message")).to have_text "The type of procurement is required if you do not select an existing specification"
 
-      # choose "Broadband"
-      # click_continue
+      choose "Broadband"
+      click_continue
 
-      # expect(find("span.govuk-hint")).to have_text "Briefly describe your problem in a few sentences."
+      expect(find("span.govuk-hint")).to have_text "Briefly describe your problem in a few sentences."
     end
   end
 

--- a/spec/features/self-serve/support_requests/submit_support_request_spec.rb
+++ b/spec/features/self-serve/support_requests/submit_support_request_spec.rb
@@ -72,5 +72,6 @@ RSpec.feature "Completed support requests" do
 
     visit "/support-requests/#{support_request.id}"
     expect(page).not_to have_button "Send request"
+    expect(page).not_to have_link "Change"
   end
 end


### PR DESCRIPTION
## Changes in this PR

- hide change links after a support request is submitted
- use the singular form in locales
- fix category validation when no specs exist
