### PR TITLE
Update Notify email variables

### DIFF
--- a/app/services/submit_support_request.rb
+++ b/app/services/submit_support_request.rb
@@ -39,14 +39,17 @@ class SubmitSupportRequest
   def call
     return false unless enquiry
 
+    # TODO: confirmation message body forms the first CM interaction
+    # email = Emails::Confirmation.new().call
+    # message = email.content["body"]
+    #
     Emails::Confirmation.new(
       recipient: request.user,
-      # reference: "WIP", # NB: propose tracking Notify using the case ref
+      reference: "WIP",
       template: template,
       variables: {
-        support_query: request.message_body,
+        message: request.message_body,
         category: category,
-        case_ref: "WIP",
       },
     ).call
   end

--- a/lib/notify/email.rb
+++ b/lib/notify/email.rb
@@ -38,7 +38,7 @@ module Notify
     # It must not contain any personal information such as name or postal address.
     #
     # @param reference [String] A unique identifier you can create if necessary
-    option :reference, Types::String, optional: true
+    option :reference, Types::String, default: proc { "generic" }
 
     # @param attachment [String] Attachment by path to file
     option :attachment, Types::String, optional: true
@@ -97,6 +97,7 @@ module Notify
     # @return [Hash<Symbol>] Keys are substituted in the template
     def template_params
       {
+        reference: reference,
         first_name: recipient.first_name,
         last_name: recipient.last_name,
         email: recipient.email,

--- a/spec/lib/self-serve/notify/email_spec.rb
+++ b/spec/lib/self-serve/notify/email_spec.rb
@@ -93,6 +93,10 @@ RSpec.describe Notify::Email do
       expect(service.template).to eql "Default"
     end
 
+    it "assigns a default message reference" do
+      expect(service.reference).to eql "generic"
+    end
+
     it "returns a response notification" do
       expect(service.call).to be_a Notifications::Client::ResponseNotification
     end


### PR DESCRIPTION
## Changes in this PR

- ensure `reference` is available as a template variable
- revert to setting a `generic` default message reference
- use variables `message` and `category` to match values seen in CM
