### PR TITLE
Rewrite SeedSchool task so that it is less memory intensive

### DIFF
--- a/app/services/support/seed_schools.rb
+++ b/app/services/support/seed_schools.rb
@@ -14,42 +14,93 @@ module Support
     # @return [String] CSV data file path
     option :data, optional: true
 
-    # @return [Array<Organisation>]
     def call
-      dataset.each { |org| persist(org) unless skip?(org) }
+      set_establishment_type_codes
+      get_persisted_urns
+      get_updated_dataset
+      update_existing_records
+      create_new_records
     end
 
   private
 
-    # ignore closed schools that are not on record
-    # update closed schools if they are on record
-    # i.e. change the status of already persisted schools
+    # ignore schools we have on record and closed schools that are not on record
     #
     # @param org [Hash<Symbol>]
     def skip?(org)
-      Organisation.find_by(urn: org[:urn]).nil? && org[:establishment_status][:code] == 2
+      @persisted_urns.include?(org[:urn].to_s) || org[:establishment_status][:code] == 2
     end
 
     # @return [Support::Organisation] create or update by URN
     #
     # @param org [Hash<Symbol>]
-    def persist(org)
-      type = EstablishmentType.find_by(code: org[:establishment_type][:code])
 
-      Organisation.find_or_create_by!(urn: org[:urn]) do |record|
-        record.establishment_type_id = type.id             # uuid
-        record.name = org[:school][:name]                  # string
-        record.address = org[:school][:address]            # jsonb
-        record.contact = org[:school][:head_teacher]       # jsonb
-        record.phase = org[:school][:phase][:code]         # integer
-        record.gender = org[:school][:gender][:code]       # integer
-        record.status = org[:establishment_status][:code]  # integer
+    def update_existing_records
+      first_batch = true
+
+      Organisation.find_in_batches(batch_size: 2000) do |group|
+        Organisation.transaction do
+          # Adding this sleep helps with the memory allocation, but if we have less than 2000
+          # records to create there seems little point in using it
+          sleep(30) unless first_batch
+          group.each { |record| update_existing(record) }
+          first_batch = false
+        end
+
+        GC.start
       end
     end
 
+    def create_new_records
+      first_batch = true
+
+      @dataset.reject { |org| skip?(org) }.each_slice(2000) do |slice|
+        Organisation.transaction do
+          # Adding this sleep helps with the memory allocation, but if we have less than 2000
+          # records to create there seems little point in using it
+          sleep(30) unless first_batch
+          slice.each { |org| create_new(org) }
+          first_batch = false
+        end
+
+        GC.start
+      end
+    end
+
+    def update_existing(record)
+      org = @dataset.find { |organisation| organisation[:urn].to_s == record.urn.to_s }
+      type = @establishment_types.find_by(code: org[:establishment_type][:code])
+      record.assign_attributes(
+        establishment_type_id: type.id,             # uuid
+        name: org[:school][:name],                  # string
+        address: org[:school][:address],            # jsonb
+        contact: org[:school][:head_teacher],       # jsonb
+        phase: org[:school][:phase][:code],         # integer
+        gender: org[:school][:gender][:code],       # integer
+        status: org[:establishment_status][:code],  # integer
+      )
+
+      record.save! if record.changed?
+    end
+
+    def create_new(org)
+      type = @establishment_types.find_by(code: org[:establishment_type][:code])
+
+      Organisation.create!(
+        urn: org[:urn],
+        establishment_type_id: type.id,
+        name: org[:school][:name],
+        address: org[:school][:address],            # jsonb
+        contact: org[:school][:head_teacher],       # jsonb
+        phase: org[:school][:phase][:code],         # integer
+        gender: org[:school][:gender][:code],       # integer
+        status: org[:establishment_status][:code],  # integer
+      )
+    end
+
     # @return [Array<Hash>] loaded from CSV file or updated live
-    def dataset
-      data ? local_dataset.call : live_dataset.call
+    def get_updated_dataset
+      @dataset = data ? local_dataset.call : live_dataset.call
     end
 
     # @return [School::Information] filtered from a local file
@@ -65,6 +116,14 @@ module Support
     # @return [Hash<String, Array>] criteria to permit
     def filter
       { "TypeOfEstablishment (code)" => EstablishmentType.all.map(&:code) }
+    end
+
+    def set_establishment_type_codes
+      @establishment_types = EstablishmentType.select(:code, :id)
+    end
+
+    def get_persisted_urns
+      @persisted_urns = Organisation.pluck(:urn)
     end
   end
 end

--- a/lib/school/information.rb
+++ b/lib/school/information.rb
@@ -47,7 +47,20 @@ module School
 
     # @return [Array<Hash>]
     def structured_data
-      filter ? mapper.call(filtered_data) : mapper.call(tuples)
+      filter ? map_data(filtered_data) : map_data(tuples)
+    end
+
+    # This method can get very memory intensive once past a few thousand records
+    # Slicing the data up and forcing the garbage collector to run
+    # keeps the memory use low (~20MB) and stops the process from failing
+    def map_data(data)
+      processed_data = []
+      data.each_slice(1000) do |slice|
+        processed_data += mapper.call(slice)
+        GC.start
+      end
+
+      processed_data
     end
 
     # @return [Enumerator::Lazy] table rows


### PR DESCRIPTION
## Changes in this PR

The main issue seemed to involve the Dry::Transformer module processing the data and not freeing up the application memory when it was done, so the number of objects in memory quickly got out of hand. I forced the Garbage Collector to run earlier to free the memory up which vastly reduced the memory usage. I also changed the seed_schools task to separate out the records that needed to be updated from the ones that needed to be created and ran them as two separate methods, processing them in batches of 2000 and wrapping it up in a single transaction.

## Next steps

Right now, we get information sent to Rollbar if the job succeeds, but none if it fails. I also noticed that the task could fail silently by just crashing out, and as far as the job was concerned it had succeeded. I think we should look at changing the error reporting so that we know if it has passed or failed.