### PR TITLE
Add static pages for next steps and link to the pages from specification

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,6 +21,14 @@ class PagesController < ApplicationController
     set_page(__method__)
   end
 
+  def next_steps_catering
+    set_page(__method__)
+  end
+
+  def next_steps_mfd
+    set_page(__method__)
+  end
+
   def planning_start_page
     @back_url = root_path
   end

--- a/app/views/pages/next_steps_catering.html.erb
+++ b/app/views/pages/next_steps_catering.html.erb
@@ -1,0 +1,5 @@
+<%= content_for :title, @title %>
+
+<div class="md-override">
+  <%= @body.html_safe %>
+</div>

--- a/app/views/pages/next_steps_mfd.html.erb
+++ b/app/views/pages/next_steps_mfd.html.erb
@@ -1,0 +1,5 @@
+<%= content_for :title, @title %>
+
+<div class="md-override">
+  <%= @body.html_safe %>
+</div>

--- a/app/views/specifications/show.html.erb
+++ b/app/views/specifications/show.html.erb
@@ -13,5 +13,6 @@
 <% end %>
 <%= link_to I18n.t("journey.specification.download.button"), journey_specification_path(@journey, format: :docx), class: "govuk-button", role: "button" %>
 <article class="specification">
+  <p><%= I18n.t("journey.specification.next_steps.text") %><%= link_to I18n.t("journey.specification.next_steps.link_text"), "/next-steps-#{@journey.category.title.downcase}" %></p>
   <%= @journey.specification %>
 </article>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,10 @@ en:
           delete: Delete specification
           cancel: Cancel
           dashboard: Continue to dashboard
+      next_steps:
+        link_text: see what the next steps are.
+        text: "Once you have a completed specification, "
+
 
   # /dashboard
   dashboard:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
   get "privacy" => "pages#privacy_notice", "id" => "privacy"
   get "accessibility" => "pages#accessibility", "id" => "accessibility"
   get "terms-and-conditions" => "pages#terms_and_conditions", "id" => "terms_and_conditions"
+  get "next-steps-catering" => "pages#next_steps_catering", "id" => "next_steps_catering"
+  get "next-steps-mfd" => "pages#next_steps_mfd", "id" => "next_steps_mfd"
 
   # DfE Sign In
   get "/auth/dfe/callback", to: "sessions#create", as: :sign_in

--- a/spec/features/common/static_pages/next_steps_catering_spec.rb
+++ b/spec/features/common/static_pages/next_steps_catering_spec.rb
@@ -1,0 +1,17 @@
+RSpec.feature "NextStepsCatering" do
+  before do
+    Page.create!(
+      title: "Next Steps",
+      slug: "next_steps_catering",
+      body: "# **Next Steps**",
+    )
+    visit "/next-steps-catering"
+  end
+
+  describe "body" do
+    scenario "contains the expected content regarding next steps" do
+      expect(page).to have_text("Next Steps")
+      expect(page).to have_title("Next Steps")
+    end
+  end
+end

--- a/spec/features/common/static_pages/next_steps_mfd_spec.rb
+++ b/spec/features/common/static_pages/next_steps_mfd_spec.rb
@@ -1,0 +1,17 @@
+RSpec.feature "NextStepsCatering" do
+  before do
+    Page.create!(
+      title: "Next Steps",
+      slug: "next_steps_mfd",
+      body: "# **Next Steps**",
+    )
+    visit "/next-steps-mfd"
+  end
+
+  describe "body" do
+    scenario "contains the expected content regarding next steps" do
+      expect(page).to have_text("Next Steps")
+      expect(page).to have_title("Next Steps")
+    end
+  end
+end

--- a/spec/features/self-serve/journeys/download_spec.rb
+++ b/spec/features/self-serve/journeys/download_spec.rb
@@ -20,6 +20,10 @@ RSpec.feature "Users can see their catering specification" do
       # journey.specification.body
       expect(find("p.govuk-body")).to have_text "Your answers have been used to create a specification, which also includes standard rules and regulations. You can go back and edit your answers if needed."
 
+      # journey.specification.next_steps
+      expect(find("article.specification p")).to have_text("Once you have a completed specification,")
+      expect(find("article.specification p")).to have_link("see what the next steps are.", href: "/next-steps-catering")
+
       # journey.specification.download.button
       expect(find("a.govuk-button")).to have_text "Download (.docx)"
       expect(find("a.govuk-button")[:role]).to eq "button"

--- a/static/next_steps_catering.md
+++ b/static/next_steps_catering.md
@@ -1,0 +1,22 @@
+
+# **Next steps**
+
+Thank you for using this service to create a specification.
+
+You can now share your completed specification with suppliers.
+
+Consider buying from a framework recommended by DfE. This can be quicker and easier than running your own process. Each one has its own list of suppliers and has been assessed for compliance with procurement regulations, ease of use, suitability and value for money.
+
+Go directly to view and choose from a list of [catering frameworks recommended by DfE](https://find-dfe-approved-framework.service.gov.uk/find/type/on-going/services-categories/facilities/fm-categories/catering) in the Find a framework tool.
+
+Or [read about frameworks and how to use one](https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools) if you haven't used one before.
+
+## **Other procurement options**
+
+If you're not able to use a framework, read guidance to find out how to continue with your procurement if you want to:
+
+* [buy high-value things **under** the procurement threshold](https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools/buying-high-value-things-under-the-eu-procurement-threshold)
+
+* [buy things **over** the procurement threshold](https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools/buying-things-that-are-over-the-eu-procurement-threshold)
+
+* [buy low to medium cost things](https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools/buying-low-to-medium-cost-things) (up to £40,000)

--- a/static/next_steps_mfd.md
+++ b/static/next_steps_mfd.md
@@ -1,0 +1,22 @@
+
+# **Next steps**
+
+Thank you for using this service to create a specification.
+
+You can now share your completed specification with suppliers.
+
+Consider buying from a framework recommended by DfE. This can be quicker and easier than running your own process. Each one has its own list of suppliers and has been assessed for compliance with procurement regulations, ease of use, suitability and value for money.
+
+Go directly to view and choose from a list of [multi-functional devices (MFD) and printing frameworks recommended by DfE](https://find-dfe-approved-framework.service.gov.uk/find/type/buying/what/ict/ict-categories/mfd) in the Find a framework tool.
+
+Or [read about frameworks and how to use one](https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools) if you haven't used one before.
+
+## **Other procurement options**
+
+If you're not able to use a framework, read guidance to find out how to continue with your procurement if you want to:
+
+* [buy high-value things **under** the procurement threshold](https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools/buying-high-value-things-under-the-eu-procurement-threshold)
+
+* [buy things **over** the procurement threshold](https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools/buying-things-that-are-over-the-eu-procurement-threshold)
+
+* [buy low to medium cost things](https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools/buying-low-to-medium-cost-things) (up to £40,000)


### PR DESCRIPTION
## Changes in this PR

Added next steps static pages for catering and MFD journeys.

## Screenshots of UI changes


![Screenshot 2021-10-29 at 17-13-47 Catering](https://user-images.githubusercontent.com/367349/139468698-7b740ee3-9316-4de5-9b4c-2134fa860321.png)

![Screenshot 2021-10-29 at 17-15-15 Next steps catering](https://user-images.githubusercontent.com/367349/139468795-0fb01734-674c-4878-aa10-d37bcf64219f.png)

![Screenshot 2021-10-29 at 17-15-33 Next steps mfd](https://user-images.githubusercontent.com/367349/139468808-25e82b31-0c78-4434-a274-ddc00070bdd3.png)
### Before
