### PR TITLE
Capability to use chrome with capybara using js: true

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,6 +12,7 @@ services:
     depends_on:
       - test-db
       - test-redis
+      - test-chrome
     env_file:
       - .env.test
     environment:
@@ -19,6 +20,7 @@ services:
       REDIS_URL: redis://test-redis:6379
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: 'true'
       DOCKER: 'true'
+      SELENIUM_HUB_URL: http://test-chrome:4444/wd/hub
     volumes:
       - .:/srv/app
     tty: true
@@ -41,6 +43,13 @@ services:
     image: redis
     volumes:
       - redis-data:/data
+    networks:
+      - test
+
+  test-chrome:
+    image: selenium/standalone-chrome:4.0.0-20211102 # this version should match that of the selenium-webdriver gem (see Gemfile)
+    volumes:
+      - /dev/shm:/dev/shm
     networks:
       - test
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -47,7 +47,7 @@ services:
       - test
 
   test-chrome:
-    image: selenium/standalone-chrome:4.0.0-20211102 # this version should match that of the selenium-webdriver gem (see Gemfile)
+    image: selenium/standalone-chrome:95.0-chromedriver-95.0
     volumes:
       - /dev/shm:/dev/shm
     networks:

--- a/script/server
+++ b/script/server
@@ -6,4 +6,11 @@
 set -e
 
 docker-compose up --detach
-docker attach buy-for-your-school_web_1
+
+check_container_name_format_command='docker ps --filter "name=buy-for-your-school_web_1" --format "{{.ID}}"'
+
+if [[ $(eval $check_container_name_format_command) ]]; then
+  docker attach buy-for-your-school_web_1
+else
+  docker attach buy-for-your-school-web-1
+fi

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,9 +20,6 @@ require "simplecov"
 SimpleCov.minimum_coverage 99
 SimpleCov.start "rails"
 
-require "webmock/rspec"
-WebMock.disable_net_connect!(allow_localhost: true)
-
 # NOTE: This is necessary for sign_in helpers to work correctly when feature
 # NOTE: are run in isolation, hence needing Dsi::Client class loaded in.
 require_relative "../lib/dsi/client"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-Capybara.app_host = "http://www.example.com:3000"
-Capybara.asset_host = "http://www.example.com"

--- a/spec/support/capybara_driver_helper.rb
+++ b/spec/support/capybara_driver_helper.rb
@@ -1,18 +1,18 @@
 JS_DRIVER = :chrome_headless
 
 Capybara.register_driver :chrome_headless do |app|
-  chrome_capabilities = ::Selenium::WebDriver::Remote::Capabilities.chrome(
-    "goog:chromeOptions" => {
-      args: %w[no-sandbox headless disable-gpu window-size=1400,1400],
-    },
-  )
+  chrome_options = Selenium::WebDriver::Chrome::Options.new
+  chrome_options.add_argument("no-sandbox")
+  chrome_options.add_argument("headless")
+  chrome_options.add_argument("disable-gpu")
+  chrome_options.add_argument("window-size=1400,1400")
 
   if ENV["SELENIUM_HUB_URL"]
     # use remote chrome (docker default)
-    Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV["SELENIUM_HUB_URL"], desired_capabilities: chrome_capabilities)
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV["SELENIUM_HUB_URL"], capabilities: [chrome_options])
   else
     # use chromedriver (local setup - ensure your chrome, chromedriver and selenium-webdriver gem versions all match)
-    Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: chrome_capabilities)
+    Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [chrome_options])
   end
 end
 

--- a/spec/support/capybara_driver_helper.rb
+++ b/spec/support/capybara_driver_helper.rb
@@ -1,0 +1,45 @@
+JS_DRIVER = :chrome_headless
+
+Capybara.register_driver :chrome_headless do |app|
+  chrome_capabilities = ::Selenium::WebDriver::Remote::Capabilities.chrome(
+    "goog:chromeOptions" => {
+      args: %w[no-sandbox headless disable-gpu window-size=1400,1400],
+    },
+  )
+
+  if ENV["SELENIUM_HUB_URL"]
+    # use remote chrome (docker default)
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV["SELENIUM_HUB_URL"], desired_capabilities: chrome_capabilities)
+  else
+    # use chromedriver (local setup - ensure your chrome, chromedriver and selenium-webdriver gem versions all match)
+    Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: chrome_capabilities)
+  end
+end
+
+Capybara.configure do |config|
+  config.default_driver = :rack_test
+  config.javascript_driver = JS_DRIVER
+  config.server = :puma, { Silent: true }
+  config.always_include_port = true
+
+  config.app_host = "http://#{IPSocket.getaddress(Socket.gethostname)}:3000"
+  config.server_host = IPSocket.getaddress(Socket.gethostname)
+  config.server_port = 3000
+end
+
+RSpec.configure do |config|
+  config.before do |example|
+    if example.metadata[:js]
+      # chromedriver is unforgiving of hidden form elements triggered by labels
+      # e.g. radio buttons
+      Capybara.ignore_hidden_elements = false
+      Capybara.current_driver = JS_DRIVER
+    end
+  end
+
+  config.after do
+    # reset to defaults
+    Capybara.ignore_hidden_elements = true
+    Capybara.use_default_driver
+  end
+end

--- a/spec/support/capybara_driver_helper.rb
+++ b/spec/support/capybara_driver_helper.rb
@@ -20,7 +20,9 @@ Capybara.configure do |config|
   config.default_driver = :rack_test
   config.javascript_driver = JS_DRIVER
   config.server = :puma, { Silent: true }
-  config.always_include_port = true
+
+  Capybara.app_host = "http://www.example.com:3000"
+  Capybara.asset_host = "http://www.example.com"
 
   config.server_host = if RUBY_PLATFORM.match?(/linux/)
                          `/sbin/ip route|awk '/scope/ { print $9 }'`.chomp
@@ -48,6 +50,6 @@ RSpec.configure do |config|
     # reset to defaults
     Capybara.ignore_hidden_elements = true
     Capybara.use_default_driver
-    Capybara.app_host = nil
+    Capybara.app_host = "http://www.example.com:3000"
   end
 end

--- a/spec/support/capybara_driver_helper.rb
+++ b/spec/support/capybara_driver_helper.rb
@@ -22,11 +22,11 @@ Capybara.configure do |config|
   config.server = :puma, { Silent: true }
   config.always_include_port = true
 
-  if RUBY_PLATFORM.match(/linux/)
-    config.server_host = `/sbin/ip route|awk '/scope/ { print $9 }'`.chomp
-  else
-    config.server_host = '127.0.0.1'
-  end
+  config.server_host = if RUBY_PLATFORM.match?(/linux/)
+                         `/sbin/ip route|awk '/scope/ { print $9 }'`.chomp
+                       else
+                         "127.0.0.1"
+                       end
 end
 
 RSpec.configure do |config|

--- a/spec/support/webmock_helper.rb
+++ b/spec/support/webmock_helper.rb
@@ -1,0 +1,17 @@
+require "webmock/rspec"
+
+allow_list = if ENV["SELENIUM_HUB_URL"]
+               hub_uri = URI(ENV["SELENIUM_HUB_URL"])
+
+               # capybara must be able to make requests to the selenium hub
+               # and from the browser it must be able to make requests back to the server
+
+               [
+                 "#{hub_uri.scheme}://#{hub_uri.host}:#{hub_uri.port}",
+                 Capybara.app_host,
+               ]
+             else
+               []
+             end
+
+WebMock.disable_net_connect!(allow_localhost: true, allow: allow_list)

--- a/spec/support/webmock_helper.rb
+++ b/spec/support/webmock_helper.rb
@@ -8,7 +8,7 @@ allow_list = if ENV["SELENIUM_HUB_URL"]
 
                [
                  "#{hub_uri.scheme}://#{hub_uri.host}:#{hub_uri.port}",
-                 Capybara.app_host,
+                 IPSocket.getaddress(Socket.gethostname),
                ]
              else
                []


### PR DESCRIPTION
## Changes in this PR

Config required to allow chrome usage with capybara to allow more advanced javascript in tests.

Use `js: true` in tests to activate the chrome driver.
