### PR TITLE
Interim solution to export KPI data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The format is based on [Keep a Changelog 1.0.0].
   currently no-op until approved
 - clean and fix deletion of stale journeys `DeleteStaleJourneysJob`, currently
   no-op until approved
+- add rake task for CSV data export of activity log items
 
 **Steps**
 

--- a/app/models/activity_log_item.rb
+++ b/app/models/activity_log_item.rb
@@ -6,6 +6,8 @@ require "csv"
 class ActivityLogItem < ApplicationRecord
   self.table_name = "activity_log"
 
+  default_scope { order(:created_at) }
+
   validates :user_id, :journey_id, :action, presence: true
 
   # @return [String]
@@ -13,7 +15,7 @@ class ActivityLogItem < ApplicationRecord
     CSV.generate(headers: true) do |csv|
       csv << column_names
 
-      all.order(:created_at).each do |record|
+      all.each do |record|
         csv << record.attributes.values
       end
     end

--- a/app/models/activity_log_item.rb
+++ b/app/models/activity_log_item.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 # Capture user activity metrics
 #
 # @see RecordAction
@@ -5,4 +7,15 @@ class ActivityLogItem < ApplicationRecord
   self.table_name = "activity_log"
 
   validates :user_id, :journey_id, :action, presence: true
+
+  # @return [String]
+  def self.to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << column_names
+
+      all.order(:created_at).each do |record|
+        csv << record.attributes.values
+      end
+    end
+  end
 end

--- a/app/models/activity_log_item.rb
+++ b/app/models/activity_log_item.rb
@@ -15,7 +15,7 @@ class ActivityLogItem < ApplicationRecord
     CSV.generate(headers: true) do |csv|
       csv << column_names
 
-      all.each do |record|
+      find_each do |record|
         csv << record.attributes.values
       end
     end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,0 +1,7 @@
+desc "Export ActivityLog items"
+task export: :environment do
+  file = Rails.root.join("public/activity_log.csv")
+  data = ActivityLogItem.to_csv
+
+  File.open(file, "w+") { |f| f.write(data) }
+end

--- a/spec/models/self-serve/activity_log_item_spec.rb
+++ b/spec/models/self-serve/activity_log_item_spec.rb
@@ -4,4 +4,12 @@ RSpec.describe ActivityLogItem, type: :model do
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:action) }
   end
+
+  describe "#to_csv" do
+    it "includes headers" do
+      expect(described_class.to_csv).to eql(
+        "id,journey_id,user_id,contentful_category_id,contentful_section_id,contentful_task_id,contentful_step_id,action,data,created_at,updated_at\n",
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- add a rake task to export activity log items as CSV data for convenience
- once the task has been run manually and the file downloaded it should be removed from the server

## TODO

- potential for restricted access CSV download route so Data Analysts can interact without developer input 