### PR TITLE
Add csv export task for Support::Cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog 1.0.0].
 - add ability to re-categorise a case
 - enable sending of emails via Notify
 - add activity logging for support cases
+- add csv export for case management
 
 ### Specify Unreleased
 

--- a/app/models/activity_log_item.rb
+++ b/app/models/activity_log_item.rb
@@ -15,9 +15,7 @@ class ActivityLogItem < ApplicationRecord
     CSV.generate(headers: true) do |csv|
       csv << column_names
 
-      find_each do |record|
-        csv << record.attributes.values
-      end
+      find_each { |record| csv << record.attributes.values }
     end
   end
 end

--- a/app/models/support/activity_log_item.rb
+++ b/app/models/support/activity_log_item.rb
@@ -15,9 +15,7 @@ module Support
       CSV.generate(headers: true) do |csv|
         csv << column_names
 
-        find_each do |record|
-          csv << record.attributes.values
-        end
+        find_each { |record| csv << record.attributes.values }
       end
     end
   end

--- a/app/models/support/case.rb
+++ b/app/models/support/case.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "csv"
+
 module Support
   #
   # A case is opened from a "support enquiry" dealing with a "category of spend"
@@ -39,6 +41,17 @@ module Support
 
     before_validation :generate_ref
     validates :ref, uniqueness: true, length: { is: 6 }, format: { with: /\A\d+\z/, message: "numbers only" }
+
+    # @return [String]
+    def self.to_csv
+      CSV.generate(headers: true) do |csv|
+        csv << column_names
+
+        find_each do |record|
+          csv << record.attributes.values
+        end
+      end
+    end
 
     # Called before validation to assign 6 digit incremental number (from last case or the default 000000)
     # @return [String]

--- a/app/models/support/case.rb
+++ b/app/models/support/case.rb
@@ -47,9 +47,7 @@ module Support
       CSV.generate(headers: true) do |csv|
         csv << column_names
 
-        find_each do |record|
-          csv << record.attributes.values
-        end
+        find_each { |record| csv << record.attributes.values }
       end
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_110826) do
+ActiveRecord::Schema.define(version: 2021_11_04_114347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -159,6 +159,14 @@ ActiveRecord::Schema.define(version: 2021_11_03_110826) do
     t.jsonb "criteria"
     t.index ["order"], name: "index_steps_on_order"
     t.index ["task_id"], name: "index_steps_on_task_id"
+  end
+
+  create_table "support_activity_log_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "support_case_id"
+    t.string "action"
+    t.jsonb "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "support_agents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -6,10 +6,10 @@ task export: :environment do
   File.open(file, "w+") { |f| f.write(data) }
 end
 
-namespace :support do
-  namespace :cases do
+namespace :export do
+  namespace :support do
     desc "Export Support Cases"
-    task export: :environment do
+    task cases: :environment do
       file = Rails.root.join("public/support_cases.csv")
       data = Support::Case.to_csv
 

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -6,10 +6,10 @@ task export: :environment do
   File.open(file, "w+") { |f| f.write(data) }
 end
 
-namespace :export do
-  namespace :support do
+namespace :support do
+  namespace :case_management do
     desc "Export Support Cases"
-    task cases: :environment do
+    task export: :environment do
       file = Rails.root.join("public/support_cases.csv")
       data = Support::Case.to_csv
 

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -8,7 +8,7 @@ end
 
 namespace :support do
   namespace :cases do
-    desc "Export Support ActivityLog items"
+    desc "Export Support Cases"
     task export: :environment do
       file = Rails.root.join("public/support_cases.csv")
       data = Support::Case.to_csv

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,4 +1,3 @@
-
 desc "Export ActivityLog items"
 task export: :environment do
   file = Rails.root.join("public/activity_log.csv")

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,0 +1,11 @@
+namespace :support do
+  namespace :cases do
+    desc "Export Support ActivityLog items"
+    task export: :environment do
+      file = Rails.root.join("public/support_cases.csv")
+      data = Support::Case.to_csv
+
+      File.open(file, "w+") { |f| f.write(data) }
+    end
+  end
+end

--- a/spec/models/support/case_spec.rb
+++ b/spec/models/support/case_spec.rb
@@ -42,4 +42,12 @@ RSpec.describe Support::Case, type: :model do
       end
     end
   end
+
+  describe "#to_csv" do
+    it "includes headers" do
+      expect(described_class.to_csv).to eql(
+        "id,ref,category_id,request_text,support_level,status,state,created_at,updated_at,agent_id,first_name,last_name,email,phone_number,organisation_name,organisation_urn\n",
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- add a `to_csv` method into `Support::Case`
- add case data as an option to the `export` rake task