### PR TITLE
Add breadcrumbs to Pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,9 +2,12 @@ class PagesController < ApplicationController
   skip_before_action :authenticate_user!
 
   def show
-    render "errors/not_found" if page.blank?
-    set_breadcrumbs(page)
-    @page = PagePresenter.new(page)
+    if page.blank?
+      render "errors/not_found"
+    else
+      set_breadcrumbs(page)
+      @page = PagePresenter.new(page)
+    end
   end
 
   def specifying_start_page

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,7 @@ class PagesController < ApplicationController
 
   def show
     render "errors/not_found" if page.blank?
+    set_breadcrumbs(page)
     @page = PagePresenter.new(page)
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,4 +21,13 @@ private
   def page
     @page ||= Page.find_by(slug: params[:slug])
   end
+
+  def set_breadcrumbs(page)
+    unless page.breadcrumbs.empty?
+      page.breadcrumbs.each do |item|
+        title, path = item.split(",")
+        breadcrumb title, path
+      end
+    end
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,7 +24,7 @@ private
   end
 
   def set_breadcrumbs(page)
-    unless page.breadcrumbs.empty?
+    if page.breadcrumbs.present?
       page.breadcrumbs.each do |item|
         title, path = item.split(",")
         breadcrumb title, path

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,12 +23,8 @@ private
     @page ||= Page.find_by(slug: params[:slug])
   end
 
+  # Apply Contentful breadcrumbs in the format "title, path"
   def set_breadcrumbs
-    return if page.blank?
-
-    page.breadcrumbs&.each do |item|
-      title, path = item.split(",")
-      breadcrumb title, path
-    end
+    page&.breadcrumbs&.each { |item| breadcrumb(*item.split(",")) }
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,11 +24,11 @@ private
   end
 
   def set_breadcrumbs
-    if page.present?
-      page.breadcrumbs&.each do |item|
-        title, path = item.split(",")
-        breadcrumb title, path
-      end
+    return if page.blank?
+
+    page.breadcrumbs&.each do |item|
+      title, path = item.split(",")
+      breadcrumb title, path
     end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,13 +1,10 @@
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :set_breadcrumbs, only: :show
 
   def show
-    if page.blank?
-      render "errors/not_found"
-    else
-      set_breadcrumbs(page)
-      @page = PagePresenter.new(page)
-    end
+    render "errors/not_found" if page.blank?
+    @page = PagePresenter.new(page)
   end
 
   def specifying_start_page
@@ -26,9 +23,9 @@ private
     @page ||= Page.find_by(slug: params[:slug])
   end
 
-  def set_breadcrumbs(page)
-    if page.breadcrumbs.present?
-      page.breadcrumbs.each do |item|
+  def set_breadcrumbs
+    if page.present?
+      page.breadcrumbs&.each do |item|
         title, path = item.split(",")
         breadcrumb title, path
       end

--- a/app/services/content/page/build.rb
+++ b/app/services/content/page/build.rb
@@ -12,11 +12,12 @@ class Content::Page::Build
   def call
     page = Page.upsert(
       {
-        title: contentful_page.title,
-        body: contentful_page.body,
+        title: contentful_page.fields[:title],
+        body: contentful_page.fields[:body],
         contentful_id: contentful_page.id,
-        slug: contentful_page.slug,
-        sidebar: contentful_page.sidebar,
+        slug: contentful_page.fields[:slug],
+        sidebar: contentful_page.fields[:sidebar],
+        breadcrumbs: contentful_page.fields[:breadcrumbs],
       },
       unique_by: :contentful_id,
       returning: %w[title contentful_id slug],

--- a/app/services/content/page/build.rb
+++ b/app/services/content/page/build.rb
@@ -6,7 +6,7 @@ class Content::Page::Build
   # @!attribute [r] contentful_page
   #   @return [Contentful::Entry] Contentful "Page" entity
   #   @api private
-  option :contentful_page, reader: :private
+  option :contentful_page, Types.Instance(Contentful::Entry), reader: :private
 
   # @return [Page]
   def call

--- a/db/migrate/20211123110903_add_breadcrumbs_to_pages.rb
+++ b/db/migrate/20211123110903_add_breadcrumbs_to_pages.rb
@@ -1,0 +1,9 @@
+class AddBreadcrumbsToPages < ActiveRecord::Migration[6.1]
+  def up
+    add_column :pages, :breadcrumbs, :string, array: true, default: []
+  end
+
+  def down
+    remove_column :pages, :breadcrumbs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_18_115424) do
+ActiveRecord::Schema.define(version: 2021_11_23_110903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 2021_11_18_115424) do
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "contentful_id", null: false
     t.text "sidebar"
+    t.string "breadcrumbs", default: [], array: true
     t.index ["contentful_id"], name: "index_pages_on_contentful_id", unique: true
     t.index ["slug"], name: "index_pages_on_slug", unique: true
   end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     slug { Faker::Internet.slug }
     sidebar { Faker::Markdown.sandwich }
     contentful_id { Faker::Alphanumeric.alphanumeric }
-    breadcrumbs { Array.new(5).map { Faker::Internet.domain_name } }
+    breadcrumbs { [] }
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     slug { Faker::Internet.slug }
     sidebar { Faker::Markdown.sandwich }
     contentful_id { Faker::Alphanumeric.alphanumeric }
+    breadcrumbs { Array.new(5).map { Faker::Internet.domain_name } }
   end
 end

--- a/spec/features/pages/breadcrumbs_spec.rb
+++ b/spec/features/pages/breadcrumbs_spec.rb
@@ -1,0 +1,17 @@
+RSpec.feature "Page with breadcrumbs" do
+  before do
+    create(:page, title: "Test Page 1", slug: "test-page-1")
+    create(:page, title: "Test Page 2", slug: "test-page-2", breadcrumbs: ["Test Page 1,/test-page-1", "Test Page 2,/test-page-2"])
+    visit "/test-page-2"
+  end
+
+  xit "shows the breadcrumbs" do
+    expect(page).to have_breadcrumbs ["Test Page 1", "Test Page 2"]
+  end
+
+  xit "takes user to the right breadcrumb page" do
+    click_link "Test Page 1"
+    expect(page).to have_current_path "/test-page-1"
+    expect(page).not_to have_breadcrumbs
+  end
+end

--- a/spec/features/pages/breadcrumbs_spec.rb
+++ b/spec/features/pages/breadcrumbs_spec.rb
@@ -1,15 +1,15 @@
 RSpec.feature "Page with breadcrumbs" do
   before do
     create(:page, title: "Test Page 1", slug: "test-page-1")
-    create(:page, title: "Test Page 2", slug: "test-page-2", breadcrumbs: ["Test Page 1,/test-page-1", "Test Page 2,/test-page-2"])
+    create(:page, title: "Test Page 2", slug: "test-page-2", breadcrumbs: ["Test Page 1,test-page-1", "Test Page 2,test-page-2"])
     visit "/test-page-2"
   end
 
-  xit "shows the breadcrumbs" do
+  it "shows the breadcrumbs" do
     expect(page).to have_breadcrumbs ["Test Page 1", "Test Page 2"]
   end
 
-  xit "takes user to the right breadcrumb page" do
+  it "takes user to the right breadcrumb page" do
     click_link "Test Page 1"
     expect(page).to have_current_path "/test-page-1"
     expect(page).not_to have_breadcrumbs

--- a/spec/requests/self-serve/api/contentful/pages_controller_spec.rb
+++ b/spec/requests/self-serve/api/contentful/pages_controller_spec.rb
@@ -1,12 +1,13 @@
 RSpec.describe Api::Contentful::PagesController, type: :request do
   let(:contentful_page) do
-    OpenStruct.new(
-      title: title,
-      body: "Test body",
-      id: contentful_id,
-      slug: slug,
-      sidebar: "Test page link",
-    )
+    fields = {
+      "title" => title,
+      "body" => "Test body",
+      "id" => contentful_id,
+      "slug" => slug,
+      "sidebar" => "Test page link",
+    }
+    contentful_entry(fields)
   end
 
   let(:params) do

--- a/spec/services/self-serve/content/page/build_spec.rb
+++ b/spec/services/self-serve/content/page/build_spec.rb
@@ -2,13 +2,14 @@ RSpec.describe Content::Page::Build do
   subject(:service) { described_class.new(contentful_page: contentful_page) }
 
   let(:contentful_page) do
-    OpenStruct.new(
-      title: "Test page",
-      body: "Test body",
-      id: "123",
-      slug: "/test-page",
-      sidebar: "Test page link",
-    )
+    fields = {
+      "title" => "Test page",
+      "body" => "Test body",
+      "id" => "123",
+      "slug" => "/test-page",
+      "sidebar" => "Test page link",
+    }
+    contentful_entry(fields)
   end
 
   let(:rollbar_info) do

--- a/spec/services/self-serve/content/page/get_spec.rb
+++ b/spec/services/self-serve/content/page/get_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Content::Page::Get do
 
   describe "#call" do
     it "returns a Contentful::Entry" do
-      allow(client).to receive(:by_id).with(page_entry_id).and_return(instance_double(Contentful::Entry))
+      allow(client).to receive(:by_id).with(page_entry_id).and_return(Contentful::Entry.new({}, {}))
 
-      expect(service.call).not_to eq :not_found
+      expect(service.call).to be_kind_of(Contentful::Entry)
     end
 
     context "when the page entry cannot be found" do

--- a/spec/support/contentful_helpers.rb
+++ b/spec/support/contentful_helpers.rb
@@ -222,4 +222,32 @@ module ContentfulHelpers
       **fields,
     )
   end
+
+  # Create a Contentful Entry with custom fields
+  #
+  # @param [Hash] fields
+  #
+  # @return [Contentful::Entry]
+  def contentful_entry(fields)
+    Contentful::Entry.new(
+      {
+        "sys" => {
+          "space" => {
+            "sys" => {
+              "id" => "id",
+            },
+          },
+          "id" => "id",
+          "contentType" => {
+            "sys" => {
+              "id" => "id",
+            },
+          },
+          "locale" => "en-US",
+        },
+        "fields" => fields,
+      },
+      {},
+    )
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- add `breadcrumbs` field to `pages`
- add a method to generate breadcrumbs based on `Page.breadcrumbs`

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/12530193/143573154-2c7e7437-993b-482b-92f7-d018518aace0.png)