### PR TITLE
[154] Correct Page CSS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,7 @@ $govuk-image-url-function: "image-url";
 @import "base/frontend";
 @import "components/govuk-radios-small";
 @import "components/autocomplete";
-@import "components/override";
+@import "components/page";
 @import "components/task-list";
 @import "components/supported/email-preview";
 @import "components/supported/new-case-form";

--- a/app/assets/stylesheets/components/_override.scss
+++ b/app/assets/stylesheets/components/_override.scss
@@ -5,7 +5,9 @@
 
 .page-sidebar {
   ul {
-    list-style-type:none
+    list-style-type:none;
+    padding-left: 0;
+    line-height: 2.5rem;
   }
 }
 

--- a/app/assets/stylesheets/components/_override.scss
+++ b/app/assets/stylesheets/components/_override.scss
@@ -3,6 +3,12 @@
 * keep the look consistent.
 **/
 
+.page-sidebar {
+  ul {
+    list-style-type:none
+  }
+}
+
 .md-override,
 #specification,
 .specification {

--- a/app/assets/stylesheets/components/_page.scss
+++ b/app/assets/stylesheets/components/_page.scss
@@ -11,7 +11,7 @@
   }
 }
 
-.md-override,
+.md-page,
 #specification,
 .specification {
   h1 {

--- a/app/assets/stylesheets/components/_page.scss
+++ b/app/assets/stylesheets/components/_page.scss
@@ -2,18 +2,18 @@
 * Specification and other markdown templates have no classes of their own so we're overriding the default styling to
 * keep the look consistent.
 **/
-
-.page-sidebar {
-  ul {
-    list-style-type:none;
-    padding-left: 0;
-    line-height: 2.5rem;
-  }
-}
-
 .md-page,
 #specification,
 .specification {
+  #page-sidebar ul {
+    @extend .govuk-list--spaced;
+    @extend .govuk-list;
+  }
+
+  #last-updated {
+    @extend .govuk-body-s;
+  }
+
   h1 {
     @extend .govuk-heading-l;
   }

--- a/app/presenters/support/case_presenter.rb
+++ b/app/presenters/support/case_presenter.rb
@@ -79,7 +79,7 @@ module Support
       OrganisationPresenter.new(super)
     end
 
-private
+  private
 
     # @return [String] 20 March 2021 at 12:00
     def date_format

--- a/app/presenters/support/case_presenter.rb
+++ b/app/presenters/support/case_presenter.rb
@@ -78,5 +78,12 @@ module Support
     def organisation
       OrganisationPresenter.new(super)
     end
+
+private
+
+    # @return [String] 20 March 2021 at 12:00
+    def date_format
+      I18n.t("support.case.date_format")
+    end
   end
 end

--- a/app/views/pages/_sidebar.html.erb
+++ b/app/views/pages/_sidebar.html.erb
@@ -1,3 +1,3 @@
-<div class="govuk-grid-column-one-third">
+<div class="govuk-grid-column-one-third page-sidebar">
   <%= @page.sidebar %>
 </div>

--- a/app/views/pages/_sidebar.html.erb
+++ b/app/views/pages/_sidebar.html.erb
@@ -1,3 +1,3 @@
-<div class="govuk-grid-column-one-third page-sidebar">
+<div id="page-sidebar" class="govuk-grid-column-one-third">
   <%= @page.sidebar %>
 </div>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,9 +1,9 @@
 <%= content_for :title, @page.title %>
 
-<div class="<%= @page.container_class%> md-override">
+<div class="<%= @page.container_class%> md-page">
   <div class="<%= @page.body_class %>">
     <%= @page.body %>
-    <p class="govuk-body-s"><%= @page.updated_at %></p>
+    <p id="last-updated"><%= @page.updated_at %></p>
   </div>
 
   <%= render 'sidebar' if @page.sidebar %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,6 +273,7 @@ en:
     header: Supported Buying Admin
 
     case:
+      date_format: "%d %B %Y at %H:%M"
       header:
         action: Actions
         school_detail: School details

--- a/spec/features/self-serve/pages/show_spec.rb
+++ b/spec/features/self-serve/pages/show_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Showing a Page" do
 
     it "shows the page without a sidebar" do
       visit "/#{our_page.slug}"
-      expect(find(".md-override h1")).to have_text("hello body")
+      expect(find(".md-page h1")).to have_text("hello body")
       expect(find(".govuk-body-s")).to have_text(updated_at)
       expect(page).not_to have_css(".govuk-grid-column-two-thirds")
       expect(page).not_to have_css(".govuk-grid-column-one-third")

--- a/spec/features/self-serve/pages/show_spec.rb
+++ b/spec/features/self-serve/pages/show_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Showing a Page" do
       visit "/#{our_page.slug}"
       expect(find(".govuk-grid-column-two-thirds h1")).to have_text("hello body")
       expect(find(".govuk-grid-column-one-third h1")).to have_text("hello sidebar")
-      expect(find(".govuk-body-s")).to have_text(updated_at)
+      expect(find("#last-updated")).to have_text(updated_at)
     end
   end
 
@@ -34,7 +34,7 @@ RSpec.feature "Showing a Page" do
     it "shows the page without a sidebar" do
       visit "/#{our_page.slug}"
       expect(find(".md-page h1")).to have_text("hello body")
-      expect(find(".govuk-body-s")).to have_text(updated_at)
+      expect(find("#last-updated")).to have_text(updated_at)
       expect(page).not_to have_css(".govuk-grid-column-two-thirds")
       expect(page).not_to have_css(".govuk-grid-column-one-third")
     end


### PR DESCRIPTION
## Changes in this PR

* Removes bullet styling of lists for page sidebar
* reinstates timestamp styling

## Screenshots of UI changes

### Before

<img width="1116" alt="Screenshot 2021-12-03 at 14 08 08" src="https://user-images.githubusercontent.com/6339025/144615979-e9044557-ce51-41f3-b2b2-2b37c166e9f5.png">

### After
<img width="1122" alt="Screenshot 2021-12-03 at 14 07 16" src="https://user-images.githubusercontent.com/6339025/144616151-07d642c7-9d4c-466b-873f-9816875c050b.png">


