### PR TITLE
Uploaded email link and spec

### DIFF
--- a/app/views/support/cases/case_history/_interaction.html.erb
+++ b/app/views/support/cases/case_history/_interaction.html.erb
@@ -34,7 +34,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <% if interaction.email? %>
-            <%= link_to I18n.t("support.interaction.link_to_email_preview"), support_case_interaction_path(interaction), target: "_blank", rel: "noopener" %>
+            <%= link_to I18n.t("support.interaction.link_to_email_preview"), support_case_interaction_path(current_case, interaction), target: "_blank", rel: "noopener" %>
           <% else %>
             <%= interaction.body %>
           <% end %>

--- a/app/views/support/cases/show.html.erb
+++ b/app/views/support/cases/show.html.erb
@@ -41,7 +41,7 @@
       </p>
     <% end %>
 
-      <%= render partial: "support/cases/case_history/interaction", collection: @current_case.interactions %>
+      <%= render partial: "support/cases/case_history/interaction", collection: @current_case.interactions, locals: { current_case: @current_case } %>
 
       <%# Only cases from Specify are initiated by a support request %>
       <% if @current_case.support_request.present? %>

--- a/spec/features/self-serve/pages/show_spec.rb
+++ b/spec/features/self-serve/pages/show_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Showing a Page" do
   # `our_page` so we don't clash with Capybara `page`
   let(:our_page) { create(:page, sidebar: sidebar, body: body) }
-  let(:updated_at) { "Last updated#{our_page.updated_at.strftime('%e %B %Y')}" }
+  let(:updated_at) { "Last updated #{our_page.updated_at.strftime('%e %B %Y')}" }
 
   context "when visiting a non-existent page slug" do
     let(:sidebar) { nil }

--- a/spec/features/support/interactions/list_interactions_spec.rb
+++ b/spec/features/support/interactions/list_interactions_spec.rb
@@ -9,12 +9,12 @@ RSpec.feature "Support request case history" do
   end
 
   let(:agent) { support_case.agent }
-  let!(:email_to_school) { create(:support_interaction, :email_to_school, case: support_case, agent: agent) }
 
   before do
     travel_to Time.zone.local(2021, 3, 20, 12, 0, 0)
 
     create(:support_interaction, :support_request, case: support_case, agent: agent)
+    create(:support_interaction, :email_to_school, case: support_case, agent: agent)
     # create(:support_interaction, :note, case: support_case, agent: agent)
     # create(:support_interaction, :note, case: support_case, agent: agent)
     # create(:support_interaction, :phone_call, case: support_case, agent: agent)
@@ -53,7 +53,7 @@ RSpec.feature "Support request case history" do
         expect(find_all("dd.govuk-summary-list__value")[1]).to have_link_to_open_in_new_tab("Open email preview in new tab")
 
         click_link "Open email preview in new tab"
-        expect(page).to have_current_path "/support/cases/#{support_case.id}/interactions/#{email_to_school.id}"
+        expect(page).to have_current_path "/support/cases/#{support_case.id}/interactions/#{support_case.interactions.email_to_school.first.id}"
       end
     end
   end

--- a/spec/features/support/interactions/list_interactions_spec.rb
+++ b/spec/features/support/interactions/list_interactions_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Support request case history" do
   end
 
   let(:agent) { support_case.agent }
+  let!(:email_to_school) { create(:support_interaction, :email_to_school, case: support_case, agent: agent) }
 
   before do
     travel_to Time.zone.local(2021, 3, 20, 12, 0, 0)
@@ -18,7 +19,6 @@ RSpec.feature "Support request case history" do
     # create(:support_interaction, :note, case: support_case, agent: agent)
     # create(:support_interaction, :phone_call, case: support_case, agent: agent)
     # create(:support_interaction, :email_from_school, case: support_case, agent: agent)
-    create(:support_interaction, :email_to_school, case: support_case, agent: agent)
 
     click_button "Agent Login"
     visit "/support/cases/#{support_case.id}#case-history"
@@ -51,6 +51,9 @@ RSpec.feature "Support request case history" do
     specify do
       within "#case-history" do
         expect(find_all("dd.govuk-summary-list__value")[1]).to have_link_to_open_in_new_tab("Open email preview in new tab")
+
+        click_link "Open email preview in new tab"
+        expect(page).to have_current_path "/support/cases/#{support_case.id}/interactions/#{email_to_school.id}"
       end
     end
   end


### PR DESCRIPTION
## Changes in this PR

This fixes an error opening the email in a new tab. The URL was malformed - passing in the current_case fixed the issue.