### PR TITLE
Add before_save method to record email being assigned to case

### DIFF
--- a/app/models/support/email.rb
+++ b/app/models/support/email.rb
@@ -1,5 +1,21 @@
 module Support
   class Email < ApplicationRecord
-    belongs_to :case, class_name: "Support::Case"
+    belongs_to :case, class_name: "Support::Case", optional: true
+    before_save :record_received_email, if: :case_id_changed?
+
+  private
+
+    def record_received_email
+      return if case_id.nil?
+
+      interaction_attrs = {
+        body: body,
+        additional_data:
+        {
+          email_id: id,
+        },
+      }
+      CreateInteraction.new(self.case.id, "email_from_school", self.case.agent_id, interaction_attrs).call
+    end
   end
 end

--- a/spec/factories/support/email.rb
+++ b/spec/factories/support/email.rb
@@ -10,6 +10,9 @@ FactoryBot.define do
     sent_at { "2021-12-15 11:51:12" }
     received_at { "2021-12-15 11:51:12" }
     read_at { "2021-12-15 11:51:12" }
+  end
+
+  trait :with_case do
     association :case, factory: :support_case
   end
 end

--- a/spec/models/support/email_spec.rb
+++ b/spec/models/support/email_spec.rb
@@ -1,7 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Support::Email, type: :model do
-  subject(:email) { create(:support_email) }
+  subject(:email) { build(:support_email) }
 
-  it { is_expected.to belong_to :case }
+  it { is_expected.to belong_to(:case).optional }
+
+  context "that has been assigned to a case" do
+    it "does not create a new support interaction" do
+      expect { subject.save! }.to change { Support::Interaction.where(event_type: "email_from_school").count }.by(0)
+    end
+  end
+
+  context "that has not been assigned to a case" do
+    it "does creates a new support interaction" do
+      kase = create(:support_case)
+      subject.case = kase
+
+      expect { subject.save! }.to change { Support::Interaction.where(event_type: "email_from_school").count }.by(1)
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

Creates a Support::Interaction when an email has been assigned to a case