### PR TITLE
Internal admin page secured by check on user roles

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AdminController < ApplicationController
+  before_action :user_analyst, only: :show
+
+  def show; end
+
+private
+
+  def user_analyst
+    return render "errors/missing_role" unless current_user.analyst?
+
+    Rollbar.info("User role has been granted access.", role: "analyst", path: request.path)
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,6 +2,7 @@
 
 class AdminController < ApplicationController
   before_action :user_analyst, only: :show
+  before_action :set_view_fields, only: :show
 
   def show; end
 
@@ -11,5 +12,11 @@ private
     return render "errors/missing_role" unless current_user.analyst?
 
     Rollbar.info("User role has been granted access.", role: "analyst", path: request.path)
+  end
+
+  def set_view_fields
+    @no_of_users = User.count
+    @no_of_specs = Journey.count
+    @last_registration_date = UserPresenter.new(User.order(created_at: :desc).first).created_at
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,10 +14,18 @@ class User < ApplicationRecord
   # users belonging to the proc-ops team
   scope :internal, -> { where("orgs @> ?", %([{"name": "#{ENV['PROC_OPS_TEAM']}"}])) }
 
+  # users who have the "analyst" role
+  scope :analysts, -> { where("roles @> ?", %("analyst")) }
+
   # @return [false] distinguish from unauthenticated user
   #
   def guest?
     false
+  end
+
+  # @return [Boolean] user is an analyst
+  def analyst?
+    self.class.analysts.include?(self)
   end
 
   # @return [Boolean] user is not an internal team member or in a supported organisation

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,4 +1,4 @@
-class UserPresenter < SimpleDelegator
+class UserPresenter < BasePresenter
   # @return [Array<JourneyPresenter>]
   def active_journeys
     journeys.initial.map { |j| JourneyPresenter.new(j) }

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-l">Admin</h1>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,1 +1,24 @@
-<h1 class="govuk-heading-l">Admin</h1>
+<%= content_for :title, I18n.t("admin.header") %>
+
+<h1 class="govuk-heading-l"><%= I18n.t("admin.header") %></h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header"><%= I18n.t("admin.body.no_of_users") %></th>
+          <td class="govuk-table__cell"><%= @no_of_users %></td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header"><%= I18n.t("admin.body.no_of_specs") %></th>
+          <td class="govuk-table__cell"><%= @no_of_specs %></td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header"><%= I18n.t("admin.body.last_registration_date") %></th>
+          <td class="govuk-table__cell"><%= @last_registration_date %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/errors/missing_role.html.erb
+++ b/app/views/errors/missing_role.html.erb
@@ -1,0 +1,4 @@
+<%= content_for :title, I18n.t("errors.missing_role.page_title") %>
+
+<h1 class="govuk-heading-l"><%= I18n.t("errors.missing_role.page_title") %></h1>
+<p class="govuk-body"><%= I18n.t("errors.missing_role.page_body") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,9 @@ en:
     specification_template_invalid:
       page_title: An unexpected error occurred
       page_body: The service has had a problem trying to retrieve a working Specification template. The team have been notified of this problem and you should be able to retry shortly.
+    missing_role:
+      page_title: Missing user role
+      page_body: You do not have the required role to access this page.
     sign_in:
       unexpected_failure:
         page_title: An unexpected error occurred

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,14 @@ en:
       read_procs_link: read buying procedures and procurement law for schools
       read_guides_link: read guides about goods and services
     back_button: Back to your dashboard
+  
+  # /admin
+  admin:
+    header: User activity data
+    body:
+      no_of_users: Total number of users
+      no_of_specs: Total number of specifications
+      last_registration_date: Last user registration date
 
   #
   # Supported ------------------------------------------------------------------

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,8 @@ Rails.application.routes.draw do
   #
   get "health_check" => "application#health_check"
 
+  get "admin", to: "admin#show"
+
   # Routes any/all Contentful Pages that are mirrored in t.pages
   # if a Page with :slug cannot be found, `errors/not_found` is rendered
   #

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -77,5 +77,11 @@ FactoryBot.define do
         ]
       end
     end
+
+    trait :analyst do
+      roles do
+        %w[analyst]
+      end
+    end
   end
 end

--- a/spec/features/self-serve/admin/show_spec.rb
+++ b/spec/features/self-serve/admin/show_spec.rb
@@ -7,10 +7,17 @@ RSpec.feature "Admin page" do
   end
 
   context "when the user is an analyst" do
-    let(:user) { create(:user, :analyst) }
+    let(:user) { create(:user, :analyst, created_at: Time.zone.parse("2021-12-20")) }
 
     it "shows the page content" do
-      expect(find("h1.govuk-heading-l")).to have_text "Admin"
+      expect(page).to have_title "User activity data"
+      expect(find("h1.govuk-heading-l")).to have_text "User activity data"
+      expect(all("th.govuk-table__header")[0]).to have_text "Total number of users"
+      expect(all("td.govuk-table__cell")[0]).to have_text "1"
+      expect(all("th.govuk-table__header")[1]).to have_text "Total number of specifications"
+      expect(all("td.govuk-table__cell")[1]).to have_text "0"
+      expect(all("th.govuk-table__header")[2]).to have_text "Last user registration date"
+      expect(all("td.govuk-table__cell")[2]).to have_text "20 December 2021"
     end
 
     it "reports access to Rollbar" do
@@ -23,6 +30,7 @@ RSpec.feature "Admin page" do
     let(:user) { create(:user) }
 
     it "shows a missing role error" do
+      expect(page).to have_title "Missing user role"
       expect(find("h1.govuk-heading-l")).to have_text "Missing user role"
       expect(find("p.govuk-body")).to have_text "You do not have the required role to access this page."
     end

--- a/spec/features/self-serve/admin/show_spec.rb
+++ b/spec/features/self-serve/admin/show_spec.rb
@@ -1,0 +1,30 @@
+RSpec.feature "Admin page" do
+  before do
+    user_exists_in_dfe_sign_in(user: user)
+    visit "/"
+    click_start
+    visit "/admin"
+  end
+
+  context "when the user is an analyst" do
+    let(:user) { create(:user, :analyst) }
+
+    it "shows the page content" do
+      expect(find("h1.govuk-heading-l")).to have_text "Admin"
+    end
+
+    it "reports access to Rollbar" do
+      expect(Rollbar).to receive(:info).with("User role has been granted access.", role: "analyst", path: "/admin")
+      visit "/admin"
+    end
+  end
+
+  context "when the user is not an analyst" do
+    let(:user) { create(:user) }
+
+    it "shows a missing role error" do
+      expect(find("h1.govuk-heading-l")).to have_text "Missing user role"
+      expect(find("p.govuk-body")).to have_text "You do not have the required role to access this page."
+    end
+  end
+end

--- a/spec/models/self-serve/user/user_analyst_spec.rb
+++ b/spec/models/self-serve/user/user_analyst_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe User, type: :model do
+  let!(:analyst) { create(:user, :analyst) }
+  let!(:not_analyst) { create(:user) }
+
+  describe ".analysts" do
+    it "returns users with the analyst role" do
+      users = described_class.analysts
+      expect(users.size).to eq 1
+      expect(users.first.roles.first).to eq "analyst"
+    end
+  end
+
+  describe "#analyst?" do
+    it "returns true if the user is an analyst" do
+      expect(analyst.analyst?).to be true
+    end
+
+    it "returns false if the user is not an analyst" do
+      expect(not_analyst.analyst?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- add new page `/admin`
- add new `User` scope `analysts`

## Screenshots of UI changes

![image](https://user-images.githubusercontent.com/12530193/146799790-70a8808e-d469-459d-973a-fab1787015a8.png)