### PR TITLE
Hide internal team members from assignable case workers

### DIFF
--- a/app/controllers/support/cases/assignments_controller.rb
+++ b/app/controllers/support/cases/assignments_controller.rb
@@ -48,7 +48,7 @@ module Support
     end
 
     def load_agents
-      @agents = Agent.all.map { |a| AgentPresenter.new(a) }.sort_by(&:full_name)
+      @agents = Agent.caseworkers.map { |a| AgentPresenter.new(a) }.sort_by(&:full_name)
     end
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,19 +15,7 @@ class TasksController < ApplicationController
       StepPresenter.new(step)
     end
 
-    # TODO: Refactor to use a private record_action method
-    RecordAction.new(
-      action: "view_task",
-      journey_id: @journey.id,
-      user_id: current_user.id,
-      contentful_category_id: @journey.category.contentful_id,
-      contentful_section_id: task.section.contentful_id,
-      contentful_task_id: task.contentful_id,
-      data: {
-        task_status: task.status,
-        task_step_tally: task.step_tally,
-      },
-    ).call
+    record_action("view_task")
   end
 
 private
@@ -50,9 +38,14 @@ private
 
     @journey = current_journey
 
-    # TODO: Refactor to use a private record_action method
+    record_action("begin_task")
+
+    redirect_to journey_step_path(current_journey, task.next_incomplete_step_id)
+  end
+
+  def record_action(action)
     RecordAction.new(
-      action: "begin_task",
+      action: action,
       journey_id: @journey.id,
       user_id: current_user.id,
       contentful_category_id: @journey.category.contentful_id,
@@ -63,7 +56,5 @@ private
         task_step_tally: task.step_tally,
       },
     ).call
-
-    redirect_to journey_step_path(current_journey, task.next_incomplete_step_id)
   end
 end

--- a/app/models/support/agent.rb
+++ b/app/models/support/agent.rb
@@ -7,5 +7,8 @@ module Support
   #
   class Agent < ApplicationRecord
     has_many :cases, class_name: "Support::Case"
+
+    # agents that are not internal team members (genuine caseworkers)
+    scope :caseworkers, -> { where(internal: false) }
   end
 end

--- a/db/migrate/20211222162846_add_internal_to_support_agents.rb
+++ b/db/migrate/20211222162846_add_internal_to_support_agents.rb
@@ -1,0 +1,5 @@
+class AddInternalToSupportAgents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :support_agents, :internal, :boolean, null: false, default: false
+  end
+end

--- a/spec/factories/support/agent.rb
+++ b/spec/factories/support/agent.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     email       { "test@test" }
     first_name  { "first_name" }
     last_name   { "last_name" }
+    internal    { false }
   end
 end

--- a/spec/features/support/case_assignment_spec.rb
+++ b/spec/features/support/case_assignment_spec.rb
@@ -48,4 +48,20 @@ RSpec.feature "Case worker assignment" do
       expect(support_case.reload.agent).to eq(agent)
     end
   end
+
+  context "when there are internal agents" do
+    let(:support_case) { create(:support_case, :initial) }
+
+    before do
+      create(:support_agent, first_name: "Internal", last_name: "Agent", internal: true)
+      click_button "Agent Login"
+      visit support_case_path(support_case)
+      click_link "Assign to case worker"
+    end
+
+    it "does not show them in the caseworker list" do
+      expect(page).to have_field "Procurement Specialist"
+      expect(page).not_to have_field "Internal Agent"
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR

- add `internal` field to `agent`
- add `caseworkers` scope to `agent`
- filter out internal team members on the case assignment page