### PR TITLE
Ensure ms graph next link is followed

### DIFF
--- a/spec/lib/microsoft_graph/client_session_spec.rb
+++ b/spec/lib/microsoft_graph/client_session_spec.rb
@@ -36,6 +36,27 @@ describe MicrosoftGraph::ClientSession do
         )
       end
     end
+
+    context "when the response is paginated" do
+      let(:api_response) { '{"value":[{"displayName":"testResponse1"}],"@odata.nextLink":"https://api.endpoint.com?page=2"}' }
+      let(:page_2_response) { '{"value":[{"displayName":"testResponse2"}],"@odata.nextLink":"https://api.endpoint.com?page=3"}' }
+      let(:page_3_response) { '{"value":[{"displayName":"testResponse3"}]}' }
+
+      before do
+        stub_request(:get, "https://api.endpoint.com?page=2").to_return(body: page_2_response, status: 200)
+        stub_request(:get, "https://api.endpoint.com?page=3").to_return(body: page_3_response, status: 200)
+      end
+
+      it "calls each page and returns the combined results" do
+        response = client_session.graph_api_get("test/endpoint")
+
+        expect(response["value"]).to match_array([
+          { "displayName" => "testResponse1" },
+          { "displayName" => "testResponse2" },
+          { "displayName" => "testResponse3" },
+        ])
+      end
+    end
   end
 
   describe "#graph_api_post" do


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG?
-->

## Changes in this PR

Previously the ms graph api ignored paged result sets, this ensures that when there are a lot of results the graph library follows each page to get the entire result set.