### PR TITLE
Display inline email attachments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,6 +46,7 @@ Rails/BulkChangeTable:
     - 'db/migrate/20210118110545_change_options_to_jsonb.rb'
     - 'db/migrate/20211117133254_add_contentful_fields_to_page.rb'
     - 'db/migrate/20211217092216_add_extra_outlook_fields_to_support_email.rb'
+    - 'db/migrate/20220112131559_add_is_inline_to_support_email_attachments.rb'
 
 # Offense count: 2
 # Configuration parameters: Include.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :authenticate_user!, except: :health_check
+  before_action :set_active_storage_host
 
   protect_from_forgery
 
@@ -54,5 +55,9 @@ protected
   # Is the user currently on the support side?
   def support?
     false
+  end
+
+  def set_active_storage_host
+    ActiveStorage::Current.host = request.base_url
   end
 end

--- a/app/models/support/email_attachment.rb
+++ b/app/models/support/email_attachment.rb
@@ -5,6 +5,8 @@ module Support
 
     before_save :update_file_attributes
 
+    scope :inline, -> { where(is_inline: true) }
+
   private
 
     def update_file_attributes

--- a/app/presenters/support/email_presenter.rb
+++ b/app/presenters/support/email_presenter.rb
@@ -28,5 +28,15 @@ module Support
     def sent_at_formatted
       sent_at.strftime(short_date_time)
     end
+
+    def body_with_inline_attachments(view_context)
+      inline_attachments = attachments.inline.index_by(&:content_id)
+
+      body.tap do |body_with_attachments|
+        inline_attachments.each do |content_id, attachment|
+          body_with_attachments.gsub!("cid:#{content_id}", view_context.url_for(attachment.file))
+        end
+      end
+    end
   end
 end

--- a/app/views/support/emails/show.html.erb
+++ b/app/views/support/emails/show.html.erb
@@ -34,6 +34,6 @@
   </dl>
 
   <div class="email-preview-body">
-    <%= @email.body.html_safe %>
+    <%= @email.body_with_inline_attachments(self).html_safe %>
   </div>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,19 +3,19 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "30446d6fe63f00d0c4334e5fc7ead53313bbbdc04d768778314bab88e5b511f4",
+      "fingerprint": "55a40e18bfdb22296c2883cd469b194cc721fd4762abdc4d8b4a40d338ea5401",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped parameter value",
       "file": "app/views/support/emails/show.html.erb",
-      "line": 35,
+      "line": 37,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "EmailPresenter.new(Support::Email.find(params[:id])).body",
+      "code": "EmailPresenter.new(Support::Email.find(params[:id])).body_with_inline_attachments(self)",
       "render_path": [
         {
           "type": "controller",
           "class": "Support::EmailsController",
           "method": "show",
-          "line": 11,
+          "line": 12,
           "file": "app/controllers/support/emails_controller.rb",
           "rendered": {
             "name": "support/emails/show",
@@ -63,6 +63,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-12-20 15:11:10 +0000",
+  "updated": "2022-01-13 09:06:32 +0000",
   "brakeman_version": "5.2.0"
 }

--- a/db/migrate/20220112131559_add_is_inline_to_support_email_attachments.rb
+++ b/db/migrate/20220112131559_add_is_inline_to_support_email_attachments.rb
@@ -1,0 +1,6 @@
+class AddIsInlineToSupportEmailAttachments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :support_email_attachments, :is_inline, :boolean, default: false
+    add_column :support_email_attachments, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_12_104638) do
+ActiveRecord::Schema.define(version: 2022_01_12_131559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -264,6 +264,8 @@ ActiveRecord::Schema.define(version: 2022_01_12_104638) do
     t.uuid "email_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_inline", default: false
+    t.string "content_id"
   end
 
   create_table "support_emails", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/presenters/support/email_presenter_spec.rb
+++ b/spec/presenters/support/email_presenter_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Support::EmailPresenter do
+  describe "#body_with_inline_attachments" do
+    include Rails.application.routes.url_helpers
+
+    context "when there is an inline email attachment" do
+      subject(:presenter) { described_class.new(email) }
+
+      let(:email) { create(:support_email, body: "<img src=\"cid:A.B.C\" /> <img src=\"cid:X.Y.Z\" />") }
+      let!(:attachment1) { create(:support_email_attachment, is_inline: true, content_id: "A.B.C", email: email) }
+      let!(:attachment2) { create(:support_email_attachment, is_inline: true, content_id: "X.Y.Z", email: email) }
+
+      it "replaces each attachment content id with its url" do
+        view_context = self # as application route helpers are included
+
+        expect(presenter.body_with_inline_attachments(view_context)).to eq(
+          "<img src=\"#{url_for(attachment1.file)}\" /> <img src=\"#{url_for(attachment2.file)}\" />",
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG?
-->

## Changes in this PR

Email attachments marked as "inline" are displayed within the email body as expected.

## Screenshots of UI changes

![Screenshot 2022-01-12 at 16 48 41](https://user-images.githubusercontent.com/1352756/149185122-534b5d04-1d38-4583-8016-226234c157f3.png)

