### PR TITLE
Bug: Email preview requires reference variable

### DIFF
--- a/app/controllers/support/cases/emails/content_controller.rb
+++ b/app/controllers/support/cases/emails/content_controller.rb
@@ -52,6 +52,7 @@ module Support
           first_name: @current_case.first_name,
           last_name: @current_case.last_name,
           from_name: current_agent.full_name,
+          reference: @current_case.ref,
         },
       )
     end


### PR DESCRIPTION
## Changes in this PR

Notify templates have "reference" variable defined, the email preview functionality does not currently supply it.
Notify errors when a defined variable is not supplied.
This PR fixes the issue by defining the variable.