### PR TITLE
Error on phone number validation

### DIFF
--- a/app/forms/support/case_hub_migration_form_schema.rb
+++ b/app/forms/support/case_hub_migration_form_schema.rb
@@ -25,7 +25,7 @@ module Support
     end
 
     # TODO: custom macro for phone number validation
-    rule(:phone_number).validate(format?: /^(?:0|\+?44)(?:\d\s*){9,10}$/)
+    rule(:phone_number).validate(max_size?: 13, format?: /^$|^(0|\+?44)[12378]\d{8,9}$/)
 
     # TODO: custom macro using chronic
     rule(:estimated_procurement_completion_date).validate(format?: /(^$|^\d{2}\/\d{2}\/\d{4}$)/)

--- a/app/forms/support/case_hub_migration_form_schema.rb
+++ b/app/forms/support/case_hub_migration_form_schema.rb
@@ -25,7 +25,7 @@ module Support
     end
 
     # TODO: custom macro for phone number validation
-    rule(:phone_number).validate(max_size?: 11, format?: /(^$|^0\d{10,}$)/)
+    rule(:phone_number).validate(format?: /^(?:0|\+?44)(?:\d\s*){9,10}$/)
 
     # TODO: custom macro using chronic
     rule(:estimated_procurement_completion_date).validate(format?: /(^$|^\d{2}\/\d{2}\/\d{4}$)/)

--- a/app/forms/support_form_schema.rb
+++ b/app/forms/support_form_schema.rb
@@ -20,7 +20,7 @@ class SupportFormSchema < Dry::Validation::Contract
     optional(:message_body).value(:string)  # step 5
   end
 
-  rule(:phone_number).validate(max_size?: 11, format?: /(^$|^0\d{10,}$)/)
+  rule(:phone_number).validate(format?: /^(?:0|\+?44)(?:\d\s*){9,10}$/)
 
   rule(:school_urn) do
     key(:school_urn).failure(:missing) if key? && value.blank?

--- a/app/forms/support_form_schema.rb
+++ b/app/forms/support_form_schema.rb
@@ -20,7 +20,7 @@ class SupportFormSchema < Dry::Validation::Contract
     optional(:message_body).value(:string)  # step 5
   end
 
-  rule(:phone_number).validate(format?: /^(?:0|\+?44)(?:\d\s*){9,10}$/)
+  rule(:phone_number).validate(max_size?: 13, format?: /^$|^(0|\+?44)[12378]\d{8,9}$/)
 
   rule(:school_urn) do
     key(:school_urn).failure(:missing) if key? && value.blank?

--- a/config/locales/validation/en.yml
+++ b/config/locales/validation/en.yml
@@ -11,8 +11,8 @@ en:
       rules:
         phone_number:
           missing: is missing
-          # format?: must start with a zero and only contain digits
-          format?: must have a minimum of 10 and maximum 12 digits with no spaces, starting with a zero or +44
+          format?: must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits
+          max_size?: "can not have more than 12 digits"
 
         message_body:
           missing: You must tell us how we can help

--- a/config/locales/validation/en.yml
+++ b/config/locales/validation/en.yml
@@ -1,7 +1,6 @@
 # config/validation/en.yml
 en:
   forms:
-
     rules:
       phone_number: Your phone number
       message_body: "" # Omitted
@@ -13,9 +12,7 @@ en:
         phone_number:
           missing: is missing
           # format?: must start with a zero and only contain digits
-          format?: must have a minimum of 10 numbers and no spaces, starting with a zero
-          # min_size?: "must have at least %{num} digits"
-          max_size?: "can not have more than %{num} digits"
+          format?: must have a minimum of 10 and maximum 12 digits with no spaces, starting with a zero or +44
 
         message_body:
           missing: You must tell us how we can help

--- a/config/locales/validation/en.yml
+++ b/config/locales/validation/en.yml
@@ -11,7 +11,9 @@ en:
       rules:
         phone_number:
           missing: is missing
+          # rules as follows; (i) permits empty string for no entry, (ii) 0 followed by 9 or 10 digits, OR +44 followed by 9 or 10 digits, with the digit immediately following one of [12378] (iii) no spaces at any point in the number
           format?: must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits
+          # value in schema set to 13 as includes the + in +44
           max_size?: "can not have more than 12 digits"
 
         message_body:

--- a/config/locales/validation/support/en.yml
+++ b/config/locales/validation/support/en.yml
@@ -69,11 +69,7 @@ en:
           missing: is missing
 
         phone_number:
-          # format?: must start with a zero and only contain digits
-          format?: must have a minimum of 10 numbers and no spaces, starting with a zero
-          # min_size?: "must have at least %{num} digits"
-          max_size?: "can not have more than %{num} digits"
+          format?: must have a minimum of 10 and maximum 12 digits with no spaces, starting with a zero or +44
 
         estimated_procurement_completion_date:
           format?: must follow the format of DD/MM/YYYY
-

--- a/config/locales/validation/support/en.yml
+++ b/config/locales/validation/support/en.yml
@@ -69,7 +69,8 @@ en:
           missing: is missing
 
         phone_number:
-          format?: must have a minimum of 10 and maximum 12 digits with no spaces, starting with a zero or +44
+          format?: must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits
+          max_size?: "can not have more than 12 digits"
 
         estimated_procurement_completion_date:
           format?: must follow the format of DD/MM/YYYY

--- a/config/locales/validation/support/en.yml
+++ b/config/locales/validation/support/en.yml
@@ -69,7 +69,9 @@ en:
           missing: is missing
 
         phone_number:
+          # rules as follows; (i) permits empty string for no entry, (ii) 0 followed by 9 or 10 digits, OR +44 followed by 9 or 10 digits, with the digit immediately following one of [12378] (iii) no spaces at any point in the number
           format?: must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits
+          # value in schema set to 13 as includes the + in +44
           max_size?: "can not have more than 12 digits"
 
         estimated_procurement_completion_date:

--- a/spec/factories/support_request.rb
+++ b/spec/factories/support_request.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :support_request do
     message_body { "Support request message from a School Buying Professional" }
-    phone_number { "0151 000 0000" }
+    phone_number { "07756471233" }
     association :user
     association :category
 

--- a/spec/features/self-serve/support_requests/create_support_request_spec.rb
+++ b/spec/features/self-serve/support_requests/create_support_request_spec.rb
@@ -91,8 +91,8 @@ RSpec.feature "Create a new support request" do
         fill_in "support_form[phone_number]", with: "0123"
         click_continue
         expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
-        expect(page).to have_link "Your phone number must have a minimum of 10 numbers and no spaces, starting with a zero", href: "#support-form-phone-number-field-error"
-        expect(find("span.govuk-error-message")).to have_text "Your phone number must have a minimum of 10 numbers and no spaces, starting with a zero"
+        expect(page).to have_link "Your phone number must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits", href: "#support-form-phone-number-field-error"
+        expect(find("span.govuk-error-message")).to have_text "Your phone number must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits"
       end
 
       # step 1
@@ -100,8 +100,8 @@ RSpec.feature "Create a new support request" do
         fill_in "support_form[phone_number]", with: "11234567890"
         click_continue
         expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
-        expect(page).to have_link "Your phone number must have a minimum of 10 numbers and no spaces, starting with a zero", href: "#support-form-phone-number-field-error"
-        expect(find("span.govuk-error-message")).to have_text "Your phone number must have a minimum of 10 numbers and no spaces, starting with a zero"
+        expect(page).to have_link "Your phone number must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits", href: "#support-form-phone-number-field-error"
+        expect(find("span.govuk-error-message")).to have_text "Your phone number must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits"
       end
 
       # step 1
@@ -109,17 +109,17 @@ RSpec.feature "Create a new support request" do
         fill_in "support_form[phone_number]", with: "0123456789x"
         click_continue
         expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
-        expect(page).to have_link "Your phone number must have a minimum of 10 numbers and no spaces, starting with a zero", href: "#support-form-phone-number-field-error"
-        expect(find("span.govuk-error-message")).to have_text "Your phone number must have a minimum of 10 numbers and no spaces, starting with a zero"
+        expect(page).to have_link "Your phone number must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits", href: "#support-form-phone-number-field-error"
+        expect(find("span.govuk-error-message")).to have_text "Your phone number must have no spaces and begin with a 0 or +44, with a minimum of 10 and maximum 12 digits"
       end
 
       # step 1
       it "(max size)" do
-        fill_in "support_form[phone_number]", with: "012345678901"
+        fill_in "support_form[phone_number]", with: "+4412345678901343"
         click_continue
         expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
-        expect(page).to have_link "Your phone number can not have more than 11 digits", href: "#support-form-phone-number-field-error"
-        expect(find("span.govuk-error-message")).to have_text "Your phone number can not have more than 11 digits"
+        expect(page).to have_link "Your phone number can not have more than 12 digits", href: "#support-form-phone-number-field-error"
+        expect(find("span.govuk-error-message")).to have_text "Your phone number can not have more than 12 digits"
       end
     end
   end
@@ -184,7 +184,6 @@ RSpec.feature "Create a new support request" do
     it "infers the category from the chosen spec" do
       choose "1 September 2021"
       click_continue
-
       expect(find("span.govuk-caption-l")).to have_text "About your procurement"
       expect(find("label.govuk-label--l")).to have_text "How can we help?"
       expect(find("span.govuk-hint")).to have_text "Briefly describe your problem in a few sentences."

--- a/spec/features/support/case_migration_spec.rb
+++ b/spec/features/support/case_migration_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Case summary" do
     fill_in "case_hub_migration_form[first_name]", with: "first_name"
     fill_in "case_hub_migration_form[last_name]", with: "last_name"
     fill_in "case_hub_migration_form[email]", with: "test@example.com"
-    fill_in "case_hub_migration_form[phone_number]", with: "00000000000"
+    fill_in "case_hub_migration_form[phone_number]", with: "0778974653"
   end
 
   def complete_valid_form


### PR DESCRIPTION
## Changes in this PR

- amended rule for phone number validation in hub cases as follows; (i) permits empty string in event of no entry, (ii) 0 followed by 9 or 10 digits, OR +44 followed by 9 or 10 digits, (iii) no spaces at any point in the number
- max_digits? captures the + in +44, so value of 13, although message correctly displays 12, with number entered greater than 12 digits
