### PR TITLE
Remove email "unread" styling for now

### DIFF
--- a/app/views/support/emails/_email_list.html.erb
+++ b/app/views/support/emails/_email_list.html.erb
@@ -15,7 +15,7 @@
     <% end %>
 
     <% emails.each do |email| %>
-      <tr class="govuk-table__row email-row <%= email.is_read ? "read" : "unread" %>">
+      <tr class="govuk-table__row email-row">
         <td class="govuk-table__cell email-sent-by">
           <span title="<%= email.sent_by_email %>">
             <%= email.sent_by_name %>


### PR DESCRIPTION
## Changes in this PR

Emails being bold when unread looks odd given you cannot mark them as read yet.
Put this styling back in when "mark as read" story is developed