### PR TITLE
Retain edited email body when going back from preview

### DIFF
--- a/app/controllers/support/cases/emails/content_controller.rb
+++ b/app/controllers/support/cases/emails/content_controller.rb
@@ -33,7 +33,7 @@ module Support
       @case_email_content_form = CaseEmailContentForm.from_validation(validation)
 
       if validation.success?
-        @back_url = edit_support_case_email_content_path(@current_case)
+        @back_url = edit_support_case_email_content_path(@current_case, case_email_content_form: { email_body: case_email_content_form_params[:email_body] })
 
         render :show
       else
@@ -69,6 +69,8 @@ module Support
     end
 
     def basic_email_body
+      return case_email_content_form_params[:email_body] if params[:case_email_content_form].present?
+
       I18n.t("support.case_email_content.edit.default_email_body.non_template")
     end
 

--- a/spec/features/support/emails/agent_sends_basic_email_spec.rb
+++ b/spec/features/support/emails/agent_sends_basic_email_spec.rb
@@ -40,6 +40,11 @@ describe "Support agent sends a basic email" do
       end
     end
 
+    it "retains the updated email body when clicking back on the preview" do
+      click_link "Back"
+      expect(page).to have_field("Enter email body", with: "New email body")
+    end
+
     context "when leaving the email body blank" do
       let(:custom_email_body) { "" }
 


### PR DESCRIPTION
## Changes in this PR

If a user edited the body of a non-template email and then went to the preview, they would lose the changes they'd made. This allows them to keep it.