### PR TITLE
[232, 233] Faf - name and email

### DIFF
--- a/app/forms/framework_support_form_schema.rb
+++ b/app/forms/framework_support_form_schema.rb
@@ -3,6 +3,8 @@
 # Validate "find-a-framework support requests"
 #
 class FrameworkSupportFormSchema < Schema
+  config.messages.top_namespace = :framework_request
+
   params do
     optional(:dsi).value(:bool)               # step 1
 

--- a/app/forms/framework_support_form_schema.rb
+++ b/app/forms/framework_support_form_schema.rb
@@ -33,6 +33,8 @@ class FrameworkSupportFormSchema < Schema
     key.failure(:missing) if key? && value.blank?
   end
 
+  rule(:email).validate(format?: URI::MailTo::EMAIL_REGEXP)
+
   rule(:school_urn) do
     key.failure(:missing) if key? && value.blank?
   end

--- a/app/forms/framework_support_form_schema.rb
+++ b/app/forms/framework_support_form_schema.rb
@@ -30,10 +30,16 @@ class FrameworkSupportFormSchema < Schema
   end
 
   rule(:email) do
-    key.failure(:missing) if key? && value.blank?
+    if key? && (value.blank? || !URI::MailTo::EMAIL_REGEXP.match?(value))
+      key.failure(:missing)
+    end
   end
 
-  rule(:email).validate(format?: URI::MailTo::EMAIL_REGEXP)
+  # rule(:email) do
+  #   unless !key? || URI::MailTo::EMAIL_REGEXP.match?(value)
+  #     key.failure(:invalid)
+  #   end
+  # end
 
   rule(:school_urn) do
     key.failure(:missing) if key? && value.blank?

--- a/app/forms/framework_support_form_schema.rb
+++ b/app/forms/framework_support_form_schema.rb
@@ -35,12 +35,6 @@ class FrameworkSupportFormSchema < Schema
     end
   end
 
-  # rule(:email) do
-  #   unless !key? || URI::MailTo::EMAIL_REGEXP.match?(value)
-  #     key.failure(:invalid)
-  #   end
-  # end
-
   rule(:school_urn) do
     key.failure(:missing) if key? && value.blank?
   end

--- a/app/views/framework_requests/steps/_form.html.erb
+++ b/app/views/framework_requests/steps/_form.html.erb
@@ -13,12 +13,7 @@
   %>
 <% end %>
 
-<% if Rails.env.development? %>
-  <%= debug @faf&.attributes %>
-  <%= debug @framework_support_form.step %>
-  <%= debug @current_user.supported_schools %>
-  <%= debug @framework_support_form.to_h %>
-<% end %>
+
 
 <%= form_with model: @framework_support_form, scope: :framework_support_form, url: path, method: verb  do |form| %>
   <%= form.govuk_error_summary %>

--- a/app/views/framework_requests/steps/_form.html.erb
+++ b/app/views/framework_requests/steps/_form.html.erb
@@ -13,7 +13,12 @@
   %>
 <% end %>
 
-
+<% if Rails.env.development? %>
+  <%= debug @faf&.attributes %>
+  <%= debug @framework_support_form.step %>
+  <%= debug @current_user.supported_schools %>
+  <%= debug @framework_support_form.to_h %>
+<% end %>
 
 <%= form_with model: @framework_support_form, scope: :framework_support_form, url: path, method: verb  do |form| %>
   <%= form.govuk_error_summary %>

--- a/app/views/framework_requests/steps/_step_2.html.erb
+++ b/app/views/framework_requests/steps/_step_2.html.erb
@@ -14,4 +14,4 @@
 
 <%= form.govuk_text_field :first_name, autofocus: true, label: { text: I18n.t("faf.name.first_name.label") } %>
 
-<%= form.govuk_text_field :last_name, autofocus: true, label: { text: I18n.t("faf.name.last_name.label") } %>
+<%= form.govuk_text_field :last_name, label: { text: I18n.t("faf.name.last_name.label") } %>

--- a/app/views/framework_requests/steps/_step_2.html.erb
+++ b/app/views/framework_requests/steps/_step_2.html.erb
@@ -2,5 +2,16 @@
 
 <%= form.hidden_field :dsi, value: form.object.dsi %>
 
-<%= form.govuk_text_field :first_name, autofocus: true %>
-<%= form.govuk_text_field :last_name %>
+<%= content_for :title, I18n.t("faf.name.title") %>
+
+<span class="govuk-caption-l">
+  <%= I18n.t("faf.name.title") %>
+</span>
+
+<h1 class="govuk-heading-l">
+  <%= I18n.t("faf.name.subtitle") %>
+</h1>
+
+<%= form.govuk_text_field :first_name, autofocus: true, label: { text: I18n.t("faf.name.first_name.label") } %>
+
+<%= form.govuk_text_field :last_name, autofocus: true, label: { text: I18n.t("faf.name.last_name.label") } %>

--- a/app/views/framework_requests/steps/_step_3.html.erb
+++ b/app/views/framework_requests/steps/_step_3.html.erb
@@ -5,16 +5,15 @@
 <%= form.hidden_field :last_name, value: form.object.last_name %>
 
 <span class="govuk-caption-l">
-  EMAIL
+  <%= I18n.t("faf.email.subtitle") %>
 </span>
-<h1 class="govuk-heading-l">
-  EMAIL
+
+<h1 class="govuk-label-wrapper">
+  <label class="govuk-label govuk-label--l" for="email-address">
+    <%= I18n.t("faf.email.title") %>
+  </label>
 </h1>
 
-<%= form.govuk_text_field :email,
-                          autofocus: true
-                        %>
-
-<br>
+<%= form.govuk_text_field :email, autofocus: true, label: { text: I18n.t("faf.email.label"), class: "govuk-hint" } %>
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,6 +276,8 @@ en:
 
   # /request-help-and-support-with-your-procurement
   faf:
+
+    # step 0
     start_page:
       header: Request advice and guidance for your procurement
       overview_purpose: Use this service if you're procuring for a single school in England, either
@@ -289,6 +291,23 @@ en:
       overview_response: The Get help buying for schools team will respond to you within 2 working days.
       subheading: Before you start
       you_can: You can
+
+    # step 2
+    name:
+      title: What is your name?
+      subtitle: About you
+      first_name:
+        label: First Name
+      last_name:
+        label: Last Name
+
+    # step 3
+    email:
+      title: What is your email address?
+      subtitle: About you
+      label: We will only use this to contact you about your request.
+
+    # step 5
     user_query:
       caption: About your request
       label: How can we help?
@@ -308,6 +327,7 @@ en:
       button:
         continue: Yes, continue
 
+    # step 1
     dsi_or_search:
       header: Do you have a DfE Sign-in account linked to the school you're requesting support for?
       subtitle: About your school

--- a/config/locales/validation/en.yml
+++ b/config/locales/validation/en.yml
@@ -41,5 +41,4 @@ en:
         last_name:
           missing: Enter your last name
         email:
-          format?: Enter an email in the correct format. For example, 'someone@school.sch.uk'.
           missing: Enter an email in the correct format. For example, 'someone@school.sch.uk'.

--- a/config/locales/validation/en.yml
+++ b/config/locales/validation/en.yml
@@ -41,4 +41,5 @@ en:
         last_name:
           missing: Enter your last name
         email:
+          format?: Enter an email in the correct format. For example, 'someone@school.sch.uk'.
           missing: Enter an email in the correct format. For example, 'someone@school.sch.uk'.

--- a/config/locales/validation/en.yml
+++ b/config/locales/validation/en.yml
@@ -27,3 +27,18 @@ en:
 
         school_urn:
           missing: You must select a school
+
+  framework_request:
+    rules:
+      first_name: "" # Omitted
+      last_name: "" # Omitted
+      email: "" # Omitted
+
+    errors:
+      rules:
+        first_name:
+          missing: Enter your first name
+        last_name:
+          missing: Enter your last name
+        email:
+          missing: Enter an email in the correct format. For example, 'someone@school.sch.uk'.


### PR DESCRIPTION
## Changes in this PR

* formatting for email and name faf pages
* custom error messages
* adds email format validation

## Screenshots of UI changes

<img width="1026" alt="1Screenshot 2022-01-26 at 12 44 54" src="https://user-images.githubusercontent.com/6339025/151165451-cbc05703-b469-4cd0-b0e0-4a2f989fda54.png">
<img width="1026" alt="2Screenshot 2022-01-26 at 12 45 03" src="https://user-images.githubusercontent.com/6339025/151165459-96dffeac-342f-4cce-8b2b-9424083efa8b.png">
<img width="936" alt="3Screenshot 2022-01-26 at 12 45 21" src="https://user-images.githubusercontent.com/6339025/151165462-6d65fc2f-4009-4131-9e44-9cf557798934.png">
<img width="919" alt="4Screenshot 2022-01-26 at 12 45 33" src="https://user-images.githubusercontent.com/6339025/151165467-5bfd6804-ee61-4bf3-a538-64107aa4bbff.png">
<img width="919" alt="5Screenshot 2022-01-26 at 12 45 39" src="https://user-images.githubusercontent.com/6339025/151165469-7c3af642-69be-4750-8d0b-60e3b0c3d47c.png">

