### PR TITLE
Add case reference to personalisation params on non-templated emails

### DIFF
--- a/app/controllers/support/cases/emails/content_controller.rb
+++ b/app/controllers/support/cases/emails/content_controller.rb
@@ -63,12 +63,9 @@ module Support
     def personalisation
       contact = CaseContactPresenter.new(@current_case)
 
-      personalisation_params = { first_name: contact.first_name, last_name: contact.last_name, from_name: current_agent.full_name }
+      personalisation_params = { first_name: contact.first_name, last_name: contact.last_name, from_name: current_agent.full_name, reference: @current_case.ref }
 
-      if basic_template?
-        personalisation_params[:text] = basic_email_body
-        personalisation_params[:reference] = @current_case.ref
-      end
+      personalisation_params[:text] = basic_email_body if basic_template?
 
       personalisation_params
     end

--- a/app/controllers/support/cases/emails/content_controller.rb
+++ b/app/controllers/support/cases/emails/content_controller.rb
@@ -65,7 +65,10 @@ module Support
 
       personalisation_params = { first_name: contact.first_name, last_name: contact.last_name, from_name: current_agent.full_name }
 
-      personalisation_params[:text] = basic_email_body if basic_template?
+      if basic_template?
+        personalisation_params[:text] = basic_email_body
+        personalisation_params[:reference] = @current_case.ref
+      end
 
       personalisation_params
     end

--- a/spec/features/support/emails/agent_sends_basic_email_spec.rb
+++ b/spec/features/support/emails/agent_sends_basic_email_spec.rb
@@ -16,6 +16,7 @@ describe "Support agent sends a basic email" do
         last_name: "Contact",
         text: default_email_body,
         from_name: "Procurement Specialist",
+        reference: "00001",
       },
     }
   end
@@ -58,6 +59,7 @@ describe "Support agent sends a basic email" do
           last_name: "Contact",
           text: custom_email_body,
           from_name: "Procurement Specialist",
+          reference: "000001",
         },
       }
     end
@@ -106,6 +108,7 @@ describe "Support agent sends a basic email" do
           last_name: "Contact",
           text: default_email_body,
           from_name: "Procurement Specialist",
+          reference: "000001",
         },
       }
     end
@@ -162,6 +165,7 @@ describe "Support agent sends a basic email" do
           last_name: "Contact",
           text: "New email body",
           from_name: "Procurement Specialist",
+          reference: "000001",
         },
       }
     end

--- a/spec/features/support/emails/agent_sends_templated_email_spec.rb
+++ b/spec/features/support/emails/agent_sends_templated_email_spec.rb
@@ -10,6 +10,7 @@ describe "Support agent sends a templated email" do
         first_name: "School",
         last_name: "Contact",
         from_name: "Procurement Specialist",
+        reference: "000001",
       },
     }
   end


### PR DESCRIPTION
## Changes in this PR

Sends the case reference as a personalised parameter for non-templated emails. 

## Next steps

Basic email template will have to be updated to include the reference in the subject and email body.