### PR TITLE
FaF school type change link fix

### DIFF
--- a/app/controllers/framework_requests_controller.rb
+++ b/app/controllers/framework_requests_controller.rb
@@ -111,9 +111,15 @@ class FrameworkRequestsController < ApplicationController
       #   @support_form.advance!
       #   render :edit
       # else
-      framework_request.update!(**framework_request.attributes.symbolize_keys, **@framework_support_form.to_h.merge(school_urn: urn, group_uid: group_uid))
-      redirect_to framework_request_path(framework_request), notice: I18n.t("support_request.flash.updated")
-      # end
+      if @framework_support_form.step == 2
+        @framework_support_form.advance!
+        render :edit
+      else
+
+        framework_request.update!(**framework_request.attributes.symbolize_keys, **@framework_support_form.to_h.merge(school_urn: urn, group_uid: group_uid))
+        redirect_to framework_request_path(framework_request), notice: I18n.t("support_request.flash.updated")
+        # end
+      end
     else
       render :edit
     end

--- a/app/controllers/framework_requests_controller.rb
+++ b/app/controllers/framework_requests_controller.rb
@@ -107,18 +107,15 @@ class FrameworkRequestsController < ApplicationController
 
       # CONDITIONAL extra questions as a result of saved changes
 
-      # if @support_form.step == 3 && !@support_form.has_journey?
-      #   @support_form.advance!
-      #   render :edit
-      # else
-      if @framework_support_form.step == 2
-        @framework_support_form.advance!
+      # NOTE: Selecting school type change link on CYA (no dsi) permits user to proceed through to selecting school or group selection after step 2
+      if @framework_support_form.position?(2)
+        # NOTE: Goes to school or group lookup (no dsi)
+        @framework_support_form.go_to!(3)
         render :edit
       else
 
         framework_request.update!(**framework_request.attributes.symbolize_keys, **@framework_support_form.to_h.merge(school_urn: urn, group_uid: group_uid))
         redirect_to framework_request_path(framework_request), notice: I18n.t("support_request.flash.updated")
-        # end
       end
     else
       render :edit

--- a/app/views/framework_requests/show.html.erb
+++ b/app/views/framework_requests/show.html.erb
@@ -69,7 +69,7 @@
           </dd>
         <% end %>
         <dd class="govuk-summary-list__actions">
-          <% unless @framework_request.submitted? %>
+          <% unless @framework_request.submitted? || !current_user.guest? %>
             <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_path(@framework_request, step: 2), class: "govuk-link", id: "edit-school-type" %>
           <% end %>
         </dd>

--- a/spec/features/self-serve/faf/create_framework_request_spec.rb
+++ b/spec/features/self-serve/faf/create_framework_request_spec.rb
@@ -205,7 +205,7 @@ RSpec.feature "Create a new framework request" do
 
             expect(all("dt.govuk-summary-list__key")[3]).to have_text "School type"
             expect(all("dd.govuk-summary-list__value")[3]).to have_text "Single"
-            expect(all("dd.govuk-summary-list__actions")[3]).to have_link "Change"
+            expect(all("dd.govuk-summary-list__actions")[3]).not_to have_link "Change"
 
             expect(all("dt.govuk-summary-list__key")[4]).to have_text "Description of request"
             expect(all("dd.govuk-summary-list__value")[4]).to have_text "I have a problem"
@@ -271,7 +271,7 @@ RSpec.feature "Create a new framework request" do
 
             expect(all("dt.govuk-summary-list__key")[3]).to have_text "School type"
             expect(all("dd.govuk-summary-list__value")[3]).to have_text "Single"
-            expect(all("dd.govuk-summary-list__actions")[3]).to have_link "Change"
+            expect(all("dd.govuk-summary-list__actions")[3]).not_to have_link "Change"
 
             expect(all("dt.govuk-summary-list__key")[4]).to have_text "Description of request"
             expect(all("dd.govuk-summary-list__value")[4]).to have_text "I have a problem"


### PR DESCRIPTION
## Changes in this PR

- No DSI journey - 'school type' change link now permits user to then select school/group after changing selection at step 2
- DSI journey - 'school type' change link no longer appearing.
