### PR TITLE
Change order of cases in supported

### DIFF
--- a/app/controllers/support/cases_controller.rb
+++ b/app/controllers/support/cases_controller.rb
@@ -12,9 +12,9 @@ module Support
         end
 
         format.html do
-          @cases = Case.includes(%i[agent category organisation]).all.map { |c| CasePresenter.new(c) }.sort_by(&:last_updated_at_date).paginate(page: params[:cases_page])
-          @new_cases = Case.includes(%i[agent category organisation]).initial.map { |c| CasePresenter.new(c) }.sort_by(&:last_updated_at_date).paginate(page: params[:new_cases_page])
-          @my_cases = Case.includes(%i[agent category organisation]).by_agent(current_agent&.id).map { |c| CasePresenter.new(c) }.sort_by(&:last_updated_at_date).paginate(page: params[:my_cases_page])
+          @cases = Case.includes(%i[agent category organisation]).all.order(created_at: :desc).map { |c| CasePresenter.new(c) }.paginate(page: params[:cases_page])
+          @new_cases = Case.includes(%i[agent category organisation]).initial.order(created_at: :desc).map { |c| CasePresenter.new(c) }.paginate(page: params[:new_cases_page])
+          @my_cases = Case.includes(%i[agent category organisation]).by_agent(current_agent&.id).order(created_at: :desc).map { |c| CasePresenter.new(c) }.paginate(page: params[:my_cases_page])
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR

Cases in supported are now ordered by ``` created_at: :desc```, ie newest cases first, rather than by the date of the latest interaction.