### PR TITLE
FaF Group name not appearing on the Case created in CM

### DIFF
--- a/app/services/submit_framework_request.rb
+++ b/app/services/submit_framework_request.rb
@@ -45,7 +45,7 @@ private
     @user ||= FrameworkRequestPresenter.new(request).user
   end
 
-  # @return [Support::Organisation]
+  # @return [Support::Organisation] or [Support::EstablishmentGroup]
   def map_organisation
     Support::Organisation.find_by(urn: request.school_urn) || Support::EstablishmentGroup.find_by(uid: request.group_uid)
   end

--- a/app/services/submit_framework_request.rb
+++ b/app/services/submit_framework_request.rb
@@ -45,7 +45,7 @@ private
     @user ||= FrameworkRequestPresenter.new(request).user
   end
 
-  # @return [Support::Organisation] or [Support::EstablishmentGroup]
+  # @return [Support::Organisation, Support::EstablishmentGroup]
   def map_organisation
     Support::Organisation.find_by(urn: request.school_urn) || Support::EstablishmentGroup.find_by(uid: request.group_uid)
   end

--- a/app/services/submit_framework_request.rb
+++ b/app/services/submit_framework_request.rb
@@ -47,7 +47,7 @@ private
 
   # @return [Support::Organisation]
   def map_organisation
-    Support::Organisation.find_by(urn: request.school_urn)
+    Support::Organisation.find_by(urn: request.school_urn) || Support::EstablishmentGroup.find_by(uid: request.group_uid)
   end
 
   # @return [Support::Case] TODO: Move into inbound API

--- a/spec/features/self-serve/faf/submit_framework_request_map_org_spec.rb
+++ b/spec/features/self-serve/faf/submit_framework_request_map_org_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature "Completed framework requests show org or group name in CM" do
   include_context "with an agent"
 
   context "when user creates a FaF request for a group" do
-    let!(:support_establishment_group) { create(:support_establishment_group, :with_address, name: "Testing Multi Academy Trust", uid: "2314", establishment_group_type: create(:support_establishment_group_type, name: "Multi-academy Trust")) }
+    let!(:support_establishment_group) { create(:support_establishment_group, :with_address, name: "Group #1", uid: "2314", establishment_group_type: create(:support_establishment_group_type, name: "Multi-academy Trust")) }
     let!(:support_case) { create(:support_case, :opened, organisation: support_establishment_group) }
 
     before do
@@ -10,48 +10,17 @@ RSpec.feature "Completed framework requests show org or group name in CM" do
       visit "/support/cases/#{support_case.id}#school-details"
     end
 
-    xit "displays the group name in New cases within CM" do
-    
+    it "displays the group name in New cases within CM" do
       visit "/support/cases#new-cases"
-     
-      # pp page.source
-      expect(page).to have_link "Testing Multi Academy Trust"
+
+      expect(page).to have_link "Group #1"
     end
 
     it "displays the group name and type on the case page in CM" do
-
-      pp page.source
       within("#school-details") do
-        expect(all("dd.govuk-summary-list__value")[3]).to have_text "Testing Multi Academy Trust"
-        expect(all("dd.govuk-summary-list__value")[4]).to have_text "Multi-Academy Trust"
+        expect(all("dd.govuk-summary-list__value")[3]).to have_text "Group #1"
+        expect(all("dd.govuk-summary-list__value")[4]).to have_text "Multi-academy Trust"
       end
     end
-  end
-
-  # def complete_group_step
-  #   fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "Group"
-  #   find(".autocomplete__option", text: "Group #1").click
-  #   click_continue
-  # end
-
-  # def complete_group_confirmation_step
-  #   choose "Yes"
-  #   click_continue
-  # end
-
-  # def complete_name_step
-  #   fill_in "framework_support_form[first_name]", with: "Test"
-  #   fill_in "framework_support_form[last_name]", with: "User"
-  #   click_continue
-  # end
-
-  # def complete_email_step
-  #   fill_in "framework_support_form[email]", with: "test@email.com"
-  #   click_continue
-  # end
-
-  def complete_help_message_step
-    fill_in "framework_support_form[message_body]", with: "I have a problem"
-    click_continue
   end
 end

--- a/spec/features/self-serve/faf/submit_framework_request_map_org_spec.rb
+++ b/spec/features/self-serve/faf/submit_framework_request_map_org_spec.rb
@@ -1,0 +1,57 @@
+RSpec.feature "Completed framework requests show org or group name in CM" do
+  include_context "with an agent"
+
+  context "when user creates a FaF request for a group" do
+    let!(:support_establishment_group) { create(:support_establishment_group, :with_address, name: "Testing Multi Academy Trust", uid: "2314", establishment_group_type: create(:support_establishment_group_type, name: "Multi-academy Trust")) }
+    let!(:support_case) { create(:support_case, :opened, organisation: support_establishment_group) }
+
+    before do
+      click_button "Agent Login"
+      visit "/support/cases/#{support_case.id}#school-details"
+    end
+
+    xit "displays the group name in New cases within CM" do
+    
+      visit "/support/cases#new-cases"
+     
+      # pp page.source
+      expect(page).to have_link "Testing Multi Academy Trust"
+    end
+
+    it "displays the group name and type on the case page in CM" do
+
+      pp page.source
+      within("#school-details") do
+        expect(all("dd.govuk-summary-list__value")[3]).to have_text "Testing Multi Academy Trust"
+        expect(all("dd.govuk-summary-list__value")[4]).to have_text "Multi-Academy Trust"
+      end
+    end
+  end
+
+  # def complete_group_step
+  #   fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "Group"
+  #   find(".autocomplete__option", text: "Group #1").click
+  #   click_continue
+  # end
+
+  # def complete_group_confirmation_step
+  #   choose "Yes"
+  #   click_continue
+  # end
+
+  # def complete_name_step
+  #   fill_in "framework_support_form[first_name]", with: "Test"
+  #   fill_in "framework_support_form[last_name]", with: "User"
+  #   click_continue
+  # end
+
+  # def complete_email_step
+  #   fill_in "framework_support_form[email]", with: "test@email.com"
+  #   click_continue
+  # end
+
+  def complete_help_message_step
+    fill_in "framework_support_form[message_body]", with: "I have a problem"
+    click_continue
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- when a FaF request is made with a group (MAT or Fed) this is now displayed in case management

## Screen-shots or screen-capture of UI changes

### After
<img width="1215" alt="Screenshot 2022-02-22 at 12 15 37" src="https://user-images.githubusercontent.com/62155037/155131147-44a29050-cf99-4d9b-b6ae-2113b4973575.png">

<img width="1069" alt="Screenshot 2022-02-24 at 15 13 23" src="https://user-images.githubusercontent.com/62155037/155551907-80727286-2c96-404f-9ab5-dfd391c299b3.png">

