### PR TITLE
Agent can add, view and download attachments on case

### DIFF
--- a/CHANGELOG.case_management.md
+++ b/CHANGELOG.case_management.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.0.0].
 
 ## [unreleased]
 
+- Agent can save email attachments to a case [#ref](https://github.com/DFE-Digital/buy-for-your-school/pull/896)
+
 <!--
 
 ## [release-xxx] - xxxx-xx-xx

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,4 +9,5 @@ $govuk-image-url-function: "image-url";
 @import "components/supported/email-preview";
 @import "components/supported/email-list";
 @import "components/supported/new-case-form";
-@import "components/pagination"
+@import "components/pagination";
+@import "components/panels/info";

--- a/app/assets/stylesheets/components/panels/_info.scss
+++ b/app/assets/stylesheets/components/panels/_info.scss
@@ -1,0 +1,3 @@
+.govuk-notification-banner.info-panel svg {
+  color: #1d70b8;
+}

--- a/app/controllers/support/document_downloads_controller.rb
+++ b/app/controllers/support/document_downloads_controller.rb
@@ -4,6 +4,7 @@ module Support
 
     SUPPORTED_TYPES = [
       "Support::EmailAttachment",
+      "Support::CaseAttachment",
     ].freeze
 
     def show

--- a/app/controllers/support/save_attachments_controller.rb
+++ b/app/controllers/support/save_attachments_controller.rb
@@ -1,0 +1,38 @@
+module Support
+  class SaveAttachmentsController < ::Support::ApplicationController
+    before_action :find_email
+    before_action { @back_url = support_email_path(@email) }
+
+    def new
+      @save_attachments_form = SaveAttachmentsForm.from_email(@email)
+    end
+
+    def create
+      @save_attachments_form = SaveAttachmentsForm.new(**save_attachments_form_params)
+
+      if @save_attachments_form.valid?
+        @save_attachments_form.save_attachments
+        @attachments = @save_attachments_form.selected_attachments
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def find_email
+      @email = Support::Email.find(params[:email_id])
+    end
+
+    def save_attachments_form_params
+      params.require(:save_attachments_form).permit(attachments_attributes: %i[
+        selected
+        name
+        support_case_id
+        support_email_attachment_id
+        description
+        label
+      ])
+    end
+  end
+end

--- a/app/controllers/support/save_attachments_controller.rb
+++ b/app/controllers/support/save_attachments_controller.rb
@@ -25,14 +25,17 @@ module Support
     end
 
     def save_attachments_form_params
-      params.require(:save_attachments_form).permit(attachments_attributes: %i[
-        selected
-        name
-        support_case_id
-        support_email_attachment_id
-        description
-        label
-      ])
+      params.require(:save_attachments_form).permit(
+        :show_file_type_warning,
+        attachments_attributes: %i[
+          selected
+          name
+          support_case_id
+          support_email_attachment_id
+          description
+          label
+        ],
+      )
     end
   end
 end

--- a/app/forms/support/save_attachments_form.rb
+++ b/app/forms/support/save_attachments_form.rb
@@ -1,14 +1,21 @@
 module Support
   class SaveAttachmentsForm
     include ActiveModel::Model
-    attr_accessor :attachments
+    attr_accessor :attachments, :show_file_type_warning
 
     def self.from_email(email)
-      attachments = email.attachments.each_with_index.map do |attachment, i|
+      attachments = email.attachments.for_case_attachments.each_with_index.map do |attachment, i|
         [i, { support_email_attachment_id: attachment.id, support_case_id: email.case_id }]
       end
 
-      new(attachments_attributes: attachments.to_h)
+      new(
+        attachments_attributes: attachments.to_h,
+        show_file_type_warning: email.has_unattachable_files_attached? ? "1" : "0",
+      )
+    end
+
+    def show_file_type_warning?
+      show_file_type_warning == "1"
     end
 
     def valid?

--- a/app/forms/support/save_attachments_form.rb
+++ b/app/forms/support/save_attachments_form.rb
@@ -1,0 +1,34 @@
+module Support
+  class SaveAttachmentsForm
+    include ActiveModel::Model
+    attr_accessor :attachments
+
+    def self.from_email(email)
+      attachments = email.attachments.each_with_index.map do |attachment, i|
+        [i, { support_email_attachment_id: attachment.id, support_case_id: email.case_id }]
+      end
+
+      new(attachments_attributes: attachments.to_h)
+    end
+
+    def valid?
+      selected_attachments.all?(&:valid?).tap do
+        errors.add(:base, I18n.t("save_attachments_form.errors.rules.base"))
+      end
+    end
+
+    def attachments_attributes=(attributes)
+      @attachments = attributes.values.map do |attachment|
+        SaveAttachmentsFormRow.new(**attachment)
+      end
+    end
+
+    def selected_attachments
+      attachments.select(&:selected)
+    end
+
+    def save_attachments
+      selected_attachments.each(&:save!)
+    end
+  end
+end

--- a/app/forms/support/save_attachments_form_row.rb
+++ b/app/forms/support/save_attachments_form_row.rb
@@ -13,11 +13,22 @@ module Support
     delegate :file_name, to: :email_attachment
 
     before_validation do
-      self.name = email_attachment&.file_name if name.blank?
+      self.name = file_name_to_save
     end
 
     def selected=(value)
       @selected = value == "1"
+    end
+
+    def file_name_to_save
+      file_extension = ActiveStorage::Filename.new(file_name).extension_with_delimiter
+      potential_name = name.presence || file_name
+
+      if potential_name.ends_with?(file_extension)
+        potential_name
+      else
+        potential_name.concat(file_extension)
+      end
     end
   end
 end

--- a/app/forms/support/save_attachments_form_row.rb
+++ b/app/forms/support/save_attachments_form_row.rb
@@ -1,0 +1,23 @@
+module Support
+  class SaveAttachmentsFormRow < ::Support::CaseAttachment
+    attr_reader :selected
+
+    validates :name, uniqueness: {
+      scope: :support_case_id,
+      message: I18n.t("save_attachments_form.errors.rules.name.already_taken"),
+    }
+    validates :description, presence: {
+      message: I18n.t("save_attachments_form.errors.rules.description.missing"),
+    }
+
+    delegate :file_name, to: :email_attachment
+
+    before_validation do
+      self.name = email_attachment&.file_name if name.blank?
+    end
+
+    def selected=(value)
+      @selected = value == "1"
+    end
+  end
+end

--- a/app/models/support/case.rb
+++ b/app/models/support/case.rb
@@ -8,15 +8,6 @@ module Support
   # A case is opened from a "support enquiry" dealing with a "category of spend"
   #
   class Case < ApplicationRecord
-    include ::PgSearch::Model
-
-    pg_search_scope :search, against: %i[ref], associated_against: {
-      organisation: %i[name urn],
-      agent: %i[first_name last_name],
-    }
-
-    scope :search, ->(q) { Support::CaseSearch.omnisearch(q).joins }
-
     belongs_to :category, class_name: "Support::Category", optional: true
     belongs_to :agent, class_name: "Support::Agent", optional: true
     belongs_to :organisation, polymorphic: true, optional: true

--- a/app/models/support/case.rb
+++ b/app/models/support/case.rb
@@ -17,6 +17,8 @@ module Support
     has_many :documents, class_name: "Support::Document", dependent: :destroy
     accepts_nested_attributes_for :documents, allow_destroy: true, reject_if: :all_blank
 
+    has_many :case_attachments, class_name: "Support::CaseAttachment", foreign_key: :support_case_id
+
     has_one :hub_transition, class_name: "Support::HubTransition", dependent: :destroy
 
     belongs_to :existing_contract, class_name: "Support::ExistingContract", optional: true

--- a/app/models/support/case_attachment.rb
+++ b/app/models/support/case_attachment.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Support
+  class CaseAttachment < ApplicationRecord
+    belongs_to :case, class_name: "Support::Case", foreign_key: :support_case_id
+    belongs_to :email_attachment, class_name: "Support::EmailAttachment", foreign_key: :support_email_attachment_id
+  end
+end

--- a/app/models/support/case_attachment.rb
+++ b/app/models/support/case_attachment.rb
@@ -4,5 +4,8 @@ module Support
   class CaseAttachment < ApplicationRecord
     belongs_to :case, class_name: "Support::Case", foreign_key: :support_case_id
     belongs_to :email_attachment, class_name: "Support::EmailAttachment", foreign_key: :support_email_attachment_id
+
+    delegate :file, :file_type, to: :email_attachment
+    alias_attribute :file_name, :name
   end
 end

--- a/app/models/support/email.rb
+++ b/app/models/support/email.rb
@@ -19,6 +19,10 @@ module Support
       email.set_case_action_required if is_first_import
     end
 
+    def has_unattachable_files_attached?
+      attachments.for_case_attachments.count < attachments.count
+    end
+
     def import_from_message(message, folder: :inbox)
       update!(
         outlook_id: message.id,

--- a/app/models/support/email_attachment.rb
+++ b/app/models/support/email_attachment.rb
@@ -6,6 +6,7 @@ module Support
     before_save :update_file_attributes
 
     scope :inline, -> { where(is_inline: true) }
+    scope :for_case_attachments, -> { where(file_type: CASE_ATTACHMENT_FILE_TYPE_ALLOW_LIST) }
 
     def self.import_attachment(attachment, email)
       email_attachment = email.attachments.find_or_initialize_by(outlook_id: attachment.id)

--- a/app/models/support/email_attachment.rb
+++ b/app/models/support/email_attachment.rb
@@ -29,6 +29,8 @@ module Support
   private
 
     def update_file_attributes
+      return unless file.new_record?
+
       self.file_name = file.filename
       self.file_size = file.attachment.byte_size
       self.file_type = file.attachment.content_type

--- a/app/views/components/panels/_info.html.erb
+++ b/app/views/components/panels/_info.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-notification-banner info-panel" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__content flex-align-center">
+    <svg role="presentation" fill="currentColor" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+        <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+      C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" />
+    </svg>
+
+    <p class="govuk-notification-banner__heading govuk-!-margin-left-4">
+      <%= yield %>
+    </p>
+  </div>
+</div>

--- a/app/views/support/cases/_case_attachments.html.erb
+++ b/app/views/support/cases/_case_attachments.html.erb
@@ -1,0 +1,19 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header"><%= I18n.t("support.case.label.attachments.table.attachment_name") %></th>
+      <th class="govuk-table__header"><%= I18n.t("support.case.label.attachments.table.description") %></th>
+      <th class="govuk-table__header"><%= I18n.t("support.case.label.attachments.table.date_added") %></th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% current_case.case_attachments.each do |attachment| %>
+      <tr class="govuk-table__row">
+        <th class="govuk-table__cell"><%= link_to attachment.name, support_document_download_path(attachment, type: attachment.class), class: "govuk-link" %></th>
+        <td class="govuk-table__cell"><%= attachment.description %></td>
+        <td class="govuk-table__cell"><%= attachment.created_at.strftime("%e %b %Y %I:%M %p") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support/cases/show.html.erb
+++ b/app/views/support/cases/show.html.erb
@@ -31,6 +31,11 @@
         <%= I18n.t("support.case.header.procurement_detail") %>
       </a>
     </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#case-attachments">
+        <%= I18n.t("support.case.header.case_attachments") %>
+      </a>
+    </li>
   </ul>
   <div class="govuk-tabs__panel" id="school-details" role="tabpanel" aria-labelledby="tab_school-details">
     <%= render "school_details", current_case: @current_case %>
@@ -59,6 +64,10 @@
       <% end %>
 
     </div>
+  </div>
+
+  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="case-attachments">
+    <%= render "case_attachments", current_case: @current_case %>
   </div>
 </div>
 

--- a/app/views/support/emails/show.html.erb
+++ b/app/views/support/emails/show.html.erb
@@ -14,10 +14,18 @@
   </h2>
 <% end %>
 
-<%= button_to I18n.t("support.emails.button.#{@email.is_read? ? "mark_as_unread" : "mark_as_read"}"),
-      support_email_read_status_path(@email, status: @email.is_read? ? "unread" : "read"),
-      method: :patch,
-      class: "govuk-button govuk-button--secondary" %>
+<div class="flex-align-center">
+  <%= button_to I18n.t("support.emails.button.#{@email.is_read? ? "mark_as_unread" : "mark_as_read"}"),
+        support_email_read_status_path(@email, status: @email.is_read? ? "unread" : "read"),
+        method: :patch,
+        class: "govuk-button govuk-button--secondary" %>
+
+  <% if @email.attachments.any? %>
+    <%= link_to I18n.t("support.save_attachments.initiate_journey"),
+                new_support_email_save_attachments_path(@email),
+                class: "govuk-button govuk-button--secondary govuk-!-margin-left-2" %>
+  <% end %>
+</div>
 
 <div class="email-preview govuk-body">
   <dl class="govuk-summary-list">

--- a/app/views/support/save_attachments/create.html.erb
+++ b/app/views/support/save_attachments/create.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-panel govuk-panel--confirmation">
+  <h1 class="govuk-panel__title">
+    <%= I18n.t("support.save_attachments.success.header") %>
+  </h1>
+</div>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header"><%= pluralize(@attachments.count, I18n.t("support.save_attachments.success.table.header.attachment")) %></th>
+      <th class="govuk-table__header"><%= I18n.t("support.save_attachments.success.table.header.description") %></th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @attachments.each do |attachment| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= attachment.name %></th>
+        <td class="govuk-table__cell"><%= attachment.description %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="govuk-body-m">
+  <p class="govuk-heading-m"><%= I18n.t("support.save_attachments.success.actions.header") %></p>
+
+  <ul class="govuk-list govuk-list">
+    <li><%= link_to I18n.t("support.save_attachments.success.actions.go_back_to_email"), support_email_path(@email) %></li>
+    <li><%= link_to I18n.t("support.save_attachments.success.actions.view_attachments"), support_case_path(@email.case, anchor: "attachments") %></li>
+  </ul>
+</div>

--- a/app/views/support/save_attachments/create.html.erb
+++ b/app/views/support/save_attachments/create.html.erb
@@ -27,6 +27,6 @@
 
   <ul class="govuk-list govuk-list">
     <li><%= link_to I18n.t("support.save_attachments.success.actions.go_back_to_email"), support_email_path(@email) %></li>
-    <li><%= link_to I18n.t("support.save_attachments.success.actions.view_attachments"), support_case_path(@email.case, anchor: "attachments") %></li>
+    <li><%= link_to I18n.t("support.save_attachments.success.actions.view_attachments"), support_case_path(@email.case, anchor: "case-attachments") %></li>
   </ul>
 </div>

--- a/app/views/support/save_attachments/new.html.erb
+++ b/app/views/support/save_attachments/new.html.erb
@@ -1,6 +1,14 @@
 <%= form_with model: @save_attachments_form, scope: :save_attachments_form, url: support_email_save_attachments_path(@email), method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
+  <% if @save_attachments_form.show_file_type_warning? %>
+    <%= render "components/panels/info" do %>
+      <%= I18n.t("support.save_attachments.form.file_types_notice") %>
+    <% end %>
+  <% end %>
+
+  <%= f.hidden_field :show_file_type_warning %>
+
   <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h1 class="govuk-fieldset__heading"><%= I18n.t("support.save_attachments.form.header") %></h1>

--- a/app/views/support/save_attachments/new.html.erb
+++ b/app/views/support/save_attachments/new.html.erb
@@ -1,0 +1,36 @@
+<%= form_with model: @save_attachments_form, scope: :save_attachments_form, url: support_email_save_attachments_path(@email), method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <fieldset class="govuk-fieldset" aria-describedby="changed-name-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading"><%= I18n.t("support.save_attachments.form.header") %></h1>
+    </legend>
+
+    <p class="govuk-body"><%= I18n.t("support.save_attachments.form.subheader") %></p>
+
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <%= f.fields_for :attachments, nil, as: "attachments" do |af| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__cell govuk-!-font-weight-regular">
+              <%= af.hidden_field :support_case_id %>
+              <%= af.hidden_field :support_email_attachment_id %>
+
+              <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                <%= af.govuk_check_box :selected, 1, 0, multiple: false, small: true, label: { text: af.object.file_name } do %>
+                  <%= af.govuk_text_field :name, label: { text: I18n.t("support.save_attachments.form.rename_attachment") } %>
+                  <%= af.govuk_text_field :description, label: { text: I18n.t("support.save_attachments.form.description") } %>
+                <% end %>
+              </div>
+            </th>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </fieldset>
+
+  <div class="govuk-button-group">
+    <%= f.submit I18n.t("support.save_attachments.form.submit"), class: "govuk-button" %>
+    <%= link_to I18n.t("support.save_attachments.form.cancel"), support_email_path(@email), class: "govuk-link" %>
+  </div>
+<% end %>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -8,3 +8,82 @@
 Mime::Type.register "application/vnd.openxmlformats-officedocument.wordprocessingml.document", :docx
 Mime::Type.register "application/pdf", :pdf
 Mime::Type.register "application/vnd.oasis.opendocument.text", :odt
+
+CASE_ATTACHMENT_FILE_TYPE_ALLOW_LIST = [
+  "video/3gpp2",  # .3g2,3GPP2 audio/video container
+  "audio/3gpp2",  # .3g2,3GPP2 audio/video container
+  "video/3gpp", # .3gp,3GPP audio/video container
+  "audio/3gpp", # .3gp,3GPP audio/video container
+  "application/x-7z-compressed", # .7z,7-zip archive
+  "audio/aac", # .aac,AAC audio
+  "application/x-abiword",  # .abw,AbiWord document
+  "application/x-freearc",  # .arc,Archive document (multiple files embedded)
+  "video/x-msvideo", # .avi,AVI: Audio Video Interleave
+  "image/avif", # .avif,AVIF image
+  "application/vnd.amazon.ebook", # .azw,Amazon Kindle eBook format
+  # "application/octet-stream", # .bin,Any kind of binary data
+  "image/bmp", # .bmp,Windows OS/2 Bitmap Graphics
+  "application/x-bzip", # .bz,BZip archive
+  "application/x-bzip2", # .bz2,BZip2 archive
+  "application/x-cdf", # .cda,CD audio
+  # "application/x-csh",  # .csh,C-Shell script
+  # "text/css", # .css,Cascading Style Sheets (CSS)
+  "text/csv", # .csv,Comma-separated values (CSV)
+  "application/msword", # .doc,Microsoft Word
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", # .docx,Microsoft Word (OpenXML)
+  # "application/vnd.ms-fontobject",  # .eot,MS Embedded OpenType fonts
+  "application/epub+zip", # .epub,Electronic publication (EPUB)
+  "image/gif", # .gif,Graphics Interchange Format (GIF)
+  "application/gzip", # .gz,GZip Compressed Archive
+  "text/html", # .htm .html,HyperText Markup Language (HTML)
+  "image/vnd.microsoft.icon", # .ico,Icon format
+  "text/calendar", # .ics,iCalendar format
+  # "application/java-archive", # .jar,Java Archive (JAR)
+  "image/jpeg", # .jpeg .jpg,JPEG images
+  # "text/javascript",  # .js,JavaScript
+  "application/json", # .json,JSON format
+  "application/ld+json", # .jsonld,JSON-LD format
+  "audio/midi", # .mid,Musical Instrument Digital Interface (MIDI)
+  "audio/x-midi", # .midi,Musical Instrument Digital Interface (MIDI)
+  "text/javascript", # .mjs,JavaScript module
+  "audio/mpeg", # .mp3,MP3 audio
+  "video/mp4",  # .mp4,MP4 video
+  "video/mpeg", # .mpeg,MPEG Video
+  # "application/vnd.apple.installer+xml",  # .mpkg,Apple Installer Package
+  "application/vnd.oasis.opendocument.presentation", # .odp,OpenDocument presentation document
+  "application/vnd.oasis.opendocument.spreadsheet", # .ods,OpenDocument spreadsheet document
+  "application/vnd.oasis.opendocument.text", # .odt,OpenDocument text document
+  "audio/ogg",  # .oga,OGG audio
+  "video/ogg",  # .ogv,OGG video
+  "application/ogg", # .ogx,OGG
+  "audio/opus", # .opus,Opus audio
+  "font/otf", # .otf,OpenType font
+  "application/pdf", # .pdf,Adobe Portable Document Format (PDF)
+  # "application/x-httpd-php",  # .php,Hypertext Preprocessor (Personal Home Page)
+  "image/png", # .png,Portable Network Graphics
+  "application/vnd.ms-powerpoint", # .ppt,Microsoft PowerPoint
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation", # .pptx,Microsoft PowerPoint (OpenXML)
+  "application/vnd.rar", # .rar,RAR archive
+  "application/rtf", # .rtf,Rich Text Format (RTF)
+  # "application/x-sh", # .sh,Bourne shell script
+  "image/svg+xml", # .svg,Scalable Vector Graphics (SVG)
+  # "application/x-shockwave-flash",  # .swf,Small web format (SWF) or Adobe Flash document
+  "application/x-tar", # .tar,Tape Archive (TAR)
+  "image/tiff", # .tif .tiff,Tagged Image File Format (TIFF)
+  "video/mp2t", # .ts,MPEG transport stream
+  "font/ttf", # .ttf,TrueType Font
+  "text/plain", # .txt,Text
+  "application/vnd.visio", # .vsd,Microsoft Visio
+  "audio/wav",  # .wav,Waveform Audio Format
+  "audio/webm", # .weba,WEBM audio
+  "video/webm", # .webm,WEBM video
+  "image/webp", # .webp,WEBP image
+  # "font/woff",  # .woff,Web Open Font Format (WOFF)
+  # "font/woff2", # .woff2,Web Open Font Format (WOFF)
+  "application/xhtml+xml", # .xhtml,XHTML
+  "application/vnd.ms-excel", # .xls,Microsoft Excel
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", # .xlsx,Microsoft Excel (OpenXML)
+  "application/xml", # .xml,XML
+  "application/vnd.mozilla.xul+xml", # .xul,XUL
+  "application/zip",  # .zip,ZIP archive
+].freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,7 +275,7 @@ en:
     users_header: Users
     download_csv: Download (.csv)
     download_json: Download (.json)
-  
+
   # /feedback
   feedback:
     title: Feedback - Get help buying for schools - GOV.UK
@@ -314,7 +314,7 @@ en:
           label: Go to Find an approved framework
           url: https://www.gov.uk/guidance/find-a-dfe-approved-framework-for-your-school
 
- 
+
 
 
   #
@@ -839,6 +839,7 @@ en:
     save_attachments:
       initiate_journey: Save attachments
       form:
+        file_types_notice: Attachments that cannot be saved due to their field type have been excluded.
         header: Select attachments to save
         subheader: You can rename and add a description to attachments you select
         rename_attachment: Rename attachment (optional)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,6 +520,7 @@ en:
         case_detail: Case details
         case_history: Case history
         procurement_detail: Procurement details
+        case_attachments: Attachments
       label:
         create: Create a new case
         change_owner: Change case owner
@@ -563,6 +564,11 @@ en:
         case_owner: "Case owner: %{owner}"
         change_case_owner: change
         assign_to_agent: Assign to case worker
+        attachments:
+          table:
+            attachment_name: Attachment name
+            description: Description
+            date_added: Date added
         procurement_details:
           change: change
           required_agreement_type: Required agreement type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -793,6 +793,26 @@ en:
       my_cases:
         header_link: My cases
 
+    save_attachments:
+      initiate_journey: Save attachments
+      form:
+        header: Select attachments to save
+        subheader: You can rename and add a description to attachments you select
+        rename_attachment: Rename attachment (optional)
+        description: Add attachment description
+        submit: Save to case
+        cancel: Cancel
+      success:
+        header: Attachments saved
+        table:
+          header:
+            attachment: Attachment
+            description: Description
+        actions:
+          header: Actions
+          go_back_to_email: Go back to email
+          view_attachments: View saved attachments
+
     emails:
       header_link: Notifications
       index:

--- a/config/locales/validation/support/en.yml
+++ b/config/locales/validation/support/en.yml
@@ -133,7 +133,7 @@ en:
       rules:
         base: "Please check the details below"
         name:
-          already_taken: Enter new attachment name
+          already_taken: File already exists. Enter new attachment name
         email_attachment_id:
           missing: Select an attachment
         description:

--- a/config/locales/validation/support/en.yml
+++ b/config/locales/validation/support/en.yml
@@ -127,3 +127,14 @@ en:
           invalid: is invalid
         ended_at:
           invalid: is invalid
+
+  save_attachments_form:
+    errors:
+      rules:
+        base: "Please check the details below"
+        name:
+          already_taken: Enter new attachment name
+        email_attachment_id:
+          missing: Select an attachment
+        description:
+          missing: Enter a description

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,9 @@ Rails.application.routes.draw do
     end
     resources :agents, only: %i[create]
     if Features.enabled?(:incoming_emails)
-      resources :emails, only: %i[index show]
+      resources :emails, only: %i[index show] do
+        resource :save_attachments, only: %i[new create]
+      end
       resources :email_read_status, only: %i[update], param: :email_id
     end
     resources :organisations, only: %i[index]

--- a/db/migrate/20220221103854_create_support_case_attachments.rb
+++ b/db/migrate/20220221103854_create_support_case_attachments.rb
@@ -1,0 +1,11 @@
+class CreateSupportCaseAttachments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :support_case_attachments, id: :uuid do |t|
+      t.belongs_to :support_case, foreign_key: true, type: :uuid
+      t.belongs_to :support_email_attachment, foreign_key: true, type: :uuid
+      t.string :name
+      t.text :description
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_15_092232) do
+ActiveRecord::Schema.define(version: 2022_02_21_103854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -227,6 +227,17 @@ ActiveRecord::Schema.define(version: 2022_02_15_092232) do
     t.boolean "internal", default: false, null: false
     t.index ["dsi_uid"], name: "index_support_agents_on_dsi_uid"
     t.index ["email"], name: "index_support_agents_on_email"
+  end
+
+  create_table "support_case_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "support_case_id"
+    t.uuid "support_email_attachment_id"
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["support_case_id"], name: "index_support_case_attachments_on_support_case_id"
+    t.index ["support_email_attachment_id"], name: "index_support_case_attachments_on_support_email_attachment_id"
   end
 
   create_table "support_cases", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -487,6 +498,8 @@ ActiveRecord::Schema.define(version: 2022_02_15_092232) do
   add_foreign_key "long_text_answers", "steps", on_delete: :cascade
   add_foreign_key "radio_answers", "steps", on_delete: :cascade
   add_foreign_key "short_text_answers", "steps", on_delete: :cascade
+  add_foreign_key "support_case_attachments", "support_cases"
+  add_foreign_key "support_case_attachments", "support_email_attachments"
   add_foreign_key "support_cases", "support_contracts", column: "existing_contract_id"
   add_foreign_key "support_cases", "support_contracts", column: "new_contract_id"
   add_foreign_key "support_cases", "support_procurements", column: "procurement_id"

--- a/spec/factories/support/case_attachments.rb
+++ b/spec/factories/support/case_attachments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :support_case_attachment, class: "Support::CaseAttachment" do
+    association :case, factory: :support_case
+    association :email_attachment, factory: :support_email_attachment
+  end
+end

--- a/spec/features/support/case_attachments/agent_can_save_attachments_to_case_spec.rb
+++ b/spec/features/support/case_attachments/agent_can_save_attachments_to_case_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe "Agent can save attachments from an email to the case", js: true do
+  include_context "with an agent"
+
+  before { click_button "Agent Login" }
+
+  context "with email attachments on an email" do
+    let(:email) { create(:support_email) }
+    let(:email_attachment1) { create(:support_email_attachment, email: email) }
+    let(:email_attachment2) { create(:support_email_attachment, email: email) }
+
+    describe "saving an attachment to the case" do
+      before do
+        email_attachment1.update!(file_name: "attachment1.txt")
+        email_attachment2.update!(file_name: "attachment2.txt")
+
+        visit support_email_path(email)
+
+        click_link "Save attachments"
+        check "attachment1.txt"
+        within ".govuk-checkboxes", text: "attachment1.txt" do
+          fill_in "Rename attachment (optional)", with: "MyNewFileName.txt"
+          fill_in "Add attachment description", with: "Neat description"
+        end
+        check "attachment2.txt"
+        within ".govuk-checkboxes", text: "attachment2.txt" do
+          fill_in "Rename attachment (optional)", with: "MyOtherFileName.txt"
+          fill_in "Add attachment description", with: "Pretty good description"
+        end
+        click_button "Save to case"
+      end
+
+      it "displays the created case attachments" do
+        expect(page).to have_content("Attachments saved")
+
+        within "tr", text: "MyNewFileName.txt" do
+          expect(page).to have_content("Neat description")
+        end
+
+        within "tr", text: "MyOtherFileName.txt" do
+          expect(page).to have_content("Pretty good description")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/support/case_attachments/agent_can_save_attachments_to_case_spec.rb
+++ b/spec/features/support/case_attachments/agent_can_save_attachments_to_case_spec.rb
@@ -20,18 +20,18 @@ describe "Agent can save attachments from an email to the case", js: true do
         click_link "Save attachments"
         check "attachment1.txt"
         within ".govuk-checkboxes", text: "attachment1.txt" do
-          fill_in "Rename attachment (optional)", with: "MyNewFileName.txt"
+          fill_in "Rename attachment (optional)", with: "MyNewFileName"
           fill_in "Add attachment description", with: "Neat description"
         end
         check "attachment2.txt"
         within ".govuk-checkboxes", text: "attachment2.txt" do
-          fill_in "Rename attachment (optional)", with: "MyOtherFileName.txt"
+          fill_in "Rename attachment (optional)", with: "MyOtherFileName"
           fill_in "Add attachment description", with: "Pretty good description"
         end
         click_button "Save to case"
       end
 
-      it "displays the created case attachments" do
+      it "displays the created case attachments with file extensions automatically added" do
         expect(page).to have_content("Attachments saved")
 
         within "tr", text: "MyNewFileName.txt" do

--- a/spec/features/support/case_attachments/agent_can_view_attachments_on_case_spec.rb
+++ b/spec/features/support/case_attachments/agent_can_view_attachments_on_case_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Agent can view attachments on a case" do
+  include_context "with an agent"
+
+  before { click_button "Agent Login" }
+
+  context "when there are attachments on the case" do
+    let(:support_case)  { create(:support_case) }
+    let!(:attachment_1) { create(:support_case_attachment, case: support_case, name: "Classroom.pdf", description: "Classroom Layout Design") }
+    let!(:attachment_2) { create(:support_case_attachment, case: support_case, name: "Meeting Recording.wav", description: "Meeting recording from dictaphone") }
+
+    it "displays them within the Attachments tab" do
+      visit support_case_path(support_case)
+
+      within "#case-attachments tr", text: "Classroom.pdf" do
+        expect(page).to have_content("Classroom Layout Design")
+        expect(page).to have_link("Classroom.pdf", href: support_document_download_path(attachment_1, type: "Support::CaseAttachment"))
+      end
+
+      within "#case-attachments tr", text: "Meeting Recording.wav" do
+        expect(page).to have_content("Meeting recording from dictaphone")
+        expect(page).to have_link("Meeting Recording.wav", href: support_document_download_path(attachment_2, type: "Support::CaseAttachment"))
+      end
+    end
+  end
+end

--- a/spec/features/support/case_summary_spec.rb
+++ b/spec/features/support/case_summary_spec.rb
@@ -19,8 +19,8 @@ RSpec.feature "Case summary" do
     expect(find("h3#case-ref")).to have_text "000001"
   end
 
-  it "has 4 visible tabs" do
-    expect(all(".govuk-tabs__list-item", visible: true).count).to eq(4)
+  it "has 5 visible tabs" do
+    expect(all(".govuk-tabs__list-item", visible: true).count).to eq(5)
   end
 
   it "defaults to the 'School details' tab" do

--- a/spec/forms/support/save_attachments_form_row_spec.rb
+++ b/spec/forms/support/save_attachments_form_row_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Support::SaveAttachmentsFormRow do
+  describe "validation" do
+    context "when a description is missing" do
+      specify "is invalid" do
+        subject = described_class.new(description: nil)
+        subject.valid?
+        expect(subject.errors.messages.to_h).to include(description: ["Enter a description"])
+      end
+    end
+
+    context "when the name has already been taken for this case" do
+      specify "is invalid" do
+        support_case = create(:support_case)
+        create(:support_case_attachment, case: support_case, name: "ExistingFile.pdf")
+
+        subject = described_class.new(name: "ExistingFile.pdf", support_case_id: support_case.id)
+        subject.valid?
+        expect(subject.errors.messages.to_h).to include(name: ["Enter new attachment name"])
+      end
+    end
+
+    context "when name is not specified" do
+      context "but email attachment has a name that already exists as CaseAttachment" do
+        specify "is invalid as the fallback name is still a duplicate" do
+          support_case = create(:support_case)
+          email_attachment = create(:support_email_attachment)
+          create(:support_case_attachment, case: support_case, name: "attachment.txt")
+
+          subject = described_class.new(name: nil, support_case_id: support_case.id, support_email_attachment_id: email_attachment.id)
+          subject.valid?
+          expect(subject.errors.messages.to_h).to include(name: ["Enter new attachment name"])
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/support/save_attachments_form_row_spec.rb
+++ b/spec/forms/support/save_attachments_form_row_spec.rb
@@ -1,10 +1,30 @@
 require "rails_helper"
 
 describe Support::SaveAttachmentsFormRow do
+  describe "#file_name_to_save" do
+    context "when file type is specified already" do
+      it "does not duplicate it" do
+        attachment = create(:support_email_attachment).tap { |a| a.update(file_name: "test.pdf") }
+        subject = described_class.new(email_attachment: attachment, name: "MyFileName.pdf")
+        expect(subject.file_name_to_save).to eq("MyFileName.pdf")
+      end
+    end
+
+    context "when no file type is specified" do
+      it "is taken from the attchment" do
+        attachment = create(:support_email_attachment).tap { |a| a.update(file_name: "test.pdf") }
+        subject = described_class.new(email_attachment: attachment, name: "MyFileNameWithoutExtension")
+        expect(subject.file_name_to_save).to eq("MyFileNameWithoutExtension.pdf")
+      end
+    end
+  end
+
   describe "validation" do
+    let(:attachment) { create(:support_email_attachment) }
+
     context "when a description is missing" do
       specify "is invalid" do
-        subject = described_class.new(description: nil)
+        subject = described_class.new(description: nil, email_attachment: attachment)
         subject.valid?
         expect(subject.errors.messages.to_h).to include(description: ["Enter a description"])
       end
@@ -13,11 +33,11 @@ describe Support::SaveAttachmentsFormRow do
     context "when the name has already been taken for this case" do
       specify "is invalid" do
         support_case = create(:support_case)
-        create(:support_case_attachment, case: support_case, name: "ExistingFile.pdf")
+        create(:support_case_attachment, case: support_case, name: "ExistingFile.txt")
 
-        subject = described_class.new(name: "ExistingFile.pdf", support_case_id: support_case.id)
+        subject = described_class.new(name: "ExistingFile.txt", support_case_id: support_case.id, email_attachment: attachment)
         subject.valid?
-        expect(subject.errors.messages.to_h).to include(name: ["Enter new attachment name"])
+        expect(subject.errors.messages.to_h).to include(name: ["File already exists. Enter new attachment name"])
       end
     end
 
@@ -30,7 +50,7 @@ describe Support::SaveAttachmentsFormRow do
 
           subject = described_class.new(name: nil, support_case_id: support_case.id, support_email_attachment_id: email_attachment.id)
           subject.valid?
-          expect(subject.errors.messages.to_h).to include(name: ["Enter new attachment name"])
+          expect(subject.errors.messages.to_h).to include(name: ["File already exists. Enter new attachment name"])
         end
       end
     end

--- a/spec/forms/support/save_attachments_form_spec.rb
+++ b/spec/forms/support/save_attachments_form_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+describe Support::SaveAttachmentsForm do
+  let(:case_1) { create(:support_case) }
+  let(:case_2) { create(:support_case) }
+  let(:email_attachment_1) { create(:support_email_attachment) }
+  let(:email_attachment_2) { create(:support_email_attachment) }
+
+  describe "#save_attachments" do
+    before { described_class.new(**input).save_attachments }
+
+    context "when multiple attachments are given" do
+      let(:input) do
+        {
+          attachments_attributes: {
+            0 => {
+              support_case_id: case_1.id,
+              support_email_attachment_id: email_attachment_1.id,
+              name: "Case1EmailAttachment1.pdf",
+              description: "A really nice file...",
+              selected: "1",
+            },
+            1 => {
+              support_case_id: case_2.id,
+              support_email_attachment_id: email_attachment_2.id,
+              name: "Case2EmailAttachment2.pdf",
+              description: "A really pleasent file...",
+              selected: "1",
+            },
+          },
+        }
+      end
+
+      it "saves each of the attachments to the case" do
+        attachment_1 = Support::CaseAttachment.find_by(name: "Case1EmailAttachment1.pdf")
+        expect(attachment_1.case).to eq(case_1)
+        expect(attachment_1.email_attachment).to eq(email_attachment_1)
+        expect(attachment_1.description).to eq("A really nice file...")
+
+        attachment_2 = Support::CaseAttachment.find_by(name: "Case2EmailAttachment2.pdf")
+        expect(attachment_2.case).to eq(case_2)
+        expect(attachment_2.email_attachment).to eq(email_attachment_2)
+        expect(attachment_2.description).to eq("A really pleasent file...")
+      end
+
+      context "but a row is not selected" do
+        let(:input) do
+          {
+            attachments_attributes: {
+              0 => {
+                support_case_id: case_1.id,
+                support_email_attachment_id: email_attachment_1.id,
+                name: "Case1EmailAttachment1.pdf",
+                description: "A really nice file...",
+                selected: "0",
+              },
+            },
+          }
+        end
+
+        specify "that row is not saved" do
+          expect(Support::CaseAttachment.count).to eq(0)
+        end
+      end
+    end
+
+    context "when attachment name is empty" do
+      let(:input) do
+        {
+          attachments_attributes: {
+            0 => {
+              support_case_id: case_1.id,
+              support_email_attachment_id: email_attachment_1.id,
+              name: nil,
+              description: "A really nice file...",
+              selected: "1",
+            },
+          },
+        }
+      end
+
+      it "uses the email attachment name as the name" do
+        attachment = Support::CaseAttachment.find_by(case: case_1, email_attachment: email_attachment_1)
+        expect(attachment.name).to eq(email_attachment_1.file_name)
+      end
+    end
+  end
+end

--- a/spec/forms/support/save_attachments_form_spec.rb
+++ b/spec/forms/support/save_attachments_form_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe Support::SaveAttachmentsForm do
   let(:case_1) { create(:support_case) }
   let(:case_2) { create(:support_case) }
-  let(:email_attachment_1) { create(:support_email_attachment).tap {|a| a.update(file_name: "test.pdf") } }
-  let(:email_attachment_2) { create(:support_email_attachment).tap {|a| a.update(file_name: "test.pdf") } }
+  let(:email_attachment_1) { create(:support_email_attachment).tap { |a| a.update(file_name: "test.pdf") } }
+  let(:email_attachment_2) { create(:support_email_attachment).tap { |a| a.update(file_name: "test.pdf") } }
 
   describe "#save_attachments" do
     before { described_class.new(**input).save_attachments }

--- a/spec/forms/support/save_attachments_form_spec.rb
+++ b/spec/forms/support/save_attachments_form_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe Support::SaveAttachmentsForm do
   let(:case_1) { create(:support_case) }
   let(:case_2) { create(:support_case) }
-  let(:email_attachment_1) { create(:support_email_attachment) }
-  let(:email_attachment_2) { create(:support_email_attachment) }
+  let(:email_attachment_1) { create(:support_email_attachment).tap {|a| a.update(file_name: "test.pdf") } }
+  let(:email_attachment_2) { create(:support_email_attachment).tap {|a| a.update(file_name: "test.pdf") } }
 
   describe "#save_attachments" do
     before { described_class.new(**input).save_attachments }

--- a/spec/models/support/email_attachment_spec.rb
+++ b/spec/models/support/email_attachment_spec.rb
@@ -55,4 +55,15 @@ RSpec.describe Support::EmailAttachment, type: :model do
       expect(email_attachment.is_inline).to be(true)
     end
   end
+
+  describe ".for_case_attachments" do
+    let(:attachment_to_hide) { create(:support_email_attachment).tap { |a| a.update(file_type: "application/bad-file") } }
+    let(:attachment_to_show) { create(:support_email_attachment).tap { |a| a.update(file_type: CASE_ATTACHMENT_FILE_TYPE_ALLOW_LIST.first) } }
+
+    it "queries for only attachments with file types within CASE_ATTACHMENT_FILE_TYPE_ALLOW_LIST" do
+      results = described_class.for_case_attachments
+      expect(results).to include(attachment_to_show)
+      expect(results).not_to include(attachment_to_hide)
+    end
+  end
 end

--- a/spec/models/support/email_spec.rb
+++ b/spec/models/support/email_spec.rb
@@ -204,6 +204,32 @@ describe Support::Email do
     end
   end
 
+  describe "#has_unattachable_files_attached?" do
+    let(:email) { create(:support_email) }
+
+    context "when there are more attachments than are acceptable" do
+      before do
+        create(:support_email_attachment, email: email).tap { |a| a.update(file_type: CASE_ATTACHMENT_FILE_TYPE_ALLOW_LIST.first) }
+        create(:support_email_attachment, email: email).tap { |a| a.update(file_type: "unacceptable") }
+      end
+
+      it "returns true" do
+        expect(email.has_unattachable_files_attached?).to eq(true)
+      end
+    end
+
+    context "when all attachments are acceptable" do
+      before do
+        create(:support_email_attachment, email: email).tap { |a| a.update(file_type: CASE_ATTACHMENT_FILE_TYPE_ALLOW_LIST.first) }
+        create(:support_email_attachment, email: email).tap { |a| a.update(file_type: CASE_ATTACHMENT_FILE_TYPE_ALLOW_LIST.first) }
+      end
+
+      it "returns false" do
+        expect(email.has_unattachable_files_attached?).to eq(false)
+      end
+    end
+  end
+
   describe "#set_case_action_required" do
     context "when case is attached" do
       let(:support_case) { create(:support_case) }

--- a/spec/views/support/save_attachments/new.html.erb_spec.rb
+++ b/spec/views/support/save_attachments/new.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe "support/save_attachments/new.html.erb" do
+  describe "file type excluded warning" do
+    before do
+      view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
+
+      email = create(:support_email)
+      attachment = create(:support_email_attachment, email: email)
+      attachment.update!(file_type: file_type)
+
+      assign(:save_attachments_form, Support::SaveAttachmentsForm.from_email(email))
+      assign(:email, email)
+    end
+
+    context "with an excluded file type saved as an email attachment" do
+      let(:file_type) { "application/exe" }
+
+      it "shows warning" do
+        render
+        expect(rendered).to match(/Attachments that cannot be saved due to their field type have been excluded./)
+      end
+    end
+
+    context "with no excluded file types saved as email attachments" do
+      let(:file_type) { "text/plain" }
+
+      it "doesnt show warning" do
+        render
+        expect(rendered).not_to match(/Attachments that cannot be saved due to their field type have been excluded./)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG?
-->

## Changes in this PR

- Agent can attach documents to a case from emails
- Agent can view and download attachmed documents from a list

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

![Screenshot 2022-02-23 at 13 43 36](https://user-images.githubusercontent.com/1352756/155345614-d22e245f-ab56-4f5a-9273-68680f367188.png)

![Screenshot 2022-02-23 at 13 43 42](https://user-images.githubusercontent.com/1352756/155345635-864a5535-eb30-4ad7-9769-24703d5c7c0c.png)

![Screenshot 2022-02-23 at 14 59 01](https://user-images.githubusercontent.com/1352756/155345648-cc943f92-231c-4397-8072-d00bc48e2042.png)

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into seperate videos if there are several journeys being preseneted
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->

