### PR TITLE
last_updated_at is displaying incorrect date

### DIFF
--- a/app/presenters/support/case_presenter.rb
+++ b/app/presenters/support/case_presenter.rb
@@ -37,7 +37,7 @@ module Support
     # @return [String] 30 January 2000 at 12:00
     def last_updated_at
       # method to compare updated_at for case and updated_at for interaction (if exists) and select most recent
-      interactions.none? ? updated_at : interactions.last.created_at
+      interactions.none? ? updated_at : interactions.first.created_at
     end
 
     # @return [String]

--- a/spec/presenters/support/case_presenter_spec.rb
+++ b/spec/presenters/support/case_presenter_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Support::CasePresenter do
   end
 
   describe "#last_updated_at" do
-    it "returns the formatted date on which the case was last updated - the interaction updated_at given there is an interaction on the case" do
+    it "returns the formatted date on which the case was last updated - being the formatted date for when the interaction was created, given there is an interaction on the case" do
       expect(presenter.last_updated_at).to eq("31 January 2021 at 12:00")
     end
   end

--- a/spec/presenters/support/case_presenter_spec.rb
+++ b/spec/presenters/support/case_presenter_spec.rb
@@ -4,17 +4,20 @@ RSpec.describe Support::CasePresenter do
   let(:agent) { create(:support_agent) }
   let(:organisation) { create(:support_organisation, urn: "000000", name: "Example Org") }
   let(:procurement) { create(:support_procurement) }
+  let(:support_case_created_at) { Time.zone.local(2020, 5, 30, 12, 0, 0) }
+  let(:support_case_updated_at) { Time.zone.local(2020, 5, 30, 12, 0, 0) }
   let(:support_case) do
     create(:support_case,
            agent: agent,
            organisation: organisation,
            procurement: procurement,
-           created_at: Time.zone.local(2021, 1, 30, 12, 0, 0),
-           updated_at: Time.zone.local(2021, 1, 30, 12, 0, 0))
+           created_at: support_case_created_at,
+           updated_at: support_case_updated_at)
   end
+  let(:support_interaction_created_at) { Time.zone.local(2020, 6, 30, 12, 0, 0) }
 
   before do
-    create(:support_interaction, case: support_case, created_at: Time.zone.local(2021, 1, 31, 12, 0, 0), updated_at: Time.zone.local(2021, 1, 31, 12, 0, 0))
+    create(:support_interaction, case: support_case, created_at: support_interaction_created_at)
   end
 
   describe "#state" do
@@ -32,7 +35,7 @@ RSpec.describe Support::CasePresenter do
 
   describe "#received_at" do
     it "returns the formatted date on which the case was received" do
-      expect(presenter.received_at).to eq("30 January 2021 at 12:00")
+      expect(presenter.received_at).to eq("30 May 2020 at 12:00")
     end
   end
 
@@ -40,23 +43,25 @@ RSpec.describe Support::CasePresenter do
     context "when no interaction" do
       subject(:presenter) { described_class.new(support_case_without_interaction) }
 
+      let(:support_case_without_interaction_created_at) { Time.zone.local(2021, 1, 30, 12, 0, 0) }
+      let(:support_case_without_interaction_updated_at) { Time.zone.local(2021, 1, 31, 12, 0, 0) }
       let(:support_case_without_interaction) do
         create(:support_case,
                agent: agent,
                organisation: organisation,
                procurement: procurement,
-               created_at: Time.zone.local(2021, 1, 30, 12, 0, 0),
-               updated_at: Time.zone.local(2021, 1, 30, 12, 0, 0))
+               created_at: support_case_without_interaction_created_at,
+               updated_at: support_case_without_interaction_updated_at)
       end
 
       it "returns the formatted date on which the case was last updated" do
-        expect(presenter.last_updated_at).to eq("30 January 2021 at 12:00")
+        expect(presenter.last_updated_at).to eq("31 January 2021 at 12:00")
       end
     end
 
     context "when there is an interaction" do
       it "returns the formatted date for when the interaction was created on the case" do
-        expect(presenter.last_updated_at).to eq("31 January 2021 at 12:00")
+        expect(presenter.last_updated_at).to eq("30 June 2020 at 12:00")
       end
     end
   end

--- a/spec/presenters/support/case_presenter_spec.rb
+++ b/spec/presenters/support/case_presenter_spec.rb
@@ -37,8 +37,27 @@ RSpec.describe Support::CasePresenter do
   end
 
   describe "#last_updated_at" do
-    it "returns the formatted date on which the case was last updated - being the formatted date for when the interaction was created, given there is an interaction on the case" do
-      expect(presenter.last_updated_at).to eq("31 January 2021 at 12:00")
+    context "when no interaction" do
+      subject(:presenter) { described_class.new(support_case_without_interaction) }
+
+      let(:support_case_without_interaction) do
+        create(:support_case,
+               agent: agent,
+               organisation: organisation,
+               procurement: procurement,
+               created_at: Time.zone.local(2021, 1, 30, 12, 0, 0),
+               updated_at: Time.zone.local(2021, 1, 30, 12, 0, 0))
+      end
+
+      it "returns the formatted date on which the case was last updated" do
+        expect(presenter.last_updated_at).to eq("30 January 2021 at 12:00")
+      end
+    end
+
+    context "when there is an interaction" do
+      it "returns the formatted date for when the interaction was created on the case" do
+        expect(presenter.last_updated_at).to eq("31 January 2021 at 12:00")
+      end
     end
   end
 


### PR DESCRIPTION
## Changes in this PR

- 'last updated' in 'all cases' and 'my cases' within CM now showing the date of the most recent interaction rather than the oldest