### PR TITLE
Fix bug: graceful validation of duplicate attachments

### DIFF
--- a/app/controllers/support/save_attachments_controller.rb
+++ b/app/controllers/support/save_attachments_controller.rb
@@ -10,8 +10,7 @@ module Support
     def create
       @save_attachments_form = SaveAttachmentsForm.new(**save_attachments_form_params)
 
-      if @save_attachments_form.valid?
-        @save_attachments_form.save_attachments
+      if @save_attachments_form.valid? && @save_attachments_form.save_attachments
         @attachments = @save_attachments_form.selected_attachments
       else
         render :new

--- a/app/forms/support/save_attachments_form.rb
+++ b/app/forms/support/save_attachments_form.rb
@@ -35,7 +35,13 @@ module Support
     end
 
     def save_attachments
-      selected_attachments.each(&:save!)
+      Support::CaseAttachment.transaction do
+        selected_attachments.each(&:save!)
+      end
+
+      true
+    rescue StandardError
+      false
     end
   end
 end

--- a/spec/forms/support/save_attachments_form_spec.rb
+++ b/spec/forms/support/save_attachments_form_spec.rb
@@ -64,6 +64,33 @@ describe Support::SaveAttachmentsForm do
       end
     end
 
+    context "when multiple attachments are given with the same names" do
+      let(:input) do
+        {
+          attachments_attributes: {
+            0 => {
+              support_case_id: case_1.id,
+              support_email_attachment_id: email_attachment_1.id,
+              name: "Case1EmailAttachment1.pdf",
+              description: "A really nice file...",
+              selected: "1",
+            },
+            1 => {
+              support_case_id: case_1.id,
+              support_email_attachment_id: email_attachment_2.id,
+              name: "Case1EmailAttachment1.pdf",
+              description: "A really pleasent file...",
+              selected: "1",
+            },
+          },
+        }
+      end
+
+      it "doesnt save any of the attachments" do
+        expect(Support::CaseAttachment.count).to be(0)
+      end
+    end
+
     context "when attachment name is empty" do
       let(:input) do
         {


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG?
-->

## Changes in this PR

Previously the first attachment saves and then throws a 500 error before saving the other.
Now it will not save any of them and warn the user instead.

![Screenshot 2022-02-28 at 12 00 28](https://user-images.githubusercontent.com/1352756/155980351-9089086e-4ece-42be-b47d-f7d18ffbb0f6.png)
