### PR TITLE
FaF support journey start

### DIFF
--- a/app/controllers/framework_requests_controller.rb
+++ b/app/controllers/framework_requests_controller.rb
@@ -30,7 +30,6 @@ class FrameworkRequestsController < ApplicationController
   end
 
   def new
-    session.delete(:support_journey)
     session.delete(:faf_group)
     session.delete(:faf_school)
 
@@ -38,6 +37,8 @@ class FrameworkRequestsController < ApplicationController
   end
 
   def create
+    session.delete(:support_journey) unless current_user.guest?
+
     if @form.restart? && back_link?
       redirect_to framework_requests_path
     elsif validation.success? && validation.to_h[:message_body]

--- a/spec/features/self-serve/framework_requests/start_page_spec.rb
+++ b/spec/features/self-serve/framework_requests/start_page_spec.rb
@@ -33,6 +33,20 @@ RSpec.feature "Starting a 'Find a Framework' request" do
 
     it "shows their profile" do
       expect(page).to have_current_path "/profile"
+      expect(find("a.govuk-button")).to have_text "Yes, continue"
+    end
+
+    it "resets the profile support button" do
+      click_on "Yes, continue"
+
+      expect(page).to have_current_path "/procurement-support/new"
+      expect(find("label.govuk-label--l")).to have_text "How can we help?"
+
+      fill_in "framework_support_form[message_body]", with: "I have a problem"
+      click_continue
+      visit "/profile"
+
+      expect(find("a.govuk-button")).to have_text "Request support"
     end
 
     describe "when user signs out" do

--- a/spec/features/self-serve/profile_spec.rb
+++ b/spec/features/self-serve/profile_spec.rb
@@ -29,22 +29,4 @@ RSpec.feature "An authenticated user" do
       expect(find("a.govuk-button")).to have_text "Request support"
     end
   end
-
-  # The profile page is a CYA page before requesting support.
-  # A user may authenticate to start a "Find a Framework" support request.
-  # After confirming the user's details for a FaF journey,
-  # ensure that the temporary session switch is cleared.
-  it "resets the support journey session flag" do
-    expect(find("a.govuk-button")).to have_text "Request support"
-
-    visit "/procurement-support"
-    visit "/profile"
-
-    expect(find("a.govuk-button")).to have_text "Yes, continue"
-
-    visit "/procurement-support/new"
-    visit "/profile"
-
-    expect(find("a.govuk-button")).to have_text "Request support"
-  end
 end


### PR DESCRIPTION
- allow a FaF support request journey to be started
- allow subsequent non-FaF support requests from the dashboard via the profile page
- only clear the faf journey session variable once the first authenticated answer has been posted