### PR TITLE
499 The timestamp in CM is an hour behind

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,5 +49,8 @@ module BuyForYourSchool
     config.exceptions_app = routes
 
     config.feature_flags = config_for(:feature_flags)
+
+    # Set London as the timezone - handles daylight savings automatically
+    config.time_zone = "London"
   end
 end


### PR DESCRIPTION
## Changes in this PR

The timezone was not set in application config so that timestamps had been showing incorrectly. 

- Added 'London' as the default timezone.

Timestamps are correct with daylight savings now.