### PR TITLE
Disable validation for unused Support Request field

### DIFF
--- a/app/forms/support_form_schema.rb
+++ b/app/forms/support_form_schema.rb
@@ -14,7 +14,8 @@ class SupportFormSchema < Schema
     optional(:message_body).value(:string)  # step 5
   end
 
-  rule(:phone_number).validate(max_size?: 13, format?: /^$|^(0|\+?44)[12378]\d{8,9}$/)
+  # temporarily disbaled until the service supports calls
+  # rule(:phone_number).validate(max_size?: 13, format?: /^$|^(0|\+?44)[12378]\d{8,9}$/)
 
   rule(:school_urn) do
     key.failure(:missing) if key? && value.blank?

--- a/config/locales/validation/en.yml
+++ b/config/locales/validation/en.yml
@@ -5,6 +5,7 @@ en:
       phone_number: Your phone number
       message_body: "" # Omitted
       category_id: The type of procurement
+      school_urn: "" # Omitted
 
     errors:
       rules:


### PR DESCRIPTION
The [bug](https://rollbar.com/dfe-digital/GHBS/items/327/) was being caused by an attempt to validate a disabled field. The `phone_number` field in the Support Request form was disabled/commented out a while ago with the intention to re-enable it at a later point, but its validation in the schema was not disabled. This caused the schema to validate a nil field.

## Changes in this PR

- disable validation for the unused `phone_number` field in the Support Request form