### PR TITLE
Case navigation back link

### DIFF
--- a/app/controllers/support/application_controller.rb
+++ b/app/controllers/support/application_controller.rb
@@ -30,8 +30,8 @@ module Support
       true
     end
 
-    def current_url_b64
-      Base64.encode64(request.fullpath)
+    def current_url_b64(tab = "")
+      Base64.encode64("#{request.fullpath}##{tab.to_s.dasherize}")
     end
   end
 end

--- a/app/controllers/support/application_controller.rb
+++ b/app/controllers/support/application_controller.rb
@@ -4,7 +4,7 @@ module Support
 
   protected
 
-    helper_method :current_agent
+    helper_method :current_agent, :current_url_b64
 
     # @return [Agent, nil]
     def current_agent
@@ -28,6 +28,10 @@ module Support
 
     def support?
       true
+    end
+
+    def current_url_b64
+      Base64.encode64(request.fullpath)
     end
   end
 end

--- a/app/controllers/support/cases_controller.rb
+++ b/app/controllers/support/cases_controller.rb
@@ -21,7 +21,7 @@ module Support
     end
 
     def show
-      @back_url = params[:back_link] || support_cases_path
+      @back_url = support_cases_path(cases_query_params)
     end
 
     def new
@@ -100,6 +100,19 @@ module Support
 
     def edit_form_params
       params.require(:edit_case_form).permit(:request_text)
+    end
+
+    def cases_query_params
+      return if params[:cases_query].blank?
+
+      params.require(:cases_query).permit(
+        { filter_all_cases_form: %i[state category agent] },
+        { filter_new_cases_form: %i[state category agent] },
+        { filter_my_cases_form: %i[state category agent] },
+        :cases_page,
+        :new_cases_page,
+        :my_cases_page,
+      )
     end
   end
 end

--- a/app/controllers/support/cases_controller.rb
+++ b/app/controllers/support/cases_controller.rb
@@ -21,7 +21,7 @@ module Support
     end
 
     def show
-      @back_url = Base64.decode64(params[:back_to]) || support_cases_path
+      @back_url = back_link_param || support_cases_path
     end
 
     def new
@@ -100,6 +100,12 @@ module Support
 
     def edit_form_params
       params.require(:edit_case_form).permit(:request_text)
+    end
+
+    def back_link_param
+      return if params[:back_to].blank?
+
+      Base64.decode64(params[:back_to])
     end
   end
 end

--- a/app/controllers/support/cases_controller.rb
+++ b/app/controllers/support/cases_controller.rb
@@ -21,7 +21,7 @@ module Support
     end
 
     def show
-      @back_url = support_cases_path(cases_query_params)
+      @back_url = Base64.decode64(params[:back_to]) || support_cases_path
     end
 
     def new
@@ -100,19 +100,6 @@ module Support
 
     def edit_form_params
       params.require(:edit_case_form).permit(:request_text)
-    end
-
-    def cases_query_params
-      return if params[:cases_query].blank?
-
-      params.require(:cases_query).permit(
-        { filter_all_cases_form: %i[state category agent] },
-        { filter_new_cases_form: %i[state category agent] },
-        { filter_my_cases_form: %i[state category agent] },
-        :cases_page,
-        :new_cases_page,
-        :my_cases_page,
-      )
     end
   end
 end

--- a/app/controllers/support/cases_controller.rb
+++ b/app/controllers/support/cases_controller.rb
@@ -21,7 +21,7 @@ module Support
     end
 
     def show
-      @back_url = support_cases_path
+      @back_url = params[:back_link] || support_cases_path
     end
 
     def new

--- a/app/views/support/cases/_row.erb
+++ b/app/views/support/cases/_row.erb
@@ -1,11 +1,11 @@
 <tr class="govuk-table__row case-row">
   <td class="govuk-table__cell">
-    <%= link_to kase.ref, support_case_path(kase.id), class: "govuk-link--no-visited-state" %>
+    <%= link_to kase.ref, support_case_path(kase.id, back_link: request.fullpath), class: "govuk-link--no-visited-state" %>
   </td>
 
   <td class="govuk-table__cell">
     <div class="ellipsis-overflow col-350px">
-      <%= link_to kase.organisation_name, support_case_path(kase.id), class: "govuk-link--no-visited-state", title: kase.organisation_name %>
+      <%= link_to kase.organisation_name, support_case_path(kase.id, back_link: request.fullpath), class: "govuk-link--no-visited-state", title: kase.organisation_name %>
     </div>
   </td>
 

--- a/app/views/support/cases/_row.erb
+++ b/app/views/support/cases/_row.erb
@@ -1,11 +1,11 @@
 <tr class="govuk-table__row case-row">
   <td class="govuk-table__cell">
-    <%= link_to kase.ref, support_case_path(kase.id, back_to: current_url_b64), class: "govuk-link--no-visited-state" %>
+    <%= link_to kase.ref, support_case_path(kase.id, back_to: current_url_b64(tab)), class: "govuk-link--no-visited-state" %>
   </td>
 
   <td class="govuk-table__cell">
     <div class="ellipsis-overflow col-350px">
-      <%= link_to kase.organisation_name, support_case_path(kase.id, back_to: current_url_b64), class: "govuk-link--no-visited-state", title: kase.organisation_name %>
+      <%= link_to kase.organisation_name, support_case_path(kase.id, back_to: current_url_b64(tab)), class: "govuk-link--no-visited-state", title: kase.organisation_name %>
     </div>
   </td>
 

--- a/app/views/support/cases/_row.erb
+++ b/app/views/support/cases/_row.erb
@@ -1,11 +1,11 @@
 <tr class="govuk-table__row case-row">
   <td class="govuk-table__cell">
-    <%= link_to kase.ref, support_case_path(kase.id, back_link: request.fullpath), class: "govuk-link--no-visited-state" %>
+    <%= link_to kase.ref, support_case_path(kase.id, cases_query: request.query_parameters), class: "govuk-link--no-visited-state" %>
   </td>
 
   <td class="govuk-table__cell">
     <div class="ellipsis-overflow col-350px">
-      <%= link_to kase.organisation_name, support_case_path(kase.id, back_link: request.fullpath), class: "govuk-link--no-visited-state", title: kase.organisation_name %>
+      <%= link_to kase.organisation_name, support_case_path(kase.id, cases_query: request.query_parameters), class: "govuk-link--no-visited-state", title: kase.organisation_name %>
     </div>
   </td>
 

--- a/app/views/support/cases/_row.erb
+++ b/app/views/support/cases/_row.erb
@@ -1,11 +1,11 @@
 <tr class="govuk-table__row case-row">
   <td class="govuk-table__cell">
-    <%= link_to kase.ref, support_case_path(kase.id, cases_query: request.query_parameters), class: "govuk-link--no-visited-state" %>
+    <%= link_to kase.ref, support_case_path(kase.id, back_to: current_url_b64), class: "govuk-link--no-visited-state" %>
   </td>
 
   <td class="govuk-table__cell">
     <div class="ellipsis-overflow col-350px">
-      <%= link_to kase.organisation_name, support_case_path(kase.id, cases_query: request.query_parameters), class: "govuk-link--no-visited-state", title: kase.organisation_name %>
+      <%= link_to kase.organisation_name, support_case_path(kase.id, back_to: current_url_b64), class: "govuk-link--no-visited-state", title: kase.organisation_name %>
     </div>
   </td>
 

--- a/spec/features/support/case_navigation_spec.rb
+++ b/spec/features/support/case_navigation_spec.rb
@@ -8,22 +8,38 @@ RSpec.feature "Case list navigation", bullet: :skip do
   end
 
   context "when navigating to a case with pagination and filters applied" do
-    before do
-      within "#all-cases" do
-        click_on "Filter results"
-        select "Example Category", from: "Filter by category"
-        click_on "Apply filter"
-        click_on "Next"
-        click_on "000001"
+    context "when using search" do
+      before do
+        within "#all-cases" do
+          click_on "Filter results"
+          select "Example Category", from: "Filter by category"
+          click_on "Apply filter"
+          click_on "Next"
+          click_on "000001"
+        end
+      end
+
+      it "has a back link to the previous page" do
+        click_on "Back"
+        within "#all-cases" do
+          expect(page).to have_select "Filter by category", selected: "Example Category"
+          expect(page).to have_selector "em", text: "2", class: "current"
+          expect(page).to have_text "Showing 11 to 13 of 13 results"
+        end
       end
     end
 
-    it "has a back link to the previous page" do
-      click_on "Back"
-      within "#all-cases" do
-        expect(page).to have_select "Filter by category", selected: "Example Category"
-        expect(page).to have_selector "em", text: "2", class: "current"
-        expect(page).to have_text "Showing 11 to 13 of 13 results"
+    context "when browsing cases" do
+      before do
+        click_on "All cases"
+        within "#all-cases" do
+          click_on "000013"
+        end
+      end
+
+      it "has a back link to the previous page" do
+        click_on "Back"
+        expect(URI(current_url).fragment).to eq "all-cases"
       end
     end
   end

--- a/spec/features/support/case_navigation_spec.rb
+++ b/spec/features/support/case_navigation_spec.rb
@@ -1,0 +1,30 @@
+RSpec.feature "Case list navigation", bullet: :skip do
+  include_context "with an agent"
+
+  before do
+    category = create(:support_category, :fixed_title)
+    create_list(:support_case, 13, category: category)
+    click_button "Agent Login"
+  end
+
+  context "when navigating to a case with pagination and filters applied" do
+    before do
+      within "#all-cases" do
+        click_on "Filter results"
+        select "Example Category", from: "Filter by category"
+        click_on "Apply filter"
+        click_on "Next"
+        click_on "000001"
+      end
+    end
+
+    it "has a back link to the previous page" do
+      click_on "Back"
+      within "#all-cases" do
+        expect(page).to have_select "Filter by category", selected: "Example Category"
+        expect(page).to have_selector "em", text: "2", class: "current"
+        expect(page).to have_text "Showing 11 to 13 of 13 results"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- add `back_to` parameter to case paths that contains the encoded current URL when going from cases `index` action to `show` action so it can be used as the back link