### PR TITLE
SubmitFrameworkRequest bugfix

### DIFF
--- a/app/services/submit_framework_request.rb
+++ b/app/services/submit_framework_request.rb
@@ -8,8 +8,8 @@ class SubmitFrameworkRequest
   extend Dry::Initializer
 
   # @!attribute request
-  #   @return [FrameworkRequest]
-  option :request, Types.Instance(FrameworkRequest)
+  #   @return [FrameworkRequestPresenter]
+  option :request, ::Types.Constructor(FrameworkRequestPresenter)
 
   # @!attribute template
   #   @return [String] Template UUID
@@ -66,8 +66,8 @@ private
       last_name: user.last_name,
       email: user.email,
       request_text: request.message_body,
-      procurement_amount: request.procurement_amount,
-      confidence_level: request.confidence_level,
+      procurement_amount: request.__getobj__.procurement_amount,
+      confidence_level: request.__getobj__.confidence_level,
       special_requirements: request.special_requirements.presence,
     }
 


### PR DESCRIPTION
Rollbar error: https://rollbar.com/dfe-digital/GHBS/items/467

## Changes in this PR

- revert changes made to `SubmitFrameworkRequest` where the `request` was being cast from `FrameworkRequest` into `FrameworkRequestPresenter`, thus providing a user struct for non-DSI users.