### PR TITLE
Ability to move category from 1 parent to another

### DIFF
--- a/app/helpers/support/collection_helper.rb
+++ b/app/helpers/support/collection_helper.rb
@@ -1,13 +1,15 @@
 module Support
   module CollectionHelper
     def procurement_category_grouped_options(selected_category_id: -1)
-      Support::Category.grouped_opts.collect do |parent_name, sub_categories|
-        [parent_name,
-         sub_categories.collect { |name, value|
-           if name != "No applicable category"
-             [name, value, { selected: selected_category_id == value }]
-           end
-         }.compact]
+      category_to_select_option = ->(category) { [category.title, category.id, { selected: selected_category_id == category.id }] }
+
+      Support::Category.top_level.ordered_by_title.each_with_object([]) do |category, grouped_options|
+        sub_categories = category.sub_categories.except_for("No applicable category")
+
+        # Don't show categories with no sub-categories
+        next unless sub_categories.any?
+
+        grouped_options << [category.title, sub_categories.map(&category_to_select_option)]
       end
     end
 

--- a/app/helpers/support/collection_helper.rb
+++ b/app/helpers/support/collection_helper.rb
@@ -3,7 +3,7 @@ module Support
     def procurement_category_grouped_options(selected_category_id: -1)
       category_to_select_option = ->(category) { [category.title, category.id, { selected: selected_category_id == category.id }] }
 
-      Support::Category.top_level.ordered_by_title.each_with_object([]) do |category, grouped_options|
+      Support::Category.top_level.each_with_object([]) do |category, grouped_options|
         sub_categories = category.sub_categories.except_for("No applicable category")
 
         # Don't show categories with no sub-categories

--- a/app/models/support/category.rb
+++ b/app/models/support/category.rb
@@ -23,9 +23,5 @@ module Support
     def self.other_category_id
       find_by(title: "Other")&.id
     end
-
-    def self.grouped_opts
-      top_level.map { |category| [category.title, category.sub_categories.pluck(:title, :id).to_h].to_h }
-    end
   end
 end

--- a/config/support/categories.yml
+++ b/config/support/categories.yml
@@ -59,6 +59,9 @@
     - title: Telecoms & Broadband
       description:
       slug: broadband
+    - title: MFD
+      slug: mfd
+      description:
 
 
 - title: FM
@@ -133,10 +136,7 @@
 - title: Business Services
   description:
   slug: business
-  sub_categories:
-    - title: MFD
-      slug: mfd
-
+  sub_categories: []
 
 - title: Financial
   description:

--- a/lib/tasks/case_management.rake
+++ b/lib/tasks/case_management.rake
@@ -76,4 +76,12 @@ namespace :case_management do
     resync_email_ids = Support::Messages::Outlook::ResyncEmailIds.new(messages_updated_after: incoming_email_went_live)
     resync_email_ids.call
   end
+
+  desc "Move sub category to new parent"
+  task :change_sub_category_parent, %i[sub_category_title new_parent_category_title] => :environment do |_task, args|
+    sub_category = Support::Category.find_by(title: args.sub_category_title)
+    new_parent_category = Support::Category.find_by(title: args.new_parent_category_title)
+
+    sub_category.update!(parent: new_parent_category)
+  end
 end

--- a/spec/helpers/support/collection_helper_spec.rb
+++ b/spec/helpers/support/collection_helper_spec.rb
@@ -8,6 +8,10 @@ describe Support::CollectionHelper do
       expect(helper.procurement_category_grouped_options.flatten).not_to include("No applicable category")
     end
 
+    it "has Or as the last option in the list" do
+      expect(helper.procurement_category_grouped_options.last[0]).to eq("Or")
+    end
+
     context "when a category exists with no sub-categories" do
       before { define_categories("Business Services" => []) }
 

--- a/spec/helpers/support/collection_helper_spec.rb
+++ b/spec/helpers/support/collection_helper_spec.rb
@@ -2,18 +2,18 @@ require "rails_helper"
 
 describe Support::CollectionHelper do
   describe "#procurement_category_grouped_options" do
-    it "does not list 'No applicable category' in the options" do
-      allow(Support::Category).to receive(:grouped_opts).and_return({
-        "ICT" => {
-          "Peripherals" => 1,
-        },
-        "Or" => {
-          "Other" => 2,
-          "No applicable category" => 3,
-        },
-      })
+    before { define_basic_categories }
 
+    it "does not list 'No applicable category' in the options" do
       expect(helper.procurement_category_grouped_options.flatten).not_to include("No applicable category")
+    end
+
+    context "when a category exists with no sub-categories" do
+      before { define_categories("Business Services" => []) }
+
+      it "does not show that category in the options" do
+        expect(helper.procurement_category_grouped_options.flatten).not_to include("Business Services")
+      end
     end
   end
 end

--- a/spec/models/support/category_spec.rb
+++ b/spec/models/support/category_spec.rb
@@ -26,14 +26,4 @@ RSpec.describe Support::Category, type: :model do
       end
     end
   end
-
-  describe ".grouped_options" do
-    context "with sub categories" do
-      let(:parent_category) { create(:support_category, :with_sub_category) }
-
-      it "returns nested hash" do
-        expect(parent_category.class.grouped_opts).to be_categorised(parent: parent_category.title, child: parent_category.sub_categories.first.title)
-      end
-    end
-  end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

- A rake task to move a category from one parent to another
- Don't show categories that have no subcategories in any dropdowns.

### Post-deployment tasks

- run `rails case_management:change_sub_category_parent'[MFD, ICT]'` on prod