### PR TITLE
Remove exit survey from templates

### DIFF
--- a/app/views/support/cases/emails/templates/index.html.erb
+++ b/app/views/support/cases/emails/templates/index.html.erb
@@ -61,15 +61,3 @@
 </p>
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-
-<h3 class="govuk-heading-m">
-  <%= link_to I18n.t("support.case_email_templates.index.exit_survey.link_text"),
-  support_case_email_content_path(@current_case, template: Support::EmailTemplates::IDS[:exit_survey]),
-  class: "govuk-link" %>
-</h3>
-
-<p class="govuk-body">
-  <%= I18n.t("support.case_email_templates.index.exit_survey.subtitle") %>
-</p>
-
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -674,7 +674,6 @@ en:
           subtitle: Link to catering on find a framework
         exit_survey:
           link_text: Send the exit survey to closed cases
-          subtitle: Link to exit survey to be sent to all cases closed within the last 7 days
         header: Send template email
         how_to_approach_suppliers:
           link_text: How to approach suppliers

--- a/spec/features/support/emails/agent_sends_templated_email_spec.rb
+++ b/spec/features/support/emails/agent_sends_templated_email_spec.rb
@@ -53,10 +53,6 @@ describe "Support agent sends a templated email" do
       # support.case_email_templates.index.user_research.link_text
       expect(page).to have_link "Ask schools to take part in user research",
                                 href: "/support/cases/#{support_case.id}/email/content/fd89b69e-7ff9-4b73-b4c4-d8c1d7b93779"
-
-      # support.case_email_templates.index.exit_survey.link_text
-      expect(page).to have_link "Send the exit survey to closed cases",
-                                href: "/support/cases/#{support_case.id}/email/content/134bc268-2c6b-4b74-b6f4-4a58e22d6c8b"
     end
   end
 


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Remove "Exit survey" email template from CMS