### PR TITLE
Exclude threads with no id

### DIFF
--- a/app/presenters/support/case_presenter.rb
+++ b/app/presenters/support/case_presenter.rb
@@ -161,7 +161,8 @@ module Support
 
     # @return [Array<MessageThreadPresenter>]
     def message_threads
-      super.includes([:messages]).map { |thread| MessageThreadPresenter.new(thread) }
+      # there are occassional emails with no conversation_id?
+      super.includes([:messages]).filter {|t| t.id.present? }.map { |thread| MessageThreadPresenter.new(thread) }
     end
 
     # @return [Array<Messages::NotifyMessagePresenter>]


### PR DESCRIPTION
## Changes in this PR

- don't display message threads with no ID (some emails come in without a conversation_id)