### PR TITLE
Always show message recap

### DIFF
--- a/app/presenters/support/messages/notify_message_presenter.rb
+++ b/app/presenters/support/messages/notify_message_presenter.rb
@@ -33,6 +33,10 @@ module Support
         []
       end
 
+      def show_recap?
+        false
+      end
+
       def render_actions(view_context)
         view_context.render("support/cases/message_threads/notify/actions", message: self)
       end

--- a/app/presenters/support/messages/outlook_message_presenter.rb
+++ b/app/presenters/support/messages/outlook_message_presenter.rb
@@ -55,6 +55,10 @@ module Support
         body_for_display(view_context, body_field: :body)
       end
 
+      def show_recap?
+        true
+      end
+
       def body_for_display(view_context, body_field: :unique_body)
         # Do initial removal of links, and replace images with inline attachments
         new_body = body_with_links_removed(

--- a/app/views/support/cases/message_threads/_four_or_less_messages.html.erb
+++ b/app/views/support/cases/message_threads/_four_or_less_messages.html.erb
@@ -4,4 +4,4 @@
   <% end %>
 <% end %>
 
-<%= render "support/cases/message_threads/message", message: messages.last, current_case: current_case, show_recap: messages.count > 1 %>
+<%= render "support/cases/message_threads/message", message: messages.last, current_case: current_case %>

--- a/app/views/support/cases/message_threads/_greater_than_four_messages.html.erb
+++ b/app/views/support/cases/message_threads/_greater_than_four_messages.html.erb
@@ -1,4 +1,4 @@
 <%= render "support/cases/message_threads/message", truncated_message: true,  message: messages.first, current_case: current_case %>
 <%= render "support/cases/message_threads/view_more_responses", messages: messages[1...-2], current_case: current_case %>
 <%= render "support/cases/message_threads/message", truncated_message: true,  message: messages.second_to_last, current_case: current_case %>
-<%= render "support/cases/message_threads/message", truncated_message: false, message: messages.last, current_case: current_case, show_recap: true %>
+<%= render "support/cases/message_threads/message", truncated_message: false, message: messages.last, current_case: current_case %>

--- a/app/views/support/cases/message_threads/_message.erb
+++ b/app/views/support/cases/message_threads/_message.erb
@@ -1,5 +1,4 @@
 <% truncated_message = defined?(truncated_message) ? truncated_message : false %>
-<% show_recap = defined?(show_recap) ? show_recap : false %>
 
 <div class="message">
   <div class="message-details">
@@ -24,7 +23,7 @@
 
       <%= render "support/cases/messages/attachments", email: message %>
 
-      <% if show_recap %>
+      <% if message.show_recap? %>
         <div class="message-recap">
           <div class="recap-controls" data-component="toggle-panel-visibility" data-panel="recap-<%= message.id %>">
             <div class="dots">


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

There are too many edge cases where the user will need to see quoted messages, simply show this button all the time for now.
