### PR TITLE
TO field pre-populated on new message thread page

### DIFF
--- a/app/assets/stylesheets/components/supported/_messages.scss
+++ b/app/assets/stylesheets/components/supported/_messages.scss
@@ -80,15 +80,43 @@
   }
 }
 
+$message-table-width: 75%;
+$message-key-width: 52px;
+
+.subject-input {
+  width: $message-table-width;
+}
+
 .recipient-input-group {
   display: flex;
   justify-content: space-between;
-  width: 420px;
+  width:  $message-table-width;
+
+  .govuk-form-group {
+    flex-grow: 1;
+  }
+
+  button {
+    margin-left: 10px;
+  }
 
   .govuk-input__wrapper {
-    width: 350px;
+    .govuk-input__prefix {
+      width: $message-key-width;
+    }
+    input {
+      flex-grow: 1;
+      flex-shrink: 1;
+    }
   }
 }
+
+.added_recipients_table {
+  .govuk-table__header {
+    width: $message-key-width;
+  }
+}
+
 
 .unread-thread {
   @extend .govuk-\!-font-weight-bold;

--- a/app/controllers/support/cases/message_threads_controller.rb
+++ b/app/controllers/support/cases/message_threads_controller.rb
@@ -14,7 +14,9 @@ module Support
 
       def show; end
 
-      def new; end
+      def new
+        @to_recipients = Array(current_case.email).to_json
+      end
 
       def templated_messages; end
 

--- a/app/javascript/components/add-recipients.js
+++ b/app/javascript/components/add-recipients.js
@@ -38,16 +38,11 @@ function createRecipientRow(tableId, label, value, collectionName) {
   const recipientEmail = document.createTextNode(value);
   recipientTd.appendChild(recipientEmail);
 
-  const recipientBlankTd = document.createElement("td");
-  recipientBlankTd.classList.add("govuk-table__cell");
-
   const recipientRemoveTd = document.createElement("td");
   recipientRemoveTd.classList.add("govuk-table__cell", "govuk-table__cell--numeric");
-
   recipientRemoveTd.appendChild(createRemoveLink(tableId, value, collectionName));
 
   recipientRow.appendChild(labelTh);
-  recipientRow.appendChild(recipientBlankTd);
   recipientRow.appendChild(recipientTd);
   recipientRow.appendChild(recipientRemoveTd);
 
@@ -86,13 +81,26 @@ function getRecipientsButtons() {
   return document.querySelectorAll('[data-component="add-recipients"]');
 }
 
+function pressEnterInInputBoxToAddRecipient(addButton) {
+  const inputField = document.querySelector(`input[name="${addButton.dataset.inputField}"]`);
+  inputField.addEventListener("keypress", (e) => {
+    if (e.key == "Enter") {
+      e.preventDefault();
+      addButton.click();
+    }
+  })
+}
+
+function clickAddButtonToAddRecipient(addButton) {
+  addButton.addEventListener("click", () => addRecipient(addButton.dataset.inputField));
+}
+
 (() => {
   window.addEventListener("DOMContentLoaded", () => {
     getRecipientsButtons().forEach(b => {
       showTables(b.dataset.inputField);
-      b.addEventListener("click", () => {
-        addRecipient(b.dataset.inputField);
-      });
+      pressEnterInInputBoxToAddRecipient(b);
+      clickAddButtonToAddRecipient(b);
     });
   });
 })();

--- a/app/views/support/cases/messages/replies/_form.html.erb
+++ b/app/views/support/cases/messages/replies/_form.html.erb
@@ -5,7 +5,7 @@
 <%= form_with id: "message-form", model: @reply_form, scope: :"message_reply_form_#{unique_id}", url: url, method: :post  do |form| %>
   <%= form.govuk_error_summary %>
 
-  <% if !reply %>
+  <% unless reply %>
     <%= render "support/cases/messages/replies/new_message_components", form: form, unique_id: unique_id %>
   <% end %>
 

--- a/app/views/support/cases/messages/replies/_new_message_components.html.erb
+++ b/app/views/support/cases/messages/replies/_new_message_components.html.erb
@@ -2,13 +2,14 @@
 <%= form.hidden_field :cc_recipients, value: @cc_recipients || nil  %>
 <%= form.hidden_field :bcc_recipients, value: @bcc_recipients || nil  %>
 
-<%= form.govuk_text_field :subject, label: { text: I18n.t("support.case.label.message_threads.new.enter_subject"), size: "m" }, class: "govuk-!-width-one-half", value: @subject || @default_subject_line %>
-    
+<%= form.govuk_text_field :subject, label: { text: I18n.t("support.case.label.message_threads.new.enter_subject"), size: "m" }, class: "subject-input", value: @subject || @default_subject_line %>
+
 <p class="govuk-label govuk-label--m"><%= I18n.t("support.case.label.message_threads.new.add_recipients") %></p>
 <span class="recipient-input-group">
   <%= form.govuk_text_field :to,
         label: nil,
         prefix_text: I18n.t("support.case.label.message_threads.new.to"),
+        placeholder: I18n.t("support.case.label.message_threads.new.press_enter_to_add_recipients"),
         "data-collection" => "message_reply_form_#{unique_id}[to_recipients]",
         "data-table" => "#{unique_id}_to" %>
   <button class="govuk-button"
@@ -24,6 +25,7 @@
     <%= form.govuk_text_field :cc,
           label: nil,
           prefix_text: I18n.t("support.case.label.message_threads.new.cc"),
+          placeholder: I18n.t("support.case.label.message_threads.new.press_enter_to_add_cc"),
           "data-collection" => "message_reply_form_#{unique_id}[cc_recipients]",
           "data-table" => "#{unique_id}_cc" %>
     <button class="govuk-button"
@@ -38,6 +40,7 @@
     <%= form.govuk_text_field :bcc,
           label: nil,
           prefix_text: I18n.t("support.case.label.message_threads.new.bcc"),
+          placeholder: I18n.t("support.case.label.message_threads.new.press_enter_to_add_bcc"),
           "data-collection" => "message_reply_form_#{unique_id}[bcc_recipients]",
           "data-table" => "#{unique_id}_bcc" %>
     <button class="govuk-button"
@@ -51,7 +54,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters">
     <table id="<%= unique_id %>_to" class="govuk-table added_recipients_table" data-row-label="TO" hidden="true">
       <tbody class="govuk-table__body">
         <% # to be populated by javascript %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -598,6 +598,9 @@ en:
             enter_subject: Enter an email subject
             hide_cc_bcc: Hide CC / BCC
             to: TO
+            press_enter_to_add_recipients: Press Enter to add recipients
+            press_enter_to_add_cc: Press Enter to add recipients as CC
+            press_enter_to_add_bcc: Press Enter to add recipients as BCC
           new_thread: Create a new message thread
           recipients: Recipients
           subject: Subject

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -597,10 +597,10 @@ en:
             cc: CC
             enter_subject: Enter an email subject
             hide_cc_bcc: Hide CC / BCC
-            to: TO
-            press_enter_to_add_recipients: Press Enter to add recipients
-            press_enter_to_add_cc: Press Enter to add recipients as CC
             press_enter_to_add_bcc: Press Enter to add recipients as BCC
+            press_enter_to_add_cc: Press Enter to add recipients as CC
+            press_enter_to_add_recipients: Press Enter to add recipients
+            to: TO
           new_thread: Create a new message thread
           recipients: Recipients
           subject: Subject

--- a/spec/features/support/emails/agent_can_send_new_emails_spec.rb
+++ b/spec/features/support/emails/agent_can_send_new_emails_spec.rb
@@ -1,7 +1,7 @@
 describe "Agent can send new emails" do
   include_context "with an agent"
 
-  let(:support_case) { create(:support_case) }
+  let(:support_case) { create(:support_case, email: "contact@email.com") }
 
   before do
     click_button "Agent Login"
@@ -38,6 +38,8 @@ describe "Agent can send new emails" do
     it "shows added recipients" do
       to_table = find("table[data-row-label='TO']")
       within(to_table) do
+        # case email added by default
+        expect(page).to have_text "contact@email.com"
         expect(page).to have_text "to@email.com"
       end
 


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

- The case contact email is auto populated to the "To" field when creating a new email thread
- Visual improvements such as lining up table columns and giving more space to input boxes for legibility
- Ability to press enter in an input box to add the recipient

### Screen captire

https://user-images.githubusercontent.com/1352756/192776935-068960a1-72ec-4597-8e62-962af027a624.mov



