### PR TITLE
Option to add a case note when case is on hold

### DIFF
--- a/app/controllers/support/interactions_controller.rb
+++ b/app/controllers/support/interactions_controller.rb
@@ -19,7 +19,7 @@ module Support
       if @interaction.save
         record_action(case_id: @interaction.case.id, action: "add_interaction", data: { event_type: @interaction.event_type })
 
-        redirect_to logged_contacts_support_case_message_threads_path(@interaction.case),
+        redirect_to determine_redirect_path(@interaction.event_type),
                     notice: I18n.t("support.interaction.message.created_flash", type: @interaction.event_type).humanize
       else
         render :new, locals: { option: safe_interaction }
@@ -39,6 +39,15 @@ module Support
 
     def current_case
       @current_case || Case.find(params[:case_id])
+    end
+
+    def determine_redirect_path(event_type)
+      case event_type
+      when "note"
+        support_case_path(current_case, anchor: "case-history")
+      else
+        logged_contacts_support_case_message_threads_path(current_case)
+      end
     end
   end
 end

--- a/app/views/support/cases/_case_actions.html.erb
+++ b/app/views/support/cases/_case_actions.html.erb
@@ -28,6 +28,9 @@
 
      <% if @current_case.on_hold? %>
       <li>
+        <%= link_to I18n.t("support.case.label.add_note"), new_support_case_interaction_path(@current_case, option: :note), class: "govuk-link" %>
+      </li>
+      <li>
         <%= link_to I18n.t("support.case.label.reopen"), support_case_opening_path(@current_case), method: :post, class: "govuk-link" %>
       </li>
     <% end %>

--- a/app/views/support/cases/_case_actions.html.erb
+++ b/app/views/support/cases/_case_actions.html.erb
@@ -1,12 +1,12 @@
 <h3 class="govuk-heading-m"><%= I18n.t("support.case.header.action") %></h3>
 
   <ul class="govuk-list case-actions">
+    <li>
+      <%= link_to I18n.t("support.case.label.add_note"), new_support_case_interaction_path(@current_case, option: :note), class: "govuk-link" %>
+    </li>
     <% if @current_case.opened? %>
       <li>
         <%= link_to I18n.t("support.case.label.change_owner"), new_support_case_assignment_path(@current_case), class: "govuk-link" %>
-      </li>
-      <li>
-        <%= link_to I18n.t("support.case.label.add_note"), new_support_case_interaction_path(@current_case, option: :note), class: "govuk-link" %>
       </li>
       <li>
         <%= link_to I18n.t("support.case.label.send_template_email"), support_case_email_templates_path(@current_case), class: "govuk-link" %>
@@ -27,9 +27,6 @@
     <% end %>
 
      <% if @current_case.on_hold? %>
-      <li>
-        <%= link_to I18n.t("support.case.label.add_note"), new_support_case_interaction_path(@current_case, option: :note), class: "govuk-link" %>
-      </li>
       <li>
         <%= link_to I18n.t("support.case.label.reopen"), support_case_opening_path(@current_case), method: :post, class: "govuk-link" %>
       </li>


### PR DESCRIPTION
## Changes in this PR

- allow the addition of case notes to all cases regardless of status
- fix redirect path for added notes