### PR TITLE
Pin docker buildx to fix OCI issue on CF

### DIFF
--- a/.github/workflows/actions/build-docker-image/action.yml
+++ b/.github/workflows/actions/build-docker-image/action.yml
@@ -53,6 +53,8 @@ runs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.9.1
 
     - name: Build docker image
       uses: docker/build-push-action@v3


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Having problems deploying due to the following errors:

```
202***-0***-2***T***0:06:08.***8+0000 [STG/0] ERR Failed getting docker image manifest by tag: Error reading manifest 805a248 in ghcr.io/dfe-digital/buy-for-your-school: manifest unknown: OCI index found, but Accept header does not support OCI indexes  Going to retry attempt: ***
	202***-0***-2***T***0:06:08.77+0000 [STG/0] ERR Failed getting docker image manifest by tag: Error reading manifest 805a248 in ghcr.io/dfe-digital/buy-for-your-school: manifest unknown: OCI index found, but Accept header does not support OCI indexes  Going to retry attempt: 2
	202***-0***-2***T***0:06:09.***9+0000 [STG/0] ERR Failed getting docker image manifest by tag: Error reading manifest 805a248 in ghcr.io/dfe-digital/buy-for-your-school: manifest unknown: OCI index found, but Accept header does not support OCI indexes  Going to retry attempt: ***
	202***-0***-2***T***0:06:09.99+0000 [STG/0] ERR Failed getting docker image manifest by tag: Error reading manifest 805a248 in ghcr.io/dfe-digital/buy-for-your-school: manifest unknown: OCI index found, but Accept header does not support OCI indexes
```

Fix suggested here: https://github.com/DFE-Digital/get-into-teaching-app/pull/3089