### PR TITLE
feat(rfh): detect only energy tower cats eng reqs

### DIFF
--- a/app/controllers/support/management/category_detections_controller.rb
+++ b/app/controllers/support/management/category_detections_controller.rb
@@ -10,7 +10,7 @@ module Support
 
   private
 
-    def form_params = params.fetch(:category_detection, {}).permit(:request_text)
+    def form_params = params.fetch(:category_detection, {}).permit(:request_text, :simulate_energy_request)
 
     def build_form = @category_detection_form = CategoryDetectionForm.new(**form_params)
 

--- a/app/forms/support/category_detection_form.rb
+++ b/app/forms/support/category_detection_form.rb
@@ -1,8 +1,8 @@
 module Support
   class CategoryDetectionForm
     include ActiveModel::Model
-    attr_accessor :request_text
+    attr_accessor :request_text, :simulate_energy_request
 
-    def results = CategoryDetection.results_for(request_text, num_results: 10)
+    def results = CategoryDetection.results_for(request_text, is_energy_request: simulate_energy_request == "true", num_results: 10)
   end
 end

--- a/app/services/submit_framework_request.rb
+++ b/app/services/submit_framework_request.rb
@@ -87,7 +87,7 @@ private
   end
 
   def detected_category_id
-    @results ||= Support::CategoryDetection.results_for(request.message_body, num_results: 1)
+    @results ||= Support::CategoryDetection.results_for(request.message_body, is_energy_request: request.is_energy_request, num_results: 1)
     @results.first.try(:category_id) if @results.any?
   end
 

--- a/app/views/support/management/category_detections/new.html.erb
+++ b/app/views/support/management/category_detections/new.html.erb
@@ -44,6 +44,9 @@
     label: { text: "Manually detect categories", size: "l" },
     hint: { text: "Enter an example request for text to see which category would be detected" }
   %>
+  <%= form.govuk_check_boxes_fieldset :simulate_energy_request, multiple: false, legend: nil do %>
+    <%= form.govuk_check_box :simulate_energy_request, true, false, multiple: false, link_errors: true, label: { text: "Simulate energy request" } %>
+  <% end %>
   <%= form.submit I18n.t("support.management.category_detection.submit"), class: "govuk-button" %>
 <% end %>
 

--- a/spec/services/self-serve/submit_framework_request_spec.rb
+++ b/spec/services/self-serve/submit_framework_request_spec.rb
@@ -28,6 +28,24 @@ describe SubmitFrameworkRequest do
       end
     end
 
+    context "when the request is an energy request" do
+      let(:request) { create(:framework_request, message_body: "An energy case", is_energy_request: true) }
+
+      it "limits detectable categories to Energy & Utility tower ones" do
+        described_class.new(request:, referrer:).call
+        expect(Support::CategoryDetection).to have_received(:results_for).with("An energy case", is_energy_request: true, num_results: 1)
+      end
+    end
+
+    context "when the request is not an energy request" do
+      let(:request) { create(:framework_request, message_body: "An energy case", is_energy_request: false) }
+
+      it "does not limit detectable categories to Energy & Utility tower ones" do
+        described_class.new(request:, referrer:).call
+        expect(Support::CategoryDetection).to have_received(:results_for).with("An energy case", is_energy_request: false, num_results: 1)
+      end
+    end
+
     context "when a category cannot be detected for the given request text" do
       let(:category_detection_results) { [] }
 


### PR DESCRIPTION
Limit the category detection to only categories in the Energy tower when the user has specified the RFH is for energy