### PR TITLE
fix(rfh): define bill upload button values

### DIFF
--- a/app/javascript/controllers/energy_bill_upload_controller.js
+++ b/app/javascript/controllers/energy_bill_upload_controller.js
@@ -16,7 +16,9 @@ export default class extends Controller {
   static values = {
     pageOneTitle: String,
     pageTwoTitle: String,
-    pageThreeTitle: String
+    pageThreeTitle: String,
+    pageOneContinueButton: String,
+    pageThreeContinueButton: String
   }
 
   static outlets = [


### PR DESCRIPTION
## Changes in this PR

Added the Continue button text values to the `energy_bill_upload_controller`'s `values` object. These were previously missing and causing the button to show "undefined" when `pageOne` elements were being rendered.