### PR TITLE
fix(specify): fix next steps links and redirects

### DIFF
--- a/app/controllers/specifications_controller.rb
+++ b/app/controllers/specifications_controller.rb
@@ -2,6 +2,7 @@
 
 class SpecificationsController < ApplicationController
   before_action :check_user_belongs_to_journey?
+  before_action :next_steps_path, only: %i[show create]
   helper_method :current_journey, :form
 
   def new
@@ -14,7 +15,7 @@ class SpecificationsController < ApplicationController
         current_journey.finish!
         redirect_to(
           URI::HTTPS.build(
-            path: "/next-steps-catering",
+            path: @next_steps_path,
             query: { redirect_url: journey_specification_url(current_journey, format: :docx) }.to_query,
           ).request_uri,
         )
@@ -88,5 +89,9 @@ private
   # @return [String]
   def file_ext
     params[:format]
+  end
+
+  def next_steps_path
+    @next_steps_path = "/next-steps-#{current_journey.category_slug}"
   end
 end

--- a/app/presenters/journey_presenter.rb
+++ b/app/presenters/journey_presenter.rb
@@ -1,4 +1,6 @@
 class JourneyPresenter < BasePresenter
+  delegate :slug, to: :category, prefix: :category
+
   # @return [Array<SectionPresenter>]
   def sections
     @sections ||= sections_with_tasks.map do |section|

--- a/app/views/specifications/show.html.erb
+++ b/app/views/specifications/show.html.erb
@@ -43,7 +43,7 @@
     <div class="govuk-!-padding-bottom-9"></div>
     <h2 class="govuk-heading-m"> <%= I18n.t("journey.specification.show.sidebar.header") %> </h2>
     <ul class="govuk-list govuk-list--spaced">
-      <li> <%= link_to I18n.t("journey.specification.show.sidebar.links.completed_specification"), "/next-steps-catering", class: "govuk-link", target: "_blank" %> </li>
+      <li> <%= link_to I18n.t("journey.specification.show.sidebar.links.completed_specification"), @next_steps_path, class: "govuk-link", target: "_blank" %> </li>
       <li> <%= link_to I18n.t("journey.specification.show.sidebar.links.feedback"), "https://dferesearch.fra1.qualtrics.com/jfe/form/SV_2gE5Us8IIKxYge2", class: "govuk-link", target: "_blank" %> </li>
     </ul>
   </div>

--- a/spec/controllers/self-serve/specifications_controller_spec.rb
+++ b/spec/controllers/self-serve/specifications_controller_spec.rb
@@ -1,0 +1,28 @@
+describe SpecificationsController, type: :controller do
+  describe "redirects to the right next steps page based on category" do
+    let(:user) { create(:user) }
+    let(:journey) { create(:journey, category:, user:) }
+    let(:params) { { journey_id: journey.id, form: { finished: true } } }
+
+    before do
+      user_is_signed_in(user:)
+      post(:create, params:)
+    end
+
+    context "when the category is catering" do
+      let(:category) { build(:category, :catering) }
+
+      it "redirects to the right next steps page" do
+        expect(response).to redirect_to(%r{/next-steps-catering})
+      end
+    end
+
+    context "when the category is mfd" do
+      let(:category) { build(:category, :mfd) }
+
+      it "redirects to the right next steps page" do
+        expect(response).to redirect_to(%r{/next-steps-mfd})
+      end
+    end
+  end
+end

--- a/spec/presenters/self-serve/journey_presenter_spec.rb
+++ b/spec/presenters/self-serve/journey_presenter_spec.rb
@@ -1,34 +1,38 @@
 RSpec.describe JourneyPresenter do
+  subject(:presenter) { described_class.new(journey) }
+
+  let(:journey) { build(:journey) }
+
+  it { is_expected.to delegate_method(:slug).to(:category).with_prefix(:category) }
+
   describe "#sections" do
+    let(:journey) { build(:journey, :with_sections, sections_count: 2) }
+
     it "returns decorated sections" do
-      journey = build(:journey, :with_sections, sections_count: 2)
-      presenter = described_class.new(journey)
       expect(presenter.sections).to all be_a(SectionPresenter)
     end
   end
 
   describe "#steps" do
+    let(:task) { build(:task, :with_steps, steps_count: 2) }
+    let(:section) { build(:section, tasks: [task]) }
+    let(:journey) { build(:journey, sections: [section]) }
+
     it "returns decorated steps" do
-      task = build(:task, :with_steps, steps_count: 2)
-      section = build(:section, tasks: [task])
-      journey = build(:journey, sections: [section])
-      presenter = described_class.new(journey)
       expect(presenter.steps).to all be_a(StepPresenter)
     end
   end
 
   describe "#created_at" do
+    let(:journey) { build(:journey, created_at: Time.zone.local(2021, 9, 8)) }
+
     it "returns a formatted date" do
-      journey = build(:journey, created_at: Time.zone.local(2021, 9, 8))
-      presenter = described_class.new(journey)
       expect(presenter.created_at).to eq " 8 September 2021"
     end
   end
 
   describe "#category" do
     it "returns a decorated category" do
-      journey = build(:journey)
-      presenter = described_class.new(journey)
       expect(presenter.category).to be_kind_of(CategoryPresenter)
     end
   end


### PR DESCRIPTION
Fixed the links and redirects to the Next Steps pages by ensuring that they go to the right page based on the specification category.

Jira: PWNN-417