### PR TITLE
Fix accessibility audit failures in RFH

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -1,1 +1,5 @@
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
+
+.autocomplete__option--no-results {
+  @include govuk-font($size: 19)
+}

--- a/app/controllers/support/establishment_groups_controller.rb
+++ b/app/controllers/support/establishment_groups_controller.rb
@@ -14,7 +14,7 @@ module Support
         format.json do
           render json: EstablishmentGroup
             .where(query, q: "%#{params.fetch(:q)}%")
-            .limit(25)
+            .limit(50)
             .each { |g| g.ukprn = "N/A" if g.ukprn.nil? }
             .as_json(only: %i[id uid name ukprn], methods: %i[formatted_name])
         end

--- a/app/controllers/support/organisations_controller.rb
+++ b/app/controllers/support/organisations_controller.rb
@@ -13,7 +13,7 @@ module Support
       results = Organisation
         .includes([:establishment_type])
         .where(query, q: "%#{params.fetch(:q)}%")
-        .limit(25)
+        .limit(50)
 
       respond_to do |format|
         format.json do

--- a/app/forms/framework_requests/procurement_amount_form.rb
+++ b/app/forms/framework_requests/procurement_amount_form.rb
@@ -1,5 +1,8 @@
 module FrameworkRequests
   class ProcurementAmountForm < BaseForm
+    include ActiveModel::Validations::Callbacks
+
+    before_validation :format_amount
     validate :procurement_amount_validation
 
     attr_accessor :procurement_amount
@@ -7,6 +10,10 @@ module FrameworkRequests
     def initialize(attributes = {})
       super
       @procurement_amount ||= (sprintf("%.2f", framework_request.procurement_amount) if framework_request.procurement_amount.present?)
+    end
+
+    def format_amount
+      @procurement_amount = @procurement_amount&.gsub(/[£,]/, "")
     end
 
     def procurement_amount_validation

--- a/app/javascript/components/autocomplete.js
+++ b/app/javascript/components/autocomplete.js
@@ -116,7 +116,8 @@ import _ from "lodash";
           suggestion: i => formatSuggestion(i, suggestionTemplate)
         },
         source: _.throttle(doQueryLookup),
-        onConfirm: setHiddenFields
+        onConfirm: setHiddenFields,
+        tStatusNoResults: () => "No results found"
       }
 
       setupFormGroupAndLabel();

--- a/app/presenters/request_presenter.rb
+++ b/app/presenters/request_presenter.rb
@@ -3,7 +3,7 @@ class RequestPresenter < BasePresenter
 
   # return [String]
   def procurement_amount
-    return I18n.t("request.procurement_amount.not_known") if super.nil?
+    return I18n.t("generic.not_provided") if super.nil?
 
     number_to_currency(super, unit: "£", precision: 2)
   end

--- a/app/presenters/support/establishment_group_presenter.rb
+++ b/app/presenters/support/establishment_group_presenter.rb
@@ -16,7 +16,8 @@ module Support
     def formatted_address
       [address["street"], address["locality"], address["postcode"]]
         .reject(&:blank?)
-        .to_sentence(last_word_connector: ", ")
+        .to_sentence(last_word_connector: ", ", two_words_connector: ", ")
+        .presence || I18n.t("generic.not_provided")
     end
 
     def postcode
@@ -46,6 +47,10 @@ module Support
 
       group_type_id = Support::EstablishmentGroup.find_by(uid:).establishment_group_type_id
       @group_type_name = Support::EstablishmentGroupType.where(id: group_type_id).first.name
+    end
+
+    def ukprn
+      super.presence || I18n.t("generic.not_provided")
     end
   end
 end

--- a/app/presenters/support/organisation_presenter.rb
+++ b/app/presenters/support/organisation_presenter.rb
@@ -9,26 +9,33 @@ module Support
     def formatted_address
       [address["street"], address["locality"], address["postcode"]]
         .reject(&:blank?)
-        .to_sentence(last_word_connector: ", ")
+        .to_sentence(last_word_connector: ", ", two_words_connector: ", ")
+        .presence || I18n.t("generic.not_provided")
     end
 
     def postcode
       address["postcode"]
     end
 
-    # @return [String, nil]
+    # @return [String]
     def local_authority
-      super["name"] if super
+      return I18n.t("generic.not_provided") unless super
+
+      super["name"]
     end
 
     # @return [String]
     def contact
-      "#{super['title']} #{super['first_name']} #{super['last_name']}" if super
+      return I18n.t("generic.not_provided") unless super
+
+      "#{super['title']} #{super['first_name']} #{super['last_name']}"
     end
 
     # @return [String, nil]
     def phase
-      super.to_s.humanize if super
+      return I18n.t("generic.not_provided") unless super
+
+      super.to_s.humanize
     end
 
     def establishment_type_name
@@ -43,6 +50,10 @@ module Support
 
     def gias_label
       I18n.t("support.case.link.view_school_information")
+    end
+
+    def ukprn
+      super.presence || I18n.t("generic.not_provided")
     end
   end
 end

--- a/app/views/framework_request_submissions/show.html.erb
+++ b/app/views/framework_request_submissions/show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :title, I18n.t("faf_submissions.title") %>
+
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/framework_requests/confirm_organisations/_confirm_group.html.erb
+++ b/app/views/framework_requests/confirm_organisations/_confirm_group.html.erb
@@ -9,7 +9,7 @@
       <%= I18n.t("faf.confirm_group_or_trust.summary.group_name") %>
     </dt>
     <dd class="govuk-summary-list__value">
-      <%= org.name %>,<br>
+      <%= org.name %>
     </dd>
   </div>
   <div class="govuk-summary-list__row">
@@ -34,9 +34,7 @@
     </dt>
     <dd class="govuk-summary-list__value">
       <%= I18n.t("faf.confirm_group_or_trust.summary.uid") %>: <%= org.uid %><br>
-      <% if org.ukprn %>
-        <%= I18n.t("faf.confirm_group_or_trust.summary.ukprn") %>: <%= org.ukprn %>
-      <% end %>
+      <%= I18n.t("faf.confirm_group_or_trust.summary.ukprn") %>: <%= org.ukprn %>
     </dd>
   </div>
 </dl>

--- a/app/views/framework_requests/emails/_form.html.erb
+++ b/app/views/framework_requests/emails/_form.html.erb
@@ -6,10 +6,4 @@
   <%= I18n.t("faf.email.subtitle") %>
 </span>
 
-<h1 class="govuk-label-wrapper">
-  <label class="govuk-label govuk-label--l" for="email-address">
-    <%= I18n.t("faf.email.title") %>
-  </label>
-</h1>
-
-<%= form.govuk_text_field :email, autofocus: true, label: { text: I18n.t("faf.email.label"), class: "govuk-hint" } %>
+<%= form.govuk_text_field :email, autofocus: true, label: { text: I18n.t("faf.email.title"), tag: :h1, size: "l" }, hint: { text: I18n.t("faf.email.hint") } %>

--- a/app/views/framework_requests/procurement_amounts/_form.html.erb
+++ b/app/views/framework_requests/procurement_amounts/_form.html.erb
@@ -3,9 +3,8 @@
 <%= render "framework_requests/common_form_fields", form: form %>
 
 <span class="govuk-caption-l"><%= I18n.t("request.procurement_amount.caption") %></span>
-<h1 class="govuk-heading-l"><%= I18n.t("request.procurement_amount.heading") %></h1>
-<% for content in I18n.t("request.procurement_amount.helper_content") do %>
-  <p class="govuk-hint"><%= content %></p>
-<% end %>
 
-<%= form.govuk_text_field :procurement_amount, width: 5, label: nil, prefix_text: "£" %>
+<%= form.govuk_text_field :procurement_amount, width: 5,
+    label: { text: I18n.t("request.procurement_amount.heading"), tag: :h1, class: "govuk-label--l" },
+    hint: -> { render "form_hint" },
+    prefix_text: "£" %>

--- a/app/views/framework_requests/procurement_amounts/_form_hint.erb
+++ b/app/views/framework_requests/procurement_amounts/_form_hint.erb
@@ -1,0 +1,3 @@
+<% for content in I18n.t("request.procurement_amount.helper_content") do %>
+  <p class="govuk-hint"><%= content %></p>
+<% end %>

--- a/app/views/framework_requests/show.html.erb
+++ b/app/views/framework_requests/show.html.erb
@@ -15,7 +15,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if @current_user.guest? %>
-            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_name_path(@framework_request), class: "govuk-link", id: "edit-name" %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_name_path(@framework_request), class: "govuk-link", id: "edit-name", "aria-label": I18n.t("faf.check_answers.aria.change_name") %>
           <% end %>
         </dd>
       </div>
@@ -28,7 +28,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if current_user.guest? %>
-            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_email_path(@framework_request), class: "govuk-link", id: "edit-email" %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_email_path(@framework_request), class: "govuk-link", id: "edit-email", "aria-label": I18n.t("faf.check_answers.aria.change_email")  %>
           <% end %>
         </dd>
       </div>
@@ -41,9 +41,9 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if current_user.guest? %>
-            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_search_for_organisation_path(@framework_request), class: "govuk-link", id: "edit-school" %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_search_for_organisation_path(@framework_request), class: "govuk-link", id: "edit-school", "aria-label": I18n.t("faf.check_answers.aria.change_school")  %>
           <% elsif !current_user.single_org? %>
-            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_select_organisation_path(@framework_request), class: "govuk-link", id: "edit-school" %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_select_organisation_path(@framework_request), class: "govuk-link", id: "edit-school", "aria-label": I18n.t("faf.check_answers.aria.change_school")  %>
           <% end %>
         </dd>
       </div>
@@ -60,7 +60,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if current_user.guest? %>
-            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_organisation_type_path(@framework_request), class: "govuk-link", id: "edit-school-type" %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_organisation_type_path(@framework_request), class: "govuk-link", id: "edit-school-type", "aria-label": I18n.t("faf.check_answers.aria.change_school_type")  %>
           <% end %>
         </dd>
       </div>
@@ -72,7 +72,7 @@
           <%= @framework_request.message_body %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_message_path(@framework_request), class: "govuk-link", id: "edit-message" %>
+          <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_message_path(@framework_request), class: "govuk-link", id: "edit-message", "aria-label": I18n.t("faf.check_answers.aria.change_message")  %>
         </dd>
       </div>
 
@@ -86,7 +86,7 @@
           </dd>
           <dd class="govuk-summary-list__actions">
             <% unless @framework_request.submitted? %>
-              <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_procurement_amount_path(@framework_request), class: "govuk-link", id: "edit-procurement-amount" %>
+              <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_procurement_amount_path(@framework_request), class: "govuk-link", id: "edit-procurement-amount", "aria-label": I18n.t("faf.check_answers.aria.change_procurement_amount")  %>
             <% end %>
           </dd>
         </div>
@@ -102,7 +102,7 @@
           </dd>
           <dd class="govuk-summary-list__actions">
             <% unless @framework_request.submitted? %>
-              <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_bill_uploads_path(@framework_request), class: "govuk-link", id: "edit-bill-uploads" %>
+              <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_bill_uploads_path(@framework_request), class: "govuk-link", id: "edit-bill-uploads", "aria-label": I18n.t("faf.check_answers.aria.change_bills_attached")  %>
             <% end %>
           </dd>
         </div>
@@ -117,7 +117,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% unless @framework_request.submitted? %>
-            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_special_requirements_path(@framework_request), class: "govuk-link", id: "edit-special-requirements" %>
+            <%= link_to I18n.t("generic.button.change_answer"), edit_framework_request_special_requirements_path(@framework_request), class: "govuk-link", id: "edit-special-requirements", "aria-label": I18n.t("faf.check_answers.aria.change_special_requirements")  %>
           <% end %>
         </dd>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,6 +292,15 @@ en:
         bills_attached: Bills attached
       header: Send your request
       response_time: Once you send this request, we will review it and get in touch within 2 working days.
+      aria:
+        change_name: "Change your name"
+        change_email: "Change your email"
+        change_school: "Change your school"
+        change_school_type: "Change your school type"
+        change_message: "Change the description of your request"
+        change_procurement_amount: "Change procurement amount"
+        change_bills_attached: "Change bills attached"
+        change_special_requirements: "Change special requirements"
     confirm_group_or_trust:
       caption: About your school
       choice:
@@ -301,7 +310,7 @@ en:
         address: Address
         group_name: Group name
         group_type: Group type
-        id: ID
+        id: IDs
         uid: UID
         ukprn: UKPRN
     confirm_school:
@@ -313,7 +322,7 @@ en:
       summary:
         dfe_number: DfE number
         headteacher: Headteacher / Principal
-        id: ID
+        id: IDs
         local_authority: Local authority
         name_and_address: Name and Address
         phase: Phase of education
@@ -330,7 +339,7 @@ en:
         no_dsi: No, continue without a DfE Sign-in account
       subtitle: About your school
     email:
-      label: We will only use this to contact you about your request.
+      hint: We will only use this to contact you about your request.
       subtitle: About you
       title: What is your email address?
     energy_alternative:
@@ -438,6 +447,7 @@ en:
       caption: About your school
       legend: Which school are you buying for?
   faf_submissions:
+    title: Support Request Confirmed - Get help buying for schools
     body:
       what_happens_next:
       - The Get help buying for schools team will now review your request and energy bills if you've sent them. We'll be in touch within %{days} working days to find a convenient time to discuss your options.
@@ -508,6 +518,7 @@ en:
       what_is: What is %{label}?
     'no': 'No'
     'yes': 'Yes'
+    not_provided: Not provided
   journey:
     edit:
       name:
@@ -585,7 +596,6 @@ en:
       helper_content:
       - This is the approximate amount you'll be spending over the lifetime of the contract. Use the value of a previous or existing contract if you're unsure.
       - We only use this value as a guide to understand your procurement better. We know it can change.
-      not_known: Not known
     special_requirements:
       caption: Special requirements
       heading: Do you have any special requirements when you communicate or use technology and/or online services?

--- a/spec/features/self-serve/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/self-serve/framework_requests/create_framework_request_guest_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
 
         expect(find("h1.govuk-heading-l")).to have_text "Is this the academy trust or federation you're buying for?"
 
-        expect(values[0]).to have_text "New Academy Trust,"
+        expect(values[0]).to have_text "New Academy Trust"
         expect(values[1]).to have_text "Boundary House Shr, 91 Charter House Street, EC1M 6HR"
       end
     end
@@ -166,10 +166,10 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
       end
 
       it "has the correct attributes" do
-        expect(find("span.govuk-caption-l")).to have_text "About you"
-        expect(find("label.govuk-label--l")).to have_text "What is your email address?"
+        expect(page).to have_text "About you"
+        expect(page).to have_text "What is your email address?"
 
-        expect(page).to have_field "We will only use this to contact you about your request."
+        expect(page).to have_text "We will only use this to contact you about your request."
 
         expect(page).to have_button "Continue"
       end
@@ -294,7 +294,7 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
         expect(find("h1.govuk-heading-l")).to have_text "Is this the academy trust or federation you're buying for?"
 
         expect(keys[0]).to have_text "Group name"
-        expect(values[0]).to have_text "New Academy Trust,"
+        expect(values[0]).to have_text "New Academy Trust"
 
         expect(keys[1]).to have_text "Address"
         expect(values[1]).to have_text "Boundary House Shr, 91 Charter House Street, EC1M 6HR"

--- a/spec/features/self-serve/support_requests/edit_support_request_spec.rb
+++ b/spec/features/self-serve/support_requests/edit_support_request_spec.rb
@@ -279,7 +279,7 @@ RSpec.feature "Editing a 'Digital Support' request" do
       end
 
       it "removes the procurement amount" do
-        expect(answers[6]).to have_text "Not known"
+        expect(answers[6]).to have_text "Not provided"
         expect(support_request.reload.procurement_amount).to be_nil
       end
     end

--- a/spec/forms/framework_requests/procurement_amount_form_spec.rb
+++ b/spec/forms/framework_requests/procurement_amount_form_spec.rb
@@ -3,6 +3,14 @@ describe FrameworkRequests::ProcurementAmountForm, type: :model do
 
   let(:framework_request) { create(:framework_request, procurement_amount: nil) }
 
+  describe "#format_amount" do
+    subject(:form) { described_class.new(procurement_amount: "£2,543.90") }
+
+    it "removes the pound sign and commas" do
+      expect(form.format_amount).to eq "2543.90"
+    end
+  end
+
   describe "#procurement_amount_validation" do
     context "when the procurement amount is not a valid number" do
       subject(:form) { described_class.new(procurement_amount: "abc") }
@@ -12,6 +20,17 @@ describe FrameworkRequests::ProcurementAmountForm, type: :model do
 
         expect(form).not_to be_valid
         expect(form.errors.messages[:procurement_amount]).to eq ["Enter a valid number"]
+      end
+    end
+
+    context "when the procurement amount includes the pound sign" do
+      subject(:form) { described_class.new(procurement_amount: "£12.95") }
+
+      it "the value is interpreted correctly" do
+        form.procurement_amount_validation
+
+        expect(form).to be_valid
+        expect(form.procurement_amount).to eq "12.95"
       end
     end
 

--- a/spec/presenters/self-serve/request_presenter_spec.rb
+++ b/spec/presenters/self-serve/request_presenter_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe RequestPresenter do
     context "when there is no procurement_amount" do
       let(:support_request) { build(:support_request, procurement_amount: nil) }
 
-      it "returns 'Not known'" do
-        expect(presenter.procurement_amount).to eq "Not known"
+      it "returns 'Not provided'" do
+        expect(presenter.procurement_amount).to eq "Not provided"
       end
     end
   end

--- a/spec/presenters/support/establishment_group_presenter_spec.rb
+++ b/spec/presenters/support/establishment_group_presenter_spec.rb
@@ -15,8 +15,26 @@ RSpec.describe Support::EstablishmentGroupPresenter do
     let(:establishment_group) { create(:support_establishment_group, :with_no_address) }
 
     describe "#formatted_address" do
-      it "returns a correctly address formatted" do
-        expect(presenter.formatted_address).to eq ""
+      it "returns 'not provided'" do
+        expect(presenter.formatted_address).to eq "Not provided"
+      end
+    end
+  end
+
+  describe "#ukprn" do
+    context "when available" do
+      let(:establishment_group) { create(:support_establishment_group, ukprn: "123") }
+
+      it "returns the UKPRN" do
+        expect(presenter.ukprn).to eq "123"
+      end
+    end
+
+    context "when not available" do
+      let(:establishment_group) { create(:support_establishment_group, ukprn: nil) }
+
+      it "returns 'Not provided'" do
+        expect(presenter.ukprn).to eq "Not provided"
       end
     end
   end

--- a/spec/presenters/support/organisation_presenter_spec.rb
+++ b/spec/presenters/support/organisation_presenter_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Support::OrganisationPresenter do
     let(:organisation) { create(:support_organisation) }
 
     describe "#formatted_address" do
-      it "returns a correctly address formatted" do
-        expect(presenter.formatted_address).to eq ""
+      it "returns 'not provided'" do
+        expect(presenter.formatted_address).to eq "Not provided"
       end
     end
   end
@@ -35,8 +35,8 @@ RSpec.describe Support::OrganisationPresenter do
     let(:organisation) { create(:support_organisation, local_authority: nil) }
 
     describe "#local_authority" do
-      it "returns nil" do
-        expect(presenter.local_authority).to be_nil
+      it "returns 'not provided'" do
+        expect(presenter.local_authority).to eq "Not provided"
       end
     end
   end
@@ -75,8 +75,26 @@ RSpec.describe Support::OrganisationPresenter do
     let(:organisation) { create(:support_organisation, phase: nil) }
 
     describe "#phase" do
-      it "returns nil" do
-        expect(presenter.phase).to be_nil
+      it "returns 'not provided'" do
+        expect(presenter.phase).to eq "Not provided"
+      end
+    end
+  end
+
+  describe "#ukprn" do
+    context "when available" do
+      let(:organisation) { create(:support_organisation, ukprn: "123") }
+
+      it "returns the UKPRN" do
+        expect(presenter.ukprn).to eq "123"
+      end
+    end
+
+    context "when not available" do
+      let(:organisation) { create(:support_organisation, ukprn: nil) }
+
+      it "returns 'Not provided'" do
+        expect(presenter.ukprn).to eq "Not provided"
       end
     end
   end


### PR DESCRIPTION
Fixes to accessibility audit failures in the Request For Help form.

## Changes

- change 'ID' to 'IDs' on the Confirm Your Organisation page
- give more descriptive aria labels to 'Change' links on the Check Your Answers page
- fix a bug where the label is not associated with the input field for email
- give the submission confirmation page a title
- show "Not provided" when:
      - an academy trust/federation does not have an address or a UKPRN
      - a school does not have an address, contact, local authority, phase or UKPRN
      - a procurement value is not provided (was 'Not known')
- relax the validation for the procurement value field to allow the pound sign
- increase the search result limit for school and academy trust/federation autocompletes from 25 to 50
- change the font for the 'No results found' string in the automcomplete component to match that of other GOV.UK components
- change the aria label for no results in the autocomplete component to 'No results found' so it matches the displayed text

## Included tickets

- PWNN-1174
- PWNN-1172
- PWNN-1168
- PWNN-1169
- PWNN-1166
- PWNN-1171
- PWNN-1173
- PWNN-1199