### PR TITLE
feat(cms): prepopulate case stage, level, value

### DIFF
--- a/app/services/support/create_case.rb
+++ b/app/services/support/create_case.rb
@@ -27,11 +27,13 @@ module Support
         special_requirements: @attrs[:special_requirements],
         new_contract: NewContract.create!,
         existing_contract: ExistingContract.create!,
-        procurement: Procurement.create!,
+        procurement: Procurement.create!(stage: :need),
         **organisation_attributes,
         other_category: @attrs[:other_category],
         other_query: @attrs[:other_query],
         query_id: @attrs[:query_id],
+        support_level: :L1,
+        value: @attrs[:procurement_amount],
       )
 
       Support::RecordAction.new(

--- a/spec/services/support/create_case_spec.rb
+++ b/spec/services/support/create_case_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe Support::CreateCase do
-  subject(:service) do
-    described_class
-  end
+  subject(:service) { described_class }
 
   let(:category) { create(:support_category, title: "Catering") }
   let(:organisation) { create(:support_organisation, name: "Hillside School") }
@@ -18,6 +16,7 @@ RSpec.describe Support::CreateCase do
         email: "test@example.com",
         phone_number: "00000000000",
         extension_number: "2121",
+        procurement_amount: 234.55,
       }
     end
 
@@ -33,6 +32,9 @@ RSpec.describe Support::CreateCase do
       expect(result.existing_contract).not_to be_nil
       expect(result.procurement).not_to be_nil
       expect(result.extension_number).to eq "2121"
+      expect(result.procurement.stage).to eq "need"
+      expect(result.support_level).to eq "L1"
+      expect(result.value).to eq 234.55
       expect(Support::Case.count).to be 1
     end
 


### PR DESCRIPTION
All new cases will have default procurement stage, level and value fields.
- procurement stage: "Need"
- support level: 1
- case value: procurement value, if provided

Jira: PWNN-1246