### PR TITLE
Fix accessibility audit failures in CMS & Specify

### DIFF
--- a/app/views/layouts/_breadcrumbs.html.erb
+++ b/app/views/layouts/_breadcrumbs.html.erb
@@ -1,5 +1,5 @@
 <% if breadcrumb_trail.any? %>
-  <div class="govuk-breadcrumbs">
+  <nav class="govuk-breadcrumbs" aria-label="breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
       <% breadcrumb_trail.each_with_index do |crumb, index| %>
         <li class="govuk-breadcrumbs__list-item <%= crumb.current? ? "current" : "" %>">
@@ -11,7 +11,7 @@
         </li>
       <% end %>
     </ol>
-  </div>
+  </nav>
 <% elsif @back_url.present? %>
   <%= link_to I18n.t("generic.button.back"), @back_url, class: "govuk-back-link" %>
 <% end %>

--- a/app/views/support/cases/index/_tab_all_cases.html.erb
+++ b/app/views/support/cases/index/_tab_all_cases.html.erb
@@ -3,9 +3,9 @@
     <%= I18n.t("support.case.filter.filter_results") %>
   </button>
 
-  <h2 class="govuk-heading-l">
+  <h1 class="govuk-heading-l">
     <%= I18n.t("support.case.list.all_cases") %>
-  </h2>
+  </h1>
 
   <%= render "support/cases/forms/filter_cases_form",
               form: @all_cases_filter_form,

--- a/app/views/support/cases/index/_tab_my_cases.html.erb
+++ b/app/views/support/cases/index/_tab_my_cases.html.erb
@@ -3,9 +3,9 @@
     <%= I18n.t("support.case.filter.filter_results") %>
   </button>
 
-  <h2 class="govuk-heading-l">
+  <h1 class="govuk-heading-l">
     <%= I18n.t("support.case.list.my_cases") %>
-  </h2>
+  </h1>
 
   <%= render "support/cases/forms/filter_cases_form",
               form: @my_cases_filter_form,

--- a/app/views/support/cases/index/_tab_new_cases.html.erb
+++ b/app/views/support/cases/index/_tab_new_cases.html.erb
@@ -3,9 +3,9 @@
     <%= I18n.t("support.case.filter.filter_results") %>
   </button>
 
-  <h2 class="govuk-heading-l">
+  <h1 class="govuk-heading-l">
     <%= I18n.t("support.case.list.new_cases") %>
-  </h2>
+  </h1>
 
   <%= render "support/cases/forms/filter_cases_form",
               form: @new_cases_filter_form,


### PR DESCRIPTION
Fixes for accessibility audit failures in CMS and Specify.

## Changes
- add an aria label to breadcrumbs in Create-a-Spec and use `nav` tag
- change CMS tab headings (on index page) to from `h2` to `h1`

## Included tickets
- PWNN-1183
- PWNN-1161