### PR TITLE
Remaining accessibiltiy fixes in CMS

### DIFF
--- a/app/controllers/support/cases/searches_controller.rb
+++ b/app/controllers/support/cases/searches_controller.rb
@@ -3,27 +3,25 @@
 module Support
   class Cases::SearchesController < Cases::ApplicationController
     require "will_paginate/array"
-    before_action :back_url
 
     def new
       @form = CaseSearchForm.new
+      @back_url = support_cases_path
     end
 
     def index
       @form = CaseSearchForm.from_validation(validation)
       if validation.success?
         @results = SearchCases.results(form_params).map { |c| CaseSearchPresenter.new(c) }.paginate(page: params[:my_cases_page])
+        @back_url = new_support_case_search_path
         render :index
       else
+        @back_url = support_cases_path
         render :new
       end
     end
 
   private
-
-    def back_url
-      @back_url = support_cases_path
-    end
 
     def form_params
       params.require(:search_case_form).permit(:search_term, :state, :category, :agent).each_value { |value| value.try(:strip!) }

--- a/app/controllers/support/cases/searches_controller.rb
+++ b/app/controllers/support/cases/searches_controller.rb
@@ -12,7 +12,7 @@ module Support
     def index
       @form = CaseSearchForm.from_validation(validation)
       if validation.success?
-        @results = SearchCases.results(form_params).map { |c| CaseSearchPresenter.new(c) }.paginate(page: params[:my_cases_page])
+        @results = SearchCases.results(form_params).map { |c| CasePresenter.new(c) }.paginate(page: params[:my_cases_page])
         @back_url = new_support_case_search_path
         render :index
       else

--- a/app/services/support/search_cases.rb
+++ b/app/services/support/search_cases.rb
@@ -9,7 +9,7 @@ module Support
       results = results.merge(Support::Case.by_category(search_params[:category])) if search_params[:category].present?
       results = results.merge(Support::Case.by_state(search_params[:state])) if search_params[:state].present?
       results = results.merge(Support::Case.by_agent(search_params[:agent])) if search_params[:agent].present?
-      results
+      results.map(&:case)
     end
 
     def self.search_results(search_term)

--- a/app/views/support/cases/message_threads/index.html.erb
+++ b/app/views/support/cases/message_threads/index.html.erb
@@ -1,5 +1,9 @@
 <%= render "support/cases/show/tabs", tab: "messages" do %>
   <div class="govuk-tabs__panel" id="messages" role="tabpanel" aria-labelledby="tab_messages">
+    <h2 class="govuk-heading-l">
+      <%= I18n.t("support.case.header.messages") %>
+    </h2>
+
     <table class="govuk-table messages-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/app/views/support/cases/searches/_result.html.erb
+++ b/app/views/support/cases/searches/_result.html.erb
@@ -1,18 +1,18 @@
 <tr class="govuk-table__row case-row">
   <td class="govuk-table__cell">
-    <%= link_to result.case.ref, support_case_path(result.case.id, back_to: current_url_b64), class: "govuk-link--no-visited-state" %>
+    <%= link_to result.ref, support_case_path(result.id, back_to: current_url_b64), class: "govuk-link--no-visited-state" %>
   </td>
 
   <td class="govuk-table__cell">
     <div class="ellipsis-overflow col-350px">
-      <%= link_to result.organisation_name, support_case_path(result.case.id, back_to: current_url_b64), class: "govuk-link--no-visited-state", title: result.organisation_name %>
+      <%= link_to result.organisation_name, support_case_path(result.id, back_to: current_url_b64), class: "govuk-link--no-visited-state", title: result.organisation_name %>
     </div>
   </td>
 
-  <td class="govuk-table__cell"><%= result.category_title %></td>
+  <td class="govuk-table__cell"><%= result.category.title %></td>
 
   <td class="govuk-table__cell case-status">
-    <%= render "support/cases/status_badge", kase: result.case %>
+    <%= render "support/cases/status_badge", kase: result %>
   </td>
 
   <td class="govuk-table__cell">

--- a/app/views/support/cases/show/_case_attachments.html.erb
+++ b/app/views/support/cases/show/_case_attachments.html.erb
@@ -1,4 +1,8 @@
 <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="case-attachments">
+  <h2 class="govuk-heading-l">
+    <%= I18n.t("support.case.header.case_attachments") %>
+  </h2>
+
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/support/cases/show/_case_details.html.erb
+++ b/app/views/support/cases/show/_case_details.html.erb
@@ -1,9 +1,13 @@
 <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="case-details">
+  <h2 class="govuk-heading-l">
+    <%= I18n.t("support.case.header.case_detail") %>
+  </h2>
+
   <div role="tabpanel" aria-labelledby="tab_case-details" id="case_details_sections">
-    <h2 class="govuk-heading-m">
+    <h3 class="govuk-heading-m">
       <%= I18n.t("support.case.case_details.case_summary.heading") %>
       - <%= link_to I18n.t("support.case.link.change"), edit_support_case_summary_path(current_case), class: "govuk-link govuk-link--no-visited-state" %>
-    </h2>
+    </h3>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -48,10 +52,10 @@
       </div>
     </dl>
 
-    <h2 class="govuk-heading-m">
+    <h3 class="govuk-heading-m">
       <%= I18n.t("support.case.case_details.request.heading") %>
       - <%= link_to I18n.t("support.case.link.change"), edit_support_case_request_details_path(current_case), class: "govuk-link govuk-link--no-visited-state" %>
-    </h2>
+    </h3>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -134,12 +138,12 @@
       </div>
     </dl>
 
-    <h2 id="procurement-details-procurement" class="govuk-heading-m">
+    <h3 id="procurement-details-procurement" class="govuk-heading-m">
       <%= I18n.t("support.case.header.procurement_detail") %>
       <% if current_case.procurement %>
         - <%= link_to I18n.t("support.case.link.change"), edit_support_case_procurement_details_path(current_case), class: "govuk-link govuk-link--no-visited-state"%>
       <% end %>
-    </h2>
+    </h3>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -204,10 +208,10 @@
       </div>
     </dl>
 
-    <h2 id="pd-existing-contract" class="govuk-heading-m">
+    <h3 id="pd-existing-contract" class="govuk-heading-m">
       Existing contract details -
       <%= link_to I18n.t("support.case.link.change"), edit_support_case_contract_path(current_case, current_case.existing_contract), class: "govuk-link govuk-link--no-visited-state" %>
-    </h2>
+    </h3>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9" id="pd-existing-contract-details">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -247,10 +251,10 @@
       </div>
     </dl>
 
-    <h2 id="pd-new-contract" class="govuk-heading-m">
+    <h3 id="pd-new-contract" class="govuk-heading-m">
       New contract details -
       <%= link_to I18n.t("support.case.link.change"), edit_support_case_contract_path(current_case, current_case.new_contract_id), class: "govuk-link govuk-link--no-visited-state"%>
-    </h2>
+    </h3>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9" id="pd-new-contract-details">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -290,9 +294,9 @@
       </div>
     </dl>
 
-    <h2 id="pd-savings" class="govuk-heading-m">
+    <h3 id="pd-savings" class="govuk-heading-m">
       <%= I18n.t("support.case_savings.show.header") %> - <%= link_to I18n.t("support.case_savings.show.link"), edit_support_case_savings_path(current_case), class: "govuk-link"%>
-    </h2>
+    </h3>
     <dl class="govuk-summary-list" id="pd-savings-details">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/support/cases/show/_case_history.html.erb
+++ b/app/views/support/cases/show/_case_history.html.erb
@@ -1,4 +1,8 @@
 <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="case-history">
+  <h2 class="govuk-heading-l">
+    <%= I18n.t("support.case.header.case_history") %>
+  </h2>
+
   <table class="govuk-table" id="case-history-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/support/cases/show/_school_details.html.erb
+++ b/app/views/support/cases/show/_school_details.html.erb
@@ -1,4 +1,8 @@
 <div class="govuk-tabs__panel" id="school-details" role="tabpanel" aria-labelledby="tab_school-details">
+  <h2 class="govuk-heading-l">
+    <%= I18n.t("support.case.header.school_detail") %>
+  </h2>
+
   <dl class="govuk-summary-list govuk-!-margin-bottom-5">
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">

--- a/config/locales/validation/support/en.yml
+++ b/config/locales/validation/support/en.yml
@@ -1,5 +1,13 @@
 # config/validation/en.yml
 en:
+  activerecord:
+    errors:
+      models:
+        interaction:
+          attributes:
+            body:
+              blank: Please enter a case note
+
   forms:
     rules:
       notes: "" # Omitted

--- a/spec/features/support/agent_can_change_case_request_details_spec.rb
+++ b/spec/features/support/agent_can_change_case_request_details_spec.rb
@@ -12,7 +12,7 @@ describe "Agent can change case request details", js: true do
     click_button "Agent Login"
     visit support_case_path(support_case)
     click_link "Case details"
-    within "h2", text: "Request - change" do
+    within "h3", text: "Request - change" do
       click_link "change"
     end
   end

--- a/spec/features/support/agent_can_change_case_summary_spec.rb
+++ b/spec/features/support/agent_can_change_case_summary_spec.rb
@@ -8,7 +8,7 @@ describe "Agent can change case summary" do
   before do
     click_button "Agent Login"
     visit support_case_path(support_case)
-    within "h2", text: "Case summary - change" do
+    within "h3", text: "Case summary - change" do
       click_link "change"
     end
   end

--- a/spec/features/support/case_description_spec.rb
+++ b/spec/features/support/case_description_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Case problem description" do
 
     it "allows a user to update the problem description" do
       within("div#case-details") do
-        within "h2", text: "Request - change" do
+        within "h3", text: "Request - change" do
           click_on "change"
         end
       end

--- a/spec/features/support/case_procurement_details_spec.rb
+++ b/spec/features/support/case_procurement_details_spec.rb
@@ -13,8 +13,8 @@ RSpec.feature "Case procurement details" do
   context "when there are no procurement details" do
     it "does not have a change link" do
       within("div#case-details") do
-        expect(all("h2.govuk-heading-m")[2]).to have_text "Procurement details"
-        expect(all("h2.govuk-heading-m")[2]).not_to have_link "change"
+        expect(all("h3.govuk-heading-m")[2]).to have_text "Procurement details"
+        expect(all("h3.govuk-heading-m")[2]).not_to have_link "change"
       end
     end
   end
@@ -25,8 +25,8 @@ RSpec.feature "Case procurement details" do
 
       it "has a change link" do
         within("div#case-details") do
-          expect(all("h2.govuk-heading-m")[2]).to have_text "Procurement details"
-          expect(all("h2.govuk-heading-m")[2]).to have_link "change", href: "/support/cases/#{support_case.id}/procurement_details/edit", class: "govuk-link"
+          expect(all("h3.govuk-heading-m")[2]).to have_text "Procurement details"
+          expect(all("h3.govuk-heading-m")[2]).to have_link "change", href: "/support/cases/#{support_case.id}/procurement_details/edit", class: "govuk-link"
         end
       end
     end
@@ -36,8 +36,8 @@ RSpec.feature "Case procurement details" do
 
       it "has a change link" do
         within("div#case-details") do
-          expect(all("h2.govuk-heading-m")[2]).to have_text "Procurement details"
-          expect(all("h2.govuk-heading-m")[2]).to have_link "change", href: "/support/cases/#{support_case.id}/procurement_details/edit", class: "govuk-link"
+          expect(all("h3.govuk-heading-m")[2]).to have_text "Procurement details"
+          expect(all("h3.govuk-heading-m")[2]).to have_link "change", href: "/support/cases/#{support_case.id}/procurement_details/edit", class: "govuk-link"
         end
       end
 

--- a/spec/services/support/search_cases_spec.rb
+++ b/spec/services/support/search_cases_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Support::SearchCases, bullet: :skip do
 
         it "returns correct result" do
           expect(service.results(search_params).count).to be(1)
-          expect(service.results(search_params).first.case.organisation.urn).to eq("12345678")
+          expect(service.results(search_params).first.organisation.urn).to eq("12345678")
         end
       end
 
@@ -33,7 +33,7 @@ RSpec.describe Support::SearchCases, bullet: :skip do
 
         it "returns correct result" do
           expect(service.results(search_params).count).to be(1)
-          expect(service.results(search_params).first.case.organisation.urn).to eq("12345678")
+          expect(service.results(search_params).first.organisation.urn).to eq("12345678")
         end
       end
 
@@ -42,7 +42,7 @@ RSpec.describe Support::SearchCases, bullet: :skip do
 
         it "returns correct result" do
           expect(service.results(search_params).count).to be(1)
-          expect(service.results(search_params).first.case.organisation.name).to eq("Example School")
+          expect(service.results(search_params).first.organisation.name).to eq("Example School")
         end
       end
 
@@ -51,7 +51,7 @@ RSpec.describe Support::SearchCases, bullet: :skip do
 
         it "returns correct result" do
           expect(service.results(search_params).count).to be(1)
-          expect(service.results(search_params).first.case.organisation.name).to eq("Example School")
+          expect(service.results(search_params).first.organisation.name).to eq("Example School")
         end
       end
 
@@ -60,7 +60,7 @@ RSpec.describe Support::SearchCases, bullet: :skip do
 
         it "returns correct result" do
           expect(service.results(search_params).count).to be(1)
-          expect(service.results(search_params).first.case.ref).to eq("000999")
+          expect(service.results(search_params).first.ref).to eq("000999")
         end
       end
     end


### PR DESCRIPTION
## Changes in this PR
- added `h2` headings to the tabs on the case show page
- added a custom validation message for case notes with a blank body
- updated the back link on the 'Find a case' results page to go back to the initial search page
- aligned the "Find a case" results table with the "All cases" table

## Included tickets
- PWNN-1187
- PWNN-1165
- PWNN-1185
- PWNN-1191