### PR TITLE
fix(cms): dynamic messages frame

### DIFF
--- a/app/controllers/support/cases/message_threads_controller.rb
+++ b/app/controllers/support/cases/message_threads_controller.rb
@@ -1,6 +1,7 @@
 module Support
   module Cases
     class MessageThreadsController < Cases::ApplicationController
+      before_action :redirect_to_case_tab, unless: :turbo_frame_request?, only: :show
       before_action :current_thread, only: %i[show]
       before_action :reply_form, only: %i[index show new]
       before_action :back_url, only: %i[index show new templated_messages logged_contacts]
@@ -50,6 +51,10 @@ module Support
 
       def default_subject_line
         @default_subject_line ||= "Case #{current_case.ref} – DfE Get help buying for schools: your request for advice and guidance"
+      end
+
+      def redirect_to_case_tab
+        redirect_to support_case_path(id: params[:case_id], anchor: "messages", messages_tab_url: request.url)
       end
     end
   end

--- a/app/views/support/cases/show.html.erb
+++ b/app/views/support/cases/show.html.erb
@@ -3,7 +3,7 @@
   <%= render "support/cases/show/case_details", current_case: @current_case %>
 
   <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="messages" role="tabpanel" aria-labelledby="tab_messages" aria-live="polite">
-    <%= turbo_frame_tag "messages-frame", src: support_case_message_threads_path(@current_case) do %>
+    <%= turbo_frame_tag "messages-frame", src: params[:messages_tab_url].presence || support_case_message_threads_path(@current_case) do %>
       <p class="govuk-body">Loading...</p>
     <% end %>
   </div>

--- a/spec/controllers/support/cases/message_threads_controller_spec.rb
+++ b/spec/controllers/support/cases/message_threads_controller_spec.rb
@@ -1,0 +1,15 @@
+describe Support::Cases::MessageThreadsController, type: :controller do
+  describe "show" do
+    let(:email) { create(:support_email) }
+
+    before { agent_is_signed_in }
+
+    context "when the request is not from a turbo frame" do
+      it "redirects to the case with a message tab URL" do
+        get :show, params: { id: email.outlook_conversation_id, case_id: email.case.id }
+
+        expect(response).to redirect_to "/support/cases/#{email.case.id}?messages_tab_url=#{CGI.escape(request.url)}#messages"
+      end
+    end
+  end
+end


### PR DESCRIPTION
The messages frame can now accept a `messages_tab_url` param on the cases show route and navigate there.