### PR TITLE
CMS accessibility improvements

### DIFF
--- a/app/assets/stylesheets/components/supported/_messages.scss
+++ b/app/assets/stylesheets/components/supported/_messages.scss
@@ -98,6 +98,7 @@ $message-key-width: 52px;
 
   button {
     margin-left: 10px;
+    width: 180px;
   }
 
   .govuk-input__wrapper {

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -64,6 +64,13 @@ module DateHelper
     end
   end
 
+  def relative_date_format(date)
+    date = normalize_distance_of_time_argument_to_time(date)
+    return short_date_format(date, show_time: false) if date < 1.year.ago
+
+    "#{simple_distance_of_time_in_words(date, Time.zone.now)} ago"
+  end
+
   def short_date_format(date, show_time: true, always_show_year: false)
     date = normalize_distance_of_time_argument_to_time(date)
     year_directive = always_show_year || date.year != Time.zone.now.year ? " %Y" : ""

--- a/app/javascript/components/display-cc-bcc.js
+++ b/app/javascript/components/display-cc-bcc.js
@@ -1,18 +1,30 @@
-function toggleCcBccDisplay(button) {
-  const ccBccInputs = document.getElementById("cc-and-bcc");
-  ccBccInputs.hidden = !ccBccInputs.hidden;
-  button.innerText = ccBccInputs.hidden === true ? "Show CC / BCC" : "Hide CC / BCC";
+function toggleCcDisplay(button) {
+  const ccInputs = document.getElementById("cc");
+  ccInputs.hidden = !ccInputs.hidden;
+  button.innerText = ccInputs.hidden === true ? "Show CC" : "Hide CC";
 }
 
-function getDisplayButtons() {
-  return document.querySelectorAll('[data-component="display-cc-bcc"]');
+function toggleBccDisplay(button) {
+  const bccInputs = document.getElementById("bcc");
+  bccInputs.hidden = !bccInputs.hidden;
+  button.innerText = bccInputs.hidden === true ? "Show BCC" : "Hide BCC";
+}
+
+function getDisplayCcButtons() {
+  return document.querySelectorAll('[data-component="display-cc"]');
+}
+
+function getDisplayBccButtons() {
+  return document.querySelectorAll('[data-component="display-bcc"]');
 }
 
 const displayCcBcc = () => {
-  getDisplayButtons().forEach(b => {
-    b.addEventListener("click", () => {
-      toggleCcBccDisplay(b);
-    });
+  getDisplayCcButtons().forEach(b => {
+    b.addEventListener("click", () => toggleCcDisplay(b));
+  });
+
+  getDisplayBccButtons().forEach(b => {
+    b.addEventListener("click", () => toggleBccDisplay(b));
   });
 };
 

--- a/app/views/support/cases/_not_found.html.erb
+++ b/app/views/support/cases/_not_found.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body govuk-!-font-weight-bold"><%= I18n.t("support.case.list.not_found") %></p>
+<p class="govuk-body"><%= I18n.t("support.case.list.improve_results") %></p>
+<ul class="govuk-list govuk-list--bullet">
+  <% I18n.t("support.case.list.improve_results_list").each do |item| %>
+    <li><%= item %></li>
+  <% end %>
+</ul>

--- a/app/views/support/cases/case_history/_interaction.html.erb
+++ b/app/views/support/cases/case_history/_interaction.html.erb
@@ -25,6 +25,8 @@
   </td>
 
   <td class="govuk-table__cell">
-    <%= simple_distance_of_time_in_words(interaction.created_at, Time.zone.now) %> ago</td>
+    <span title="<%= interaction.created_at %>">
+      <%= relative_date_format(interaction.created_at) %></td>
+    </span>
   </td>
 </tr>

--- a/app/views/support/cases/index/_detailed_case.html.erb
+++ b/app/views/support/cases/index/_detailed_case.html.erb
@@ -22,7 +22,7 @@
   </td>
 
   <td class="govuk-table__cell">
-    <span title="<%= kase.last_updated_at %>"><%= simple_distance_of_time_in_words(kase.last_updated_at, Time.zone.now) %> ago</span>
+    <span title="<%= kase.last_updated_at %>"><%= relative_date_format(kase.last_updated_at) %></span>
   </td>
 
   <td class="govuk-table__cell">

--- a/app/views/support/cases/index/_detailed_cases.html.erb
+++ b/app/views/support/cases/index/_detailed_cases.html.erb
@@ -1,5 +1,5 @@
 <% if cases.none? %>
-  <p class="govuk-body"><%= I18n.t("support.case.list.not_found") %></p>
+  <%= render partial: "support/cases/not_found" %>
 <% else %>
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/app/views/support/cases/index/_simple_case.html.erb
+++ b/app/views/support/cases/index/_simple_case.html.erb
@@ -18,8 +18,16 @@
   <% case tab %>
   <% when :all_cases %>
     <td class="govuk-table__cell"><%= kase.agent_name %></td>
-    <td class="govuk-table__cell"><%= short_date_format(kase.last_updated_at) %></td>
+    <td class="govuk-table__cell">
+      <span title="<%= kase.last_updated_at %>">
+        <%= relative_date_format(kase.last_updated_at) %>
+      </span>
+    </td>
   <% when :new_cases %>
-    <td class="govuk-table__cell"><%= simple_distance_of_time_in_words(kase.received_at, Time.zone.now) %> ago</td>
+    <td class="govuk-table__cell">
+      <span title="<%= kase.received_at %>">
+        <%= relative_date_format(kase.received_at) %>
+      </span>
+    </td>
   <% end %>
 </tr>

--- a/app/views/support/cases/index/_simple_cases.html.erb
+++ b/app/views/support/cases/index/_simple_cases.html.erb
@@ -1,7 +1,5 @@
 <% if cases.none? %>
-  <p class="govuk-body">
-    <%= I18n.t("support.case.list.not_found") %>
-  </p>
+  <%= render partial: "support/cases/not_found" %>
 <% else %>
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/app/views/support/cases/message_threads/_logged_contact_thread.html.erb
+++ b/app/views/support/cases/message_threads/_logged_contact_thread.html.erb
@@ -9,6 +9,9 @@
     <%= simple_distance_of_time_in_words(@current_case.logged_contacts_last_updated, Time.zone.now) %> ago
   </td>
   <td class="govuk-table__cell">
+    N/A
+  </td>
+  <td class="govuk-table__cell">
     <%= link_to I18n.t("support.case.label.message_threads.view"), logged_contacts_support_case_message_threads_path(back_to: Base64.encode64(@back_url)), class: "govuk-link" %>
   </td>
 </tr>

--- a/app/views/support/cases/message_threads/_logged_contact_thread.html.erb
+++ b/app/views/support/cases/message_threads/_logged_contact_thread.html.erb
@@ -6,7 +6,9 @@
     <%= I18n.t("support.case.label.message_threads.logged_contacts") %>
   </td>
   <td class="govuk-table__cell">
-    <%= simple_distance_of_time_in_words(@current_case.logged_contacts_last_updated, Time.zone.now) %> ago
+    <span title="<%= @current_case.logged_contacts_last_updated %>">
+      <%= relative_date_format(@current_case.logged_contacts_last_updated) %>
+    </span>
   </td>
   <td class="govuk-table__cell">
     N/A

--- a/app/views/support/cases/message_threads/_templated_message_thread.html.erb
+++ b/app/views/support/cases/message_threads/_templated_message_thread.html.erb
@@ -9,6 +9,9 @@
     <%= simple_distance_of_time_in_words(@current_case.templated_messages_last_updated, Time.zone.now) %> ago
   </td>
   <td class="govuk-table__cell">
+    N/A
+  </td>
+  <td class="govuk-table__cell">
     <%= link_to I18n.t("support.case.label.message_threads.view"), templated_messages_support_case_message_threads_path(back_to: Base64.encode64(@back_url)), class: "govuk-link" %>
   </td>
 </tr>

--- a/app/views/support/cases/message_threads/_templated_message_thread.html.erb
+++ b/app/views/support/cases/message_threads/_templated_message_thread.html.erb
@@ -6,7 +6,9 @@
     <%= I18n.t("support.case.label.message_threads.templated_messages") %>
   </td>
   <td class="govuk-table__cell">
-    <%= simple_distance_of_time_in_words(@current_case.templated_messages_last_updated, Time.zone.now) %> ago
+    <span title="<%= @current_case.templated_messages_last_updated %>">
+      <%= relative_date_format(@current_case.templated_messages_last_updated) %>
+    </span>
   </td>
   <td class="govuk-table__cell">
     N/A

--- a/app/views/support/cases/message_threads/_thread.html.erb
+++ b/app/views/support/cases/message_threads/_thread.html.erb
@@ -9,6 +9,9 @@
     <%= simple_distance_of_time_in_words(thread.last_updated, Time.zone.now) %> ago
   </td>
   <td class="govuk-table__cell">
+    <%= render "support/cases/emails/#{thread.unread_messages? ? "unread_badge" : "read_badge"}" %>
+  </td>
+  <td class="govuk-table__cell">
     <%= link_to I18n.t("support.case.label.message_threads.view"), support_case_message_thread_path(id: thread, back_to: Base64.encode64(@back_url)), class: "govuk-link" %>
   </td>
 </tr>

--- a/app/views/support/cases/message_threads/_thread.html.erb
+++ b/app/views/support/cases/message_threads/_thread.html.erb
@@ -6,7 +6,9 @@
     <%= thread.subject %>
   </td>
   <td class="govuk-table__cell">
-    <%= simple_distance_of_time_in_words(thread.last_updated, Time.zone.now) %> ago
+    <span title="<%= thread.last_updated %>">
+      <%= relative_date_format(thread.last_updated) %>
+    </span>
   </td>
   <td class="govuk-table__cell">
     <%= render "support/cases/emails/#{thread.unread_messages? ? "unread_badge" : "read_badge"}" %>

--- a/app/views/support/cases/message_threads/index.html.erb
+++ b/app/views/support/cases/message_threads/index.html.erb
@@ -7,6 +7,7 @@
         <th class="govuk-table__header name-column"><%= I18n.t("support.case.label.message_threads.recipients") %></th>
         <th class="govuk-table__header"><%= I18n.t("support.case.label.message_threads.subject") %></th>
         <th class="govuk-table__header date-column"><%= I18n.t("support.case.label.message_threads.last_update") %></th>
+        <th class="govuk-table__header date-column"><%= I18n.t("support.case.label.message_threads.status") %></th>
         <th class="govuk-table__header date-column"><%= I18n.t("support.case.label.message_threads.action") %></th>
       </tr>
     </thead>

--- a/app/views/support/cases/messages/replies/_form.html.erb
+++ b/app/views/support/cases/messages/replies/_form.html.erb
@@ -26,11 +26,6 @@
       "data-component" => "display-attachments",
       "data-display-attachments-id" => unique_id
     %>
-    <% if !reply %>
-      <button class="govuk-button govuk-button--secondary" data-module="govuk-button" data-component="display-cc-bcc" type="button">
-        <%= I18n.t("support.case.label.message_threads.new.hide_cc_bcc") %>
-      </button>
-    <% end %>
   </div>
 
   <div class="govuk-grid-row">

--- a/app/views/support/cases/messages/replies/_new_message_components.html.erb
+++ b/app/views/support/cases/messages/replies/_new_message_components.html.erb
@@ -17,10 +17,10 @@
           data-component="add-recipients"
           data-input-field=<%= "message_reply_form_#{unique_id}[to]" %>
           type="button">
-    <%= I18n.t("support.case.label.message_threads.new.add") %>
+    <%= I18n.t("support.case.label.message_threads.new.add_to") %>
   </button>
 </span>
-<div id="cc-and-bcc">
+<div id="cc" hidden="true">
   <span class="recipient-input-group">
     <%= form.govuk_text_field :cc,
           label: nil,
@@ -33,9 +33,12 @@
             data-component="add-recipients"
             data-input-field=<%= "message_reply_form_#{unique_id}[cc]" %>
             type="button">
-      <%= I18n.t("support.case.label.message_threads.new.add") %>
+      <%= I18n.t("support.case.label.message_threads.new.add_cc") %>
     </button>
   </span>
+</div>
+
+<div id="bcc" hidden="true">
   <span class="recipient-input-group">
     <%= form.govuk_text_field :bcc,
           label: nil,
@@ -48,9 +51,18 @@
             data-component="add-recipients"
             data-input-field=<%= "message_reply_form_#{unique_id}[bcc]" %>
             type="button">
-      <%= I18n.t("support.case.label.message_threads.new.add") %>
+      <%= I18n.t("support.case.label.message_threads.new.add_bcc") %>
     </button>
   </span>
+</div>
+
+<div class="govuk-button-group">
+  <button class="govuk-button govuk-button--secondary" data-module="govuk-button" data-component="display-cc" type="button">
+    <%= I18n.t("support.case.label.message_threads.new.show_cc") %>
+  </button>
+  <button class="govuk-button govuk-button--secondary" data-module="govuk-button" data-component="display-bcc" type="button">
+    <%= I18n.t("support.case.label.message_threads.new.show_bcc") %>
+  </button>
 </div>
 
 <div class="govuk-grid-row">

--- a/app/views/support/cases/searches/index.html.erb
+++ b/app/views/support/cases/searches/index.html.erb
@@ -21,9 +21,7 @@
                search_term: @form.search_term %>
 
     <% if @results.none? %>
-      <p class="govuk-body">
-        <%= I18n.t("support.case.list.not_found") %>
-      </p>
+      <%= render partial: "support/cases/not_found" %>
     <% else %>
       <table class="govuk-table">
         <thead class="govuk-table__head">

--- a/app/views/support/cases/show/_case_attachments.html.erb
+++ b/app/views/support/cases/show/_case_attachments.html.erb
@@ -17,14 +17,22 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__cell" scope="row"><%= link_to attachment.name, support_document_download_path(attachment, type: attachment.class), class: "govuk-link" %></th>
           <td class="govuk-table__cell"><%= attachment.description %></td>
-          <td class="govuk-table__cell"><%= simple_distance_of_time_in_words(attachment.created_at, Time.zone.now) %> ago</td>
+          <td class="govuk-table__cell">
+            <span title="<%= attachment.created_at.strftime("%d %B %Y %H:%M") %>">
+              <%= relative_date_format(attachment.created_at) %>
+            </span>
+          </td>
         </tr>
       <% end %>
       <% @current_case.energy_bills.each do |energy_bill| %>
         <tr class="govuk-table__row">
           <th class="govuk-table__cell" scope="row"><%= link_to energy_bill.filename, support_document_download_path(energy_bill, type: energy_bill.class), class: "govuk-link" %></th>
           <td class="govuk-table__cell"><%= I18n.t("support.case.label.attachments.table.energy_bill") %></td>
-          <td class="govuk-table__cell"><%= simple_distance_of_time_in_words(energy_bill.created_at, Time.zone.now) %> ago</td>
+          <td class="govuk-table__cell">
+            <span title="<%= energy_bill.created_at.strftime("%d %B %Y %H:%M") %>">
+              <%= relative_date_format(energy_bill.created_at) %>
+            </span>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -867,8 +867,12 @@ en:
         all_cases: All cases
         my_cases: My cases
         new_cases: New cases
-        not_found: No cases found
+        not_found: No cases found.
         tower: Tower
+        improve_results: "Improve your results by:"
+        improve_results_list:
+          - removing filters
+          - choosing different filters
       new:
         request_text:
           header: Description of query

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -744,12 +744,15 @@ en:
           last_update: Last update
           logged_contacts: Logged contacts
           new:
-            add: Add
+            add_to: "Add To: recipient"
+            add_cc: "Add Cc: recipient"
+            add_bcc: "Add Bcc: recipient"
             add_recipients: Add recipients to the email
             bcc: BCC
             cc: CC
             enter_subject: Enter an email subject
-            hide_cc_bcc: Hide CC / BCC
+            show_cc: Show CC
+            show_bcc: Show BCC
             press_enter_to_add_bcc: Press Enter to add recipients as BCC
             press_enter_to_add_cc: Press Enter to add recipients as CC
             press_enter_to_add_recipients: Press Enter to add recipients

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -743,6 +743,7 @@ en:
           back: Back to message list
           last_update: Last update
           logged_contacts: Logged contacts
+          status: Status
           new:
             add_to: "Add To: recipient"
             add_cc: "Add Cc: recipient"

--- a/spec/features/support/emails/agent_can_send_new_emails_spec.rb
+++ b/spec/features/support/emails/agent_can_send_new_emails_spec.rb
@@ -16,6 +16,8 @@ describe "Agent can send new emails", js: true do
   describe "creating a new thread", js: true do
     before do
       click_link "Create a new message thread"
+      click_on "Show CC"
+      click_on "Show BCC"
 
       to_input = find("input[name$='[to]']")
       to_input.fill_in with: "to@email.com"

--- a/spec/features/support/emails/agent_sees_email_threads_spec.rb
+++ b/spec/features/support/emails/agent_sees_email_threads_spec.rb
@@ -32,6 +32,11 @@ describe "Agent sees email threads", js: true, bullet: :skip do
       end
     end
 
+    it "displays the unread badge when a message is unread" do
+      within("tr", text: "Email thread 1") { expect(page).to have_css(".govuk-tag", text: "Unread") }
+      within("tr", text: "Email thread 2") { expect(page).to have_css(".govuk-tag", text: "Read") }
+    end
+
     describe "within a thread" do
       it "displays each message" do
         within "tr", text: "Email thread 2" do

--- a/spec/features/support/interactions/list_interactions_spec.rb
+++ b/spec/features/support/interactions/list_interactions_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Support request case history", bullet: :skip do
     it "displays request for support as first time in the case history" do
       within "#case-history #case-history-table tbody:last-child" do
         expect(page).to have_text "Request for support"
-        expect(page).to have_text "almost 2 years ago"
+        expect(page).to have_text "20 Mar 2021"
       end
     end
 

--- a/spec/helpers/self-serve/date_helper_spec.rb
+++ b/spec/helpers/self-serve/date_helper_spec.rb
@@ -52,4 +52,29 @@ RSpec.describe DateHelper, type: :helper do
       expect(helper.short_date_format("2023-01-20 02:13", always_show_year: true)).to eq "20 Jan 2023 02:13"
     end
   end
+
+  describe "#relative_date_format" do
+    before { travel_to Time.zone.local(2023, 3, 7, 0, 0) }
+    after { travel_back }
+
+    context "when the date is less than a year ago" do
+      it "calls simple_distance_of_time_in_words" do
+        allow(helper).to receive(:simple_distance_of_time_in_words).with(Time.zone.parse("2023-02-25 15:58"), Time.zone.now)
+
+        helper.relative_date_format("2023-02-25 15:58")
+
+        expect(helper).to have_received(:simple_distance_of_time_in_words).with(Time.zone.parse("2023-02-25 15:58"), Time.zone.now).once
+      end
+    end
+
+    context "when the date is more than a year ago" do
+      it "calls short_date_format" do
+        allow(helper).to receive(:short_date_format).with(Time.zone.parse("2022-02-25 15:58"), show_time: false)
+
+        helper.relative_date_format("2022-02-25 15:58")
+
+        expect(helper).to have_received(:short_date_format).with(Time.zone.parse("2022-02-25 15:58"), show_time: false).once
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
- renamed the add buttons in 'Create a new message thread' and split 'Show CC/BCC' into two
- added a read/unread status badge to the message threads view
- updated the text shown when there are no cases to display in case tabs and case search

## Included tickets
- PWNN-1184
- PWNN-1189
- PWNN-1162
- PWNN-1226