### PR TITLE
879 - Show message contacts

### DIFF
--- a/app/presenters/support/message_thread_presenter.rb
+++ b/app/presenters/support/message_thread_presenter.rb
@@ -41,6 +41,10 @@ module Support
       messages.any? { |message| message.can_mark_as_read? && !message.is_read? }
     end
 
+    def last_received_reply
+      Support::Messages::OutlookMessagePresenter.new(super) if super.present?
+    end
+
   private
 
     def date_format

--- a/app/presenters/support/messages/outlook_message_presenter.rb
+++ b/app/presenters/support/messages/outlook_message_presenter.rb
@@ -101,6 +101,12 @@ module Support
         view_context.render("support/cases/message_threads/outlook/details", message: self)
       end
 
+      def to_recipients = extract_recipient_addresses([sender] + super)
+
+      def cc_recipients = extract_recipient_addresses(super)
+
+      def bcc_recipients = extract_recipient_addresses(super)
+
     private
 
       def body_with_links_removed(_view_context, cleaned_body)
@@ -133,6 +139,12 @@ module Support
 
       def message_sent_at_date
         sent_at
+      end
+
+      def extract_recipient_addresses(recipients)
+        return if recipients.blank?
+
+        recipients.pluck("address").uniq.filter { |r| r != ENV["MS_GRAPH_SHARED_MAILBOX_ADDRESS"] }.join(", ")
       end
     end
   end

--- a/app/services/support/messages/outlook/message.rb
+++ b/app/services/support/messages/outlook/message.rb
@@ -26,9 +26,18 @@ module Support
           { address: from.email_address.address, name: from.email_address.name }
         end
 
-        def recipients
-          all_recipients = to_recipients + cc_recipients + bcc_recipients
-          all_recipients.map(&:email_address).map do |email_address|
+        def recipients = to_recipients + cc_recipients + bcc_recipients
+
+        def to_recipients = map_recipients(super)
+
+        def cc_recipients = map_recipients(super)
+
+        def bcc_recipients = map_recipients(super)
+
+      private
+
+        def map_recipients(recipients_to_map)
+          recipients_to_map.map(&:email_address).map do |email_address|
             { address: email_address.address, name: email_address.name }
           end
         end

--- a/app/services/support/messages/outlook/send_reply_to_email.rb
+++ b/app/services/support/messages/outlook/send_reply_to_email.rb
@@ -23,7 +23,7 @@ module Support
         attr_reader :ms_graph_client, :reply_to_email, :reply_text, :sender, :file_attachments
 
         def create_draft_reply
-          draft_reply = ms_graph_client.create_reply_message(
+          draft_reply = ms_graph_client.create_reply_all_message(
             user_id: SHARED_MAILBOX_USER_ID,
             reply_to_id: reply_to_email.outlook_id,
             http_headers: { "Prefer" => 'IdType="ImmutableId"' },

--- a/app/services/support/messages/outlook/synchronisation/steps/persist_email.rb
+++ b/app/services/support/messages/outlook/synchronisation/steps/persist_email.rb
@@ -20,6 +20,9 @@ module Support
                 outlook_is_read: message.is_read,
                 outlook_is_draft: message.is_draft,
                 in_reply_to_id: message.in_reply_to_id,
+                to_recipients: message.to_recipients,
+                cc_recipients: message.cc_recipients,
+                bcc_recipients: message.bcc_recipients,
               )
             end
           end

--- a/app/views/support/cases/message_threads/_recipient_table.html.erb
+++ b/app/views/support/cases/message_threads/_recipient_table.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <table id="recipient-table" class="govuk-table added_recipients_table">
+      <tbody class="govuk-table__body">
+        <%= render "recipients", recipients: email.to_recipients, recipient_type: "TO" %>
+        <%= render "recipients", recipients: email.cc_recipients, recipient_type: "CC" %>
+        <%= render "recipients", recipients: email.bcc_recipients, recipient_type: "BCC" %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/support/cases/message_threads/_recipients.html.erb
+++ b/app/views/support/cases/message_threads/_recipients.html.erb
@@ -1,0 +1,6 @@
+<% if recipients.present? %>
+  <tr class="govuk-table__row">
+    <th scope="row" class="govuk-table__header"><%= recipient_type %></th>
+    <td class="govuk-table__cell"><%= recipients %></td>
+  </tr>
+<% end %>

--- a/app/views/support/cases/message_threads/show.html.erb
+++ b/app/views/support/cases/message_threads/show.html.erb
@@ -13,6 +13,7 @@
         </span>
       </summary>
       <div class="govuk-details__text">
+        <%= render "recipient_table", email: @last_received_reply %>
         <%= render "support/cases/messages/replies/form", reply: true, email: @last_received_reply %>
       </div>
     </details>

--- a/db/migrate/20230309165049_add_to_cc_bcc_recipients_to_support_emails.rb
+++ b/db/migrate/20230309165049_add_to_cc_bcc_recipients_to_support_emails.rb
@@ -1,0 +1,9 @@
+class AddToCcBccRecipientsToSupportEmails < ActiveRecord::Migration[7.0]
+  def change
+    change_table :support_emails, bulk: true do |t|
+      t.column :to_recipients, :jsonb
+      t.column :cc_recipients, :jsonb
+      t.column :bcc_recipients, :jsonb
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -447,6 +447,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_15_085421) do
     t.string "outlook_internet_message_id"
     t.string "in_reply_to_id"
     t.text "unique_body"
+    t.jsonb "to_recipients"
+    t.jsonb "cc_recipients"
+    t.jsonb "bcc_recipients"
     t.index ["in_reply_to_id"], name: "index_support_emails_on_in_reply_to_id"
   end
 

--- a/lib/microsoft_graph/client.rb
+++ b/lib/microsoft_graph/client.rb
@@ -79,6 +79,12 @@ module MicrosoftGraph
       Transformer::UpdateMessage.transform(response, into: Resource::Message)
     end
 
+    # https://learn.microsoft.com/en-us/graph/api/message-createreplyall?view=graph-rest-1.0&tabs=http
+    def create_reply_all_message(user_id:, reply_to_id:, http_headers: {})
+      response = client_session.graph_api_post("users/#{user_id}/messages/#{reply_to_id}/createReplyAll", nil, http_headers)
+      Transformer::UpdateMessage.transform(response, into: Resource::Message)
+    end
+
     # https://docs.microsoft.com/en-us/graph/api/user-post-messages?view=graph-rest-1.0&tabs=http
     def create_message(user_id:, request_body: {}, http_headers: {})
       response = client_session.graph_api_post(

--- a/spec/factories/support/email.rb
+++ b/spec/factories/support/email.rb
@@ -5,6 +5,9 @@ FactoryBot.define do
     body { "<html><head></head><body><h1>My support request</h1><p>Please update my case</p></body></html>" }
     sender { { address: "sender1@email.com", name: "Sender 1" } }
     recipients { [{ address: "recipient1@email.com", name: "Recipient 1" }] }
+    to_recipients { [{ address: "to_recipient@email.com", name: "To Recipient" }] }
+    cc_recipients { [{ address: "cc_recipient@email.com", name: "CC Recipient" }] }
+    bcc_recipients { [{ address: "bcc_recipient@email.com", name: "BCC Recipient" }] }
     outlook_conversation_id { "MyString" }
     case_id { "" }
     sent_at { "2021-12-15 11:51:12" }

--- a/spec/features/support/emails/agent_can_send_replies_spec.rb
+++ b/spec/features/support/emails/agent_can_send_replies_spec.rb
@@ -35,11 +35,19 @@ describe "Agent can reply to incoming emails", js: true do
         within("#messages-frame") { click_link "View" }
 
         find("span", text: "Reply to message").click
-        fill_in_editor "Your message", with: "This is a test reply"
-        click_button "Send reply"
       end
 
-      it "shows the reply" do
+      it "shows the recipients" do
+        within("#recipient-table") do
+          expect(page).to have_text "CC"
+          expect(page).to have_text "sender1@email.com"
+        end
+      end
+
+      it "shows the sent reply" do
+        fill_in_editor "Your message", with: "This is a test reply"
+        click_button "Send reply"
+
         within("#messages") do
           expect(page).to have_text "Caseworker"
           expect(page).to have_text "This is a test reply"

--- a/spec/presenters/support/messages/outlook_message_presenter_spec.rb
+++ b/spec/presenters/support/messages/outlook_message_presenter_spec.rb
@@ -264,4 +264,34 @@ describe Support::Messages::OutlookMessagePresenter do
       end
     end
   end
+
+  describe "#cc_recipients" do
+    context "when there are no recipients" do
+      let(:email) { create(:support_email, cc_recipients: nil) }
+
+      it "returns nil" do
+        expect(presenter.cc_recipients).to be_nil
+      end
+    end
+
+    context "when there are recipients" do
+      let(:email) { create(:support_email, cc_recipients:) }
+      let(:cc_recipients) do
+        [
+          { "name" => "Test User 1", "address" => "test1@email.com" },
+          { "name" => "Test User 2", "address" => "test2@email.com" },
+          { "name" => "Test User 2", "address" => "test2@email.com" },
+          { "name" => "Shared Mailbox", "address" => "shared@mailbox.com" },
+        ]
+      end
+
+      around do |example|
+        ClimateControl.modify(MS_GRAPH_SHARED_MAILBOX_ADDRESS: "shared@mailbox.com") { example.run }
+      end
+
+      it "returns unique addresses without the shared mailbox" do
+        expect(presenter.cc_recipients).to eq "test1@email.com, test2@email.com"
+      end
+    end
+  end
 end

--- a/spec/services/support/messages/outlook/send_reply_to_email_spec.rb
+++ b/spec/services/support/messages/outlook/send_reply_to_email_spec.rb
@@ -18,13 +18,13 @@ describe Support::Messages::Outlook::SendReplyToEmail do
   let(:attachment1)                   { double("attachment1") }
   let(:attachment2)                   { double("attachment2") }
 
-  let(:create_reply_message_repsonse) { double("create_reply_message_repsonse", id: "DRAFT-OUTLOOK-ID", internet_message_id: "IMID1", body: double(content: "Previous content here")) }
+  let(:create_reply_all_message_repsonse) { double("create_reply_all_message_repsonse", id: "DRAFT-OUTLOOK-ID", internet_message_id: "IMID1", body: double(content: "Previous content here")) }
   let(:update_message_response)       { double("update_message_response", id: "DRAFT-OUTLOOK-ID", internet_message_id: "IMID1", body: double(content: "My Reply - Previous content here")) }
   let(:send_message_response)         { nil }
   let(:get_message_response)          { double("get_message_response", id: "DRAFT-OUTLOOK-ID", internet_message_id: "IMID1", body: double(content: "My Reply - Previous content here")) }
 
   before do
-    allow(ms_graph_client).to receive(:create_reply_message).and_return(create_reply_message_repsonse)
+    allow(ms_graph_client).to receive(:create_reply_all_message).and_return(create_reply_all_message_repsonse)
     allow(ms_graph_client).to receive(:update_message).and_return(update_message_response)
     allow(ms_graph_client).to receive(:send_message).and_return(send_message_response)
     allow(ms_graph_client).to receive(:get_message).and_return(get_message_response)
@@ -36,7 +36,7 @@ describe Support::Messages::Outlook::SendReplyToEmail do
   it "creates a draft message in outlook" do
     send_reply.call
 
-    expect(ms_graph_client).to have_received(:create_reply_message)
+    expect(ms_graph_client).to have_received(:create_reply_all_message)
       .with(
         user_id: SHARED_MAILBOX_USER_ID,
         reply_to_id: "REPLY-OUTLOOK-ID",

--- a/spec/services/support/messages/outlook/synchronisation/steps/persist_email_spec.rb
+++ b/spec/services/support/messages/outlook/synchronisation/steps/persist_email_spec.rb
@@ -20,6 +20,9 @@ describe Support::Messages::Outlook::Synchronisation::Steps::PersistEmail do
       has_attachments: true,
       case_reference_from_headers: "000888",
       in_reply_to_id: "IMID-2",
+      to_recipients: [{ name: "To Recipient", address: "to_recipient@email.com" }],
+      cc_recipients: [{ name: "CC Recipient 1", address: "cc_recipient1@email.com" }, { name: "CC Recipient 2", address: "cc_recipient2@email.com" }],
+      bcc_recipients: [{ name: "BCC Recipient", address: "bcc_recipient@email.com" }],
     )
   end
 
@@ -41,6 +44,9 @@ describe Support::Messages::Outlook::Synchronisation::Steps::PersistEmail do
     expect(email.in_reply_to_id).to eq("IMID-2")
     expect(email.body).to eq("Unique Body, Reply Body")
     expect(email.unique_body).to eq("Unique Body")
+    expect(email.to_recipients).to eq([{ "name" => "To Recipient", "address" => "to_recipient@email.com" }])
+    expect(email.cc_recipients).to eq([{ "name" => "CC Recipient 1", "address" => "cc_recipient1@email.com" }, { "name" => "CC Recipient 2", "address" => "cc_recipient2@email.com" }])
+    expect(email.bcc_recipients).to eq([{ "name" => "BCC Recipient", "address" => "bcc_recipient@email.com" }])
   end
 
   context "when message is coming from the inbox mail folder" do


### PR DESCRIPTION
## Changes in this PR
- The message reply details now shows the To, CC and BCC recipients
- The columns for the different types of recipients have been added to support_emails
- Sending a reply now calls "createReplyAll" on the MS Graph API

Jira: PWNN-879

## Post-merge actions
- [ ] Run `rake data_migrations:backfill_email_recipients` in staging
- [ ] Run `rake data_migrations:backfill_email_recipients` in production