### PR TITLE
1279, 1295 - show agent initials on latest note, new email signature

### DIFF
--- a/app/models/support/agent.rb
+++ b/app/models/support/agent.rb
@@ -26,5 +26,7 @@ module Support
     }
 
     def full_name = "#{first_name} #{last_name}"
+
+    def initials = "#{first_name.first}#{last_name.first}"
   end
 end

--- a/app/presenters/support/case_presenter.rb
+++ b/app/presenters/support/case_presenter.rb
@@ -188,6 +188,10 @@ module Support
       last_case_note.created_at.strftime("%d %b %y")
     end
 
+    def last_case_note_author
+      last_case_note.agent
+    end
+
     def value
       return I18n.t("support.case.label.value.unspecified") unless super
 

--- a/app/views/support/cases/index/_detailed_case.html.erb
+++ b/app/views/support/cases/index/_detailed_case.html.erb
@@ -33,7 +33,7 @@
 <tr class="govuk-table__row tower-bottom-row">
   <td class="govuk-table__cell tower-note" colspan="7">
     <% if kase.last_case_note.present? %>
-      <span><%= simple_format("Note: #{kase.last_case_note_date} - " + kase.last_case_note_body) %></span>
+      <span><%= simple_format("Note: #{kase.last_case_note_date} #{kase.last_case_note_author&.initials} - " + kase.last_case_note_body) %></span>
     <% end %>
   </td>
 </tr>

--- a/app/views/support/cases/messages/_reply_form_template.html.erb
+++ b/app/views/support/cases/messages/_reply_form_template.html.erb
@@ -1,7 +1,13 @@
-<p>Type your message here</p>
+<br />
 <p>
 Regards<br />
 <%= current_agent.full_name %><br />
 Procurement Specialist<br />
 Get help buying for schools<br />
+</p>
+
+<p>
+Please reply to this email within 15 working days or by the date we agreed.<br />
+We'll need to adjust any timelines we've given you if you're not able to reply on time.<br />
+We'll close the case if we don't hear back from you. You can reopen the case at any time by replying to this email.<br />
 </p>

--- a/spec/models/support/agent_spec.rb
+++ b/spec/models/support/agent_spec.rb
@@ -47,4 +47,12 @@ RSpec.describe Support::Agent, type: :model do
       expect(agents[1].last_name).to eq "Gelon"
     end
   end
+
+  describe "#initials" do
+    subject(:agent) { create(:support_agent, first_name: "Sidney", last_name: "Prescott") }
+
+    it "returns the agent's initials" do
+      expect(agent.initials).to eq("SP")
+    end
+  end
 end


### PR DESCRIPTION
## Changes in this PR
- the initials of the agent who wrote the latest case note are now shown
- the email signature has been updated

Jira: PWNN-1279, PWNN-1295