### PR TITLE
1334: Email address visibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -614,6 +614,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/app/presenters/support/message_thread_presenter.rb
+++ b/app/presenters/support/message_thread_presenter.rb
@@ -3,10 +3,10 @@ module Support
     # The recipients for all emails in a thread combined into one array
     #
     # @return [String]
-    def recipients
+    def recipient_names
       # group by email address in case there are multiple recipients with the same address
       # and prefer the one that has a proper name (rather than an email address for a name)
-      grouped = Array(super)
+      grouped = Array(recipients)
         .group_by { |r| r["address"].downcase }
         .map { |_k, v|
           if v.size > 1
@@ -18,6 +18,18 @@ module Support
       resolve_name_from_case(grouped)
       # remove the shared mailbox name
       grouped.pluck("name").filter { |name| name != ENV["MS_GRAPH_SHARED_MAILBOX_NAME"] }.join(", ")
+    end
+
+    def recipient_emails
+      emails = Array(recipients)
+        .group_by { |r| r["address"].downcase }
+        .map { |_k, v| v }.flatten
+
+      emails
+        .pluck("address")
+        .filter { |address| address != ENV["MS_GRAPH_SHARED_MAILBOX_ADDRESS"] }
+        .uniq
+        .join(", ")
     end
 
     # @return [String]

--- a/app/presenters/support/messages/outlook_message_presenter.rb
+++ b/app/presenters/support/messages/outlook_message_presenter.rb
@@ -107,6 +107,12 @@ module Support
 
       def bcc_recipients = extract_recipient_addresses(super)
 
+      def recipient_addresses
+        return if recipients.blank?
+
+        recipients.pluck("address").uniq.join(", ")
+      end
+
     private
 
       def body_with_links_removed(_view_context, cleaned_body)

--- a/app/views/support/cases/message_threads/_message.erb
+++ b/app/views/support/cases/message_threads/_message.erb
@@ -1,9 +1,10 @@
 <% truncated_message = defined?(truncated_message) ? truncated_message : false %>
+<% has_recipients = defined?(message.recipients) %>
 
 <div id="<%= dom_id(message) %>" class="message">
   <div class="message-details">
     <div>
-      <%= message.sent_by_name %>
+      From: <%= message.sent_by_name %>
       <%= message.render_actions(self) %>
       <%= message.render_details(self) %>
     </div>
@@ -11,6 +12,7 @@
     <div><%= message.sent_at_formatted %></div>
   </div>
 
+  <% if has_recipients %>
   <details class="govuk-details govuk-!-margin-top-0 govuk-!-margin-bottom-1" data-module="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
@@ -23,6 +25,7 @@
       <div>CC: <%= message.cc_recipients || "none" %></div>
     </div>
   </details>
+  <% end %>
 
   <div <% if truncated_message %>class="message-preview govuk-body truncated-view" data-component="toggle-truncate"<% else %>class="message-preview govuk-body"<% end %>>
     <% if truncated_message %>

--- a/app/views/support/cases/message_threads/_message.erb
+++ b/app/views/support/cases/message_threads/_message.erb
@@ -11,6 +11,19 @@
     <div><%= message.sent_at_formatted %></div>
   </div>
 
+  <details class="govuk-details govuk-!-margin-top-0 govuk-!-margin-bottom-1" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Display recipients
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <div>From: <%= message.sent_by_email %></div>
+      <div>To: <%= message.recipient_addresses || "none" %></div>
+      <div>CC: <%= message.cc_recipients || "none" %></div>
+    </div>
+  </details>
+
   <div <% if truncated_message %>class="message-preview govuk-body truncated-view" data-component="toggle-truncate"<% else %>class="message-preview govuk-body"<% end %>>
     <% if truncated_message %>
       <div class="truncated">

--- a/app/views/support/cases/message_threads/_thread.html.erb
+++ b/app/views/support/cases/message_threads/_thread.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row <%= thread.unread_messages? ? "unread-thread" : "" %>">
   <td class="govuk-table__cell">
-    <%= thread.recipients %>
+    <%= thread.recipient_emails %>
   </td>
   <td class="govuk-table__cell">
     <%= thread.subject %>

--- a/spec/features/support/emails/agent_sees_email_threads_spec.rb
+++ b/spec/features/support/emails/agent_sees_email_threads_spec.rb
@@ -18,10 +18,10 @@ describe "Agent sees email threads", js: true, bullet: :skip do
 
     it "displays each thread within the case messages tab" do
       within "tr", text: "Email thread 1" do
-        expect(page).to have_content("Test 1")
+        expect(page).to have_content("test1@email.com")
       end
       within "tr", text: "Email thread 2" do
-        expect(page).to have_content("Test 2")
+        expect(page).to have_content("test2@email.com")
       end
     end
 

--- a/spec/presenters/support/message_thread_presenter_spec.rb
+++ b/spec/presenters/support/message_thread_presenter_spec.rb
@@ -11,7 +11,7 @@ describe Support::MessageThreadPresenter do
 
   let(:thread) { Support::MessageThread.find_by(conversation_id: "MyString") }
 
-  describe "#recipients" do
+  describe "#recipient_names" do
     around do |example|
       ClimateControl.modify(MS_GRAPH_SHARED_MAILBOX_NAME: "sharedMailbox") do
         example.run
@@ -19,7 +19,19 @@ describe Support::MessageThreadPresenter do
     end
 
     it "lists all the recipients except for the shared mailbox" do
-      expect(presenter.recipients).to eq "recipient 1, School Contact"
+      expect(presenter.recipient_names).to eq "recipient 1, School Contact"
+    end
+  end
+
+  describe "#recipient_emails" do
+    around do |example|
+      ClimateControl.modify(MS_GRAPH_SHARED_MAILBOX_ADDRESS: "sharedMailbox@email.com") do
+        example.run
+      end
+    end
+
+    it "lists all the recipient emails except for the shared mailbox address" do
+      expect(presenter.recipient_emails).to eq "recipient1@email.com, school@email.co.uk"
     end
   end
 


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

<!--
  Succinct list of changes explaining what has changed and why.
-->

- Message list Recipients column now displays email addresses, rather than names
- Each message in a thread has a 'From:' prefix to the sender name in the details row
- Each message in a thread has an expandable 'Display recipients' that shows the email addresses for the `from`, `to`, and `CC` fields.

## Screen-shots or screen-capture of UI changes

(Screenshots attached to story ticket)
<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
