### PR TITLE
Retain layout for notes and logged contacts.

### DIFF
--- a/app/assets/stylesheets/base/_frontend.scss
+++ b/app/assets/stylesheets/base/_frontend.scss
@@ -3,3 +3,13 @@ $govuk-images-path: "/assets/images/";
 $govuk-fonts-path: "/assets/fonts/";
 
 @import "govuk-frontend/govuk/all";
+
+.govuk-table__row.borderless .govuk-table__cell,
+.borderless {
+   border: 0 !important;
+}
+
+td.govuk-table__cell :first-child {
+   margin-top: 0;
+ }
+ 

--- a/app/views/support/cases/case_history/_interaction.html.erb
+++ b/app/views/support/cases/case_history/_interaction.html.erb
@@ -7,8 +7,9 @@
     <% if interaction.custom_template.present? %>
       <%= render "support/cases/case_history/#{interaction.custom_template}", interaction: interaction %>
     <% else %>
-      <%= interaction.body %>
+      <%= simple_format interaction.body %>
 
+      <% if interaction.additional_data.any? %>
       <dl class="govuk-summary-list">
         <% interaction.additional_data.each do |key, value|  %>
           <div class="govuk-summary-list__row">
@@ -21,6 +22,7 @@
           </div>
         <% end %>
       </dl>
+      <% end %>
     <% end %>
   </td>
 

--- a/app/views/support/cases/message_threads/_message.erb
+++ b/app/views/support/cases/message_threads/_message.erb
@@ -35,7 +35,7 @@
     <% end %>
 
     <div class="full-view <% if truncated_message %>govuk-!-display-none<% end %>">
-      <%= message.body_for_display(self) %>
+      <%= simple_format message.body_for_display(self) %>
 
       <%= render "support/cases/messages/attachments", email: message %>
 


### PR DESCRIPTION
## Changes in this PR

- The layout of notes and logged contacts is now preserved, rather than collapsed to a single line.
