### PR TITLE
1413 - ci: add pg_trgm to postgres extensions

### DIFF
--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -67,6 +67,7 @@ variable "postgres_json_params" {
     enable_extensions = [
       "pgcrypto",
       "plpgsql",
+      "pg_trgm",
     ]
   }
   type = map(any)


### PR DESCRIPTION
## Changes in this PR
- add `pg_trgm` to enabled PostgreSQL extensions in Terraform

Jira: PWNN-1413