### PR TITLE
1527 - fix(rfh): fix missing category mappings

### DIFF
--- a/config/request_for_help/categories.yml
+++ b/config/request_for_help/categories.yml
@@ -82,7 +82,7 @@ categories:
         support_category: Passenger transport
       - title: Vehicle hire or purchase
         slug: vehicle-hire-or-purchase
-        support_category: Vehicle hire or purchase
+        support_category: Vehicle hire & purchase
       - title: Other
         slug: other
         support_category: Other (BS)

--- a/config/support/categories.yml
+++ b/config/support/categories.yml
@@ -21,10 +21,8 @@ categories:
         slug: displays
       - title: Broadband Infrastructure
         slug: broadband_infrastructure
-        is_archived: true
       - title: Broadband service
         slug: broadband_service
-        is_archived: true
       - title: Cloud SaaS
         slug: cloud_saas
       - title: Curriculum Content

--- a/spec/services/support/seed_categories_spec.rb
+++ b/spec/services/support/seed_categories_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe Support::SeedCategories do
 
   it "saves archived status of categories" do
     service.call
-    expect(Support::Category.find_by(title: "Broadband service")).to be_archived
-    expect(Support::Category.find_by(title: "Broadband Infrastructure")).to be_archived
     expect(Support::Category.find_by(title: "Switches & Routers")).not_to be_archived
   end
 


### PR DESCRIPTION
## Changes in this PR
- fix mapping to "Vehicle hire or purchase" category form RFH to CMS by fixing typo
- fix mappings to "Broadband service" and "Broadband infrastructure" categories form RFH to CMS by un-archiving corresponding categories in CMS

Jira: PWNN-1527

## Post-deploy actions
- [ ] Run `case_management:seed_categories`
- [ ] Run `request_for_help:seed_categories`