### PR TITLE
fix: app insights ignore cable 404s

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -138,8 +138,8 @@ Rails.application.configure do
   # Application insights
   application_insights_key = ENV["ApplicationInsights__InstrumentationKey"]
   if application_insights_key.present?
-    require "application_insights"
-    config.middleware.use ApplicationInsights::Rack::TrackRequest, application_insights_key
+    require "middleware/application_insights_track_request_conditionally"
+    config.middleware.use ApplicationInsightsTrackRequestConditionally, instrumentation_key: application_insights_key, ignore_paths: ["/cable"]
     # send unhandled exceptions
     ApplicationInsights::UnhandledException.collect(application_insights_key)
   end

--- a/lib/middleware/application_insights_track_request_conditionally.rb
+++ b/lib/middleware/application_insights_track_request_conditionally.rb
@@ -1,0 +1,19 @@
+require "application_insights"
+
+class ApplicationInsightsTrackRequestConditionally
+  def initialize(app, instrumentation_key:, ignore_paths: [])
+    @app = app
+    @instrumentation_key = instrumentation_key
+    @ignore_paths = ignore_paths
+    @application_insights = ApplicationInsights::Rack::TrackRequest.new(app, instrumentation_key)
+  end
+
+  def call(env)
+    request = ::Rack::Request.new env
+    if request.path.in?(@ignore_paths)
+      @app.call(env)
+    else
+      @application_insights.call(env)
+    end
+  end
+end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

As azure front door does not currently support websockets, action cable will fail it's initial request. 
This is a temporary fix to stop these 404s polluting our app insights dashboards as failures.