### PR TITLE
1491 - fix(cms): fix formatting of text with whitespace

### DIFF
--- a/app/presenters/support/messages/notify_message_presenter.rb
+++ b/app/presenters/support/messages/notify_message_presenter.rb
@@ -1,6 +1,8 @@
 module Support
   module Messages
     class NotifyMessagePresenter < ::Support::MessagePresenter
+      include ActionView::Helpers::TextHelper
+
       def sent_by_email
         "Email"
       end
@@ -10,7 +12,7 @@ module Support
       end
 
       def body_for_display(_)
-        body.html_safe
+        simple_format(body.html_safe, class: "govuk-body")
       end
 
       def truncated_body_for_display(_view_context)

--- a/app/views/engagement/cases/previews/new.html.erb
+++ b/app/views/engagement/cases/previews/new.html.erb
@@ -189,7 +189,7 @@
             <%= I18n.t("support.case_hub_migration.label.request_text") %>
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= @form.request_text %>
+            <%= simple_format(@form.request_text, class: "govuk-body") %>
           </dd>
           <dd id="changeRequestText" class="govuk-summary-list__list__actions">
             <%= form.button I18n.t("generic.button.change_answer"), class: "govuk-link", value: "change" %>

--- a/app/views/support/cases/message_threads/_message.erb
+++ b/app/views/support/cases/message_threads/_message.erb
@@ -41,7 +41,7 @@
     <% end %>
 
     <div class="full-view <% if truncated_message %>govuk-!-display-none<% end %>">
-      <%= simple_format message.body_for_display(self) %>
+      <%= message.body_for_display(self) %>
 
       <%= render "support/cases/messages/attachments", email: message %>
 

--- a/app/views/support/cases/previews/new.html.erb
+++ b/app/views/support/cases/previews/new.html.erb
@@ -192,7 +192,7 @@
             <%= I18n.t("support.case_hub_migration.label.request_text") %>
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= @form.request_text %>
+            <%= simple_format(@form.request_text, class: "govuk-body") %>
           </dd>
           <dd id="changeRequestText" class="govuk-summary-list__list__actions">
             <%= form.button I18n.t("generic.button.change_answer"), class: "govuk-link", value: "change" %>

--- a/app/views/support/cases/show/_case_details.html.erb
+++ b/app/views/support/cases/show/_case_details.html.erb
@@ -141,7 +141,7 @@
           <%= I18n.t("support.case.label.problem_description") %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= current_case.request_text %>
+          <%= simple_format(current_case.request_text, class: "govuk-body") %>
         </dd>
         <dd class="govuk-summary-list__actions"></dd>
       </div>


### PR DESCRIPTION
## Changes in this PR
- fixed excessive whitespace in message bodies by removing `simple_format`
- added `simple_format` to bodies of non-messages to retain intended whitespace

Jira: PWNN-1491