### PR TITLE
1639 feat(rfh): add validation to the email form to exclude certain addresses

### DIFF
--- a/app/forms/framework_requests/email_form.rb
+++ b/app/forms/framework_requests/email_form.rb
@@ -1,12 +1,40 @@
 module FrameworkRequests
   class EmailForm < BaseForm
     validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+    validate :email_is_not_personal
 
     attr_accessor :email
 
     def initialize(attributes = {})
       super
       @email ||= framework_request.email
+    end
+
+    def email_is_not_personal
+      return unless email
+      return if email.downcase.include?("@sky.learning.mat")
+
+      invalid_emails = ["@gmail.",
+                        "@yahoo.",
+                        "@aol.",
+                        "@hotmail.",
+                        "@mail.",
+                        "@outlook.",
+                        "@icloud.",
+                        "@lycos.",
+                        "@sky.",
+                        "@btinternet",
+                        "@talktalk",
+                        "@virginmedia",
+                        "@plus.net",
+                        "@btopenworld",
+                        "@talk21",
+                        "@live"]
+      found_invalid_domain = invalid_emails.find { |i| email.downcase.include?(i) }
+      if found_invalid_domain.present?
+        _, domain = email.split("@")
+        errors.add(:email, I18n.t("support_request.errors.rules.email.invalid", domain: "@#{domain}"))
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -408,7 +408,7 @@ en:
         no_dsi: No, continue without a DfE Sign-in account
       subtitle: About your school
     email:
-      hint: We will only use this to contact you about your request.
+      hint: Use your school email address. We will only use this to contact you about your request.
       subtitle: About you
       title: What is your email address?
     energy_alternative:

--- a/config/locales/validation/en.yml
+++ b/config/locales/validation/en.yml
@@ -109,6 +109,8 @@ en:
 
     errors:
       rules:
+        email:
+          invalid: Enter a school email address in the correct format, like name@example.sch.uk. You cannot use a personal email address such as %{domain}
         phone_number:
           missing: is missing
           # rules as follows; (i) permits empty string for no entry, (ii) 0 followed by 9 or 10 digits, OR +44 followed by 9 or 10 digits, with the digit immediately following one of [12378] (iii) no spaces at any point in the number

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -181,7 +181,7 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
         expect(page).to have_text "About you"
         expect(page).to have_text "What is your email address?"
 
-        expect(page).to have_text "We will only use this to contact you about your request."
+        expect(page).to have_text "Use your school email address. We will only use this to contact you about your request."
 
         expect(page).to have_button "Continue"
       end
@@ -191,6 +191,39 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
 
         expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
         expect(page).to have_link "Enter an email address", href: "#framework-support-form-email-field-error"
+      end
+
+      it "doesn't allow non-school email addresses" do
+        fill_in "framework_support_form[email]", with: "test@gmail.com"
+        click_continue
+
+        expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
+        expect(page).to have_link "Enter a school email address in the correct format, like name@example.sch.uk. You cannot use a personal email address such as @gmail.com", href: "#framework-support-form-email-field-error"
+
+        fill_in "framework_support_form[email]", with: "test@Gmail.com"
+        click_continue
+
+        expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
+        expect(page).to have_link "Enter a school email address in the correct format, like name@example.sch.uk. You cannot use a personal email address such as @Gmail.com", href: "#framework-support-form-email-field-error"
+
+        fill_in "framework_support_form[email]", with: "test@sky.example"
+        click_continue
+
+        expect(find("h2.govuk-error-summary__title")).to have_text "There is a problem"
+        expect(page).to have_link "Enter a school email address in the correct format, like name@example.sch.uk. You cannot use a personal email address such as @sky.example", href: "#framework-support-form-email-field-error"
+      end
+
+      it "allows school email addresses" do
+        fill_in "framework_support_form[email]", with: "test@sky.learning.mat"
+        click_continue
+
+        expect(page).to have_text "How can we help?"
+
+        click_link "Back"
+        fill_in "framework_support_form[email]", with: "test@sch.uk"
+        click_continue
+
+        expect(page).to have_text "How can we help?"
       end
     end
 

--- a/spec/forms/framework_requests/email_form_spec.rb
+++ b/spec/forms/framework_requests/email_form_spec.rb
@@ -25,6 +25,34 @@ describe FrameworkRequests::EmailForm, type: :model do
           expect(form.errors.messages[:email]).to eq ["Enter an email in the correct format. For example, 'someone@school.sch.uk'."]
         end
       end
+
+      context "when using a personal email" do
+        invalid_emails = ["@gmail.",
+                          "@yahoo.",
+                          "@aol.",
+                          "@hotmail.",
+                          "@mail.",
+                          "@outlook.",
+                          "@icloud.",
+                          "@lycos.",
+                          "@sky.",
+                          "@btinternet",
+                          "@talktalk",
+                          "@virginmedia",
+                          "@plus.net",
+                          "@btopenworld",
+                          "@talk21",
+                          "@live"]
+
+        invalid_emails.each do |personal_email_domain|
+          it "gives an error message for #{personal_email_domain}" do
+            framework_request = create(:framework_request, email: "invalid_email#{personal_email_domain}")
+            form = described_class.new(id: framework_request.id)
+            expect(form).not_to be_valid
+            expect(form.errors.messages[:email]).to include("Enter a school email address in the correct format, like name@example.sch.uk. You cannot use a personal email address such as #{personal_email_domain}")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Added validation to exclude personal email addresses when filling out the request for help form when signing in as a guest
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
<img width="680" alt="Screenshot 2023-09-22 at 11 53 48" src="https://github.com/DFE-Digital/buy-for-your-school/assets/77166906/2dc6ea27-7d81-4d80-a79d-1d93b3d829e3">

  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
