### PR TITLE
1683 - feat(cms): change case origin options

### DIFF
--- a/app/models/support/case.rb
+++ b/app/models/support/case.rb
@@ -85,13 +85,14 @@ module Support
     #
     #   used_before         - I've used this service before
     #   meeting_or_event    - Meeting or event
-    #   newsletter          - Newsletter
+    #   dfe_publication     - DfE publication (e.g. ESFA update, SBP update, Sector Bulletin)
+    #   non_dfe_publication - Non-DfE newsletter
     #   recommendation      - Recommendation
     #   search_engine       - Search engine, such as Google
-    #   social_media        - Social media, such as Twitter
+    #   social_media        - Social media, such as LinkedIn, Facebook, X (formerly Twitter)
     #   website             - Website, such as GOV.UK
     #   other               - Other
-    enum discovery_method: { used_before: 0, meeting_or_event: 1, newsletter: 2, recommendation: 3, search_engine: 4, social_media: 5, website: 6, other: 7 }
+    enum discovery_method: { used_before: 0, meeting_or_event: 1, dfe_publication: 2, non_dfe_publication: 3, recommendation: 4, search_engine: 5, social_media: 6, website: 7, other: 8 }
 
     # Creation Source
     #

--- a/app/views/support/cases/discovery_method/_discovery_method.html.erb
+++ b/app/views/support/cases/discovery_method/_discovery_method.html.erb
@@ -2,16 +2,17 @@
 
 		<%= form.govuk_radio_button :discovery_method, '0', label: { text: I18n.t("support.case.label.discovery_method.used_before") }, link_errors: true %>
 		<%= form.govuk_radio_button :discovery_method, '1', label: { text: I18n.t("support.case.label.discovery_method.meeting_or_event") } %>
-		<%= form.govuk_radio_button :discovery_method, '2', label: { text: I18n.t("support.case.label.discovery_method.newsletter") } %>
-		<%= form.govuk_radio_button :discovery_method, '3', label: { text: I18n.t("support.case.label.discovery_method.recommendation") } %>
-		<%= form.govuk_radio_button :discovery_method, '4', label: { text: I18n.t("support.case.label.discovery_method.search_engine") } %>
-		<%= form.govuk_radio_button :discovery_method, '5', label: { text: I18n.t("support.case.label.discovery_method.social_media") } %>
-		<%= form.govuk_radio_button :discovery_method, '6', label: { text: I18n.t("support.case.label.discovery_method.website") } %>
-		<%= form.govuk_radio_button :discovery_method, '7', label: { text: I18n.t("support.case.label.discovery_method.other") } do %>
+		<%= form.govuk_radio_button :discovery_method, '2', label: { text: I18n.t("support.case.label.discovery_method.dfe_publication") } %>
+		<%= form.govuk_radio_button :discovery_method, '3', label: { text: I18n.t("support.case.label.discovery_method.non_dfe_publication") } %>
+		<%= form.govuk_radio_button :discovery_method, '4', label: { text: I18n.t("support.case.label.discovery_method.recommendation") } %>
+		<%= form.govuk_radio_button :discovery_method, '5', label: { text: I18n.t("support.case.label.discovery_method.search_engine") } %>
+		<%= form.govuk_radio_button :discovery_method, '6', label: { text: I18n.t("support.case.label.discovery_method.social_media") } %>
+		<%= form.govuk_radio_button :discovery_method, '7', label: { text: I18n.t("support.case.label.discovery_method.website") } %>
+		<%= form.govuk_radio_button :discovery_method, '8', label: { text: I18n.t("support.case.label.discovery_method.other") } do %>
 			<%= form.govuk_text_field :discovery_method_other_text,
 						id: "discovery_method_other_text",
 						label: { text: I18n.t("support.case.label.discovery_method.other_text_field") },
 						link_errors: true
 			%>
-		<% end %>		
+		<% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -962,10 +962,11 @@ en:
           other_text_field: Please specify origin
           used_before: Used this service before
           meeting_or_event: Meeting or event
-          newsletter: Newsletter
+          dfe_publication: DfE publication (e.g. ESFA update, SBP update, Sector Bulletin)
+          non_dfe_publication: Non-DfE newsletter
           recommendation: Recommendation
           search_engine: Search engine, such as Google
-          social_media: Social media, such as Twitter
+          social_media: Social media, such as LinkedIn, Facebook, X (formerly Twitter)
           website: Website, such as GOV.UK
           other: Other
         special_requirements: Accessibility

--- a/spec/features/engagement/create_case_spec.rb
+++ b/spec/features/engagement/create_case_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature "Create case", js: true do
     fill_in "create_case_form[last_name]", with: "last_name"
     fill_in "create_case_form[email]", with: "test@example.com"
     fill_in "create_case_form[phone_number]", with: "0778974653"
-    choose "Newsletter" # case origin
+    choose "Non-DfE newsletter" # case origin
     choose "Procurement" # request type
     select "Other (General)", from: "select_request_details_category_id"
     find("#request_details_other_category_text").set("Other Category Details")

--- a/spec/features/support/case_summary_spec.rb
+++ b/spec/features/support/case_summary_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Case summary details" do
   end
 
   context "when value and support levels have been populated" do
-    let(:support_case) { create(:support_case, :with_fixed_category, :opened, value: 123.32, support_level: "L2", source: :incoming_email, discovery_method: :newsletter) }
+    let(:support_case) { create(:support_case, :with_fixed_category, :opened, value: 123.32, support_level: "L2", source: :incoming_email, discovery_method: :non_dfe_publication) }
 
     it "shows fields with details" do
       within("div#case-details") do
@@ -37,7 +37,7 @@ RSpec.feature "Case summary details" do
         expect(all("dt.govuk-summary-list__key")[2]).to have_text "Case value"
         expect(all("dd.govuk-summary-list__value")[2]).to have_text "£123.32"
         expect(all("dt.govuk-summary-list__key")[3]).to have_text "Origin"
-        expect(all("dd.govuk-summary-list__value")[3]).to have_text "Newsletter"
+        expect(all("dd.govuk-summary-list__value")[3]).to have_text "Non-DfE newsletter"
         expect(all("dt.govuk-summary-list__key")[4]).to have_text "Source"
         expect(all("dd.govuk-summary-list__value")[4]).to have_text "Email"
       end

--- a/spec/features/support/create_case_spec.rb
+++ b/spec/features/support/create_case_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Create case", js: true do
     fill_in "create_case_form[last_name]", with: "last_name"
     fill_in "create_case_form[email]", with: "test@example.com"
     fill_in "create_case_form[phone_number]", with: "0778974653"
-    choose "Newsletter" # case origin
+    choose "Non-DfE newsletter" # case origin
     choose "Procurement" # request type
     select "Other (General)", from: "select_request_details_category_id"
     find("#request_details_other_category_text").set("Other Category Details")


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Definition of discovery_methods changed to:

    # Discovery Method
    #
    #   used_before         - I've used this service before
    #   meeting_or_event    - Meeting or event
    #   dfe_publication     - DfE publication (e.g. ESFA update, SBP update, Sector Bulletin)
    #   non_dfe_publication - Non-DfE newsletter
    #   recommendation      - Recommendation
    #   search_engine       - Search engine, such as Google
    #   social_media        - Social media, such as LinkedIn, Facebook, X (formerly Twitter)
    #   website             - Website, such as GOV.UK
    #   other               - Other
    enum discovery_method: { used_before: 0, meeting_or_event: 1, dfe_publication: 2, non_dfe_publication: 3, recommendation: 4, search_engine: 5, social_media: 6, website: 7, other: 8 }

(note: non_dfe_publication is new and shunted the remaining enum cases along by a digit, but there is no live data using the enum yet so this was considered the preferred route)

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
