### PR TITLE
1685 - fix(cms): cases created by email stay new

### DIFF
--- a/app/cores/case_management/handle_messages.rb
+++ b/app/cores/case_management/handle_messages.rb
@@ -6,7 +6,7 @@ module CaseManagement
       support_case = Support::Case.find(payload[:support_case_id])
       support_case.update!(action_required: true, with_school: false)
 
-      if support_case.may_open?
+      if !support_case.initial? && support_case.may_open?
         support_case.open!
         broadcast(:case_reopened_due_to_received_email, payload)
       end

--- a/spec/cores/case_management/handle_messages_spec.rb
+++ b/spec/cores/case_management/handle_messages_spec.rb
@@ -29,6 +29,24 @@ describe CaseManagement::HandleMessages do
         end
       end
     end
+
+    context "when the case is new" do
+      let(:support_case) { create(:support_case, :initial) }
+
+      it "does not reopen the case" do
+        payload = { support_case_id: support_case.id, support_email_id: }
+        expect { handler.received_email_attached_to_case(payload) }.to(not_change { support_case.reload.state })
+      end
+
+      it "does not broadcast the reopening of the case" do
+        payload = { support_case_id: support_case.id, support_email_id: }
+
+        with_event_handler(listening_to: :case_reopened_due_to_received_email) do |other_handler|
+          handler.received_email_attached_to_case(payload)
+          expect(other_handler).not_to have_received(:case_reopened_due_to_received_email).with(payload)
+        end
+      end
+    end
   end
 
   describe "#contact_to_school_made" do


### PR DESCRIPTION
## Changes in this PR
- fixes the bug where a case created by email is automatically transitioned from `initial` state to `opened`

Jira: PWNN-1685