### PR TITLE
fix(cms): school details tab shown in other tabs

### DIFF
--- a/app/views/support/cases/school_details/participating_schools/edit.html.erb
+++ b/app/views/support/cases/school_details/participating_schools/edit.html.erb
@@ -1,13 +1,11 @@
 <%= turbo_frame_tag "school-details-frame" do %>
-  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="school-details">
-    <%= link_to I18n.t("support.case.label.school_details.participating_schools.edit.back"), @back_url, class: "govuk-back-link pull-up" %>
+  <%= link_to I18n.t("support.case.label.school_details.participating_schools.edit.back"), @back_url, class: "govuk-back-link pull-up" %>
 
-    <%= render "components/school_picker/school_picker",
-        results_model: @case_school_picker,
-        filters_model: @filters,
-        scope: :participating_schools,
-        update_url: support_case_school_details_participating_schools_path,
-        filters_url: edit_support_case_school_details_participating_schools_path,
-        method: :patch %>
-  </div>
+  <%= render "components/school_picker/school_picker",
+      results_model: @case_school_picker,
+      filters_model: @filters,
+      scope: :participating_schools,
+      update_url: support_case_school_details_participating_schools_path,
+      filters_url: edit_support_case_school_details_participating_schools_path,
+      method: :patch %>
 <% end %>

--- a/app/views/support/cases/school_details/participating_schools/show.html.erb
+++ b/app/views/support/cases/school_details/participating_schools/show.html.erb
@@ -1,29 +1,27 @@
 <%= turbo_frame_tag "school-details-frame" do %>
-  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="school-details">
-    <%= link_to I18n.t("support.case.label.school_details.back"), @back_url, class: "govuk-back-link pull-up" %>
-    <h2 class="govuk-heading-l">
-      <%= I18n.t("support.case.label.participating_schools") %> - <%= link_to I18n.t("support.case.link.change"), edit_support_case_school_details_participating_schools_path, class: "govuk-link govuk-link--no-visited-state" %>
-    </h2>
+  <%= link_to I18n.t("support.case.label.school_details.back"), @back_url, class: "govuk-back-link pull-up" %>
+  <h2 class="govuk-heading-l">
+    <%= I18n.t("support.case.label.participating_schools") %> - <%= link_to I18n.t("support.case.link.change"), edit_support_case_school_details_participating_schools_path, class: "govuk-link govuk-link--no-visited-state" %>
+  </h2>
 
-    <table class="govuk-table" aria-label="Participating schools">
-      <thead class="govuk-table__head">
+  <table class="govuk-table" aria-label="Participating schools">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header"><%= I18n.t("support.case.label.school_details.participating_schools.table.school_name") %></th>
+        <th scope="col" class="govuk-table__header"><%= I18n.t("support.case.label.school_details.participating_schools.table.address") %></th>
+        <th scope="col" class="govuk-table__header"><%= I18n.t("support.case.label.school_details.participating_schools.table.phase") %></th>
+        <th scope="col" class="govuk-table__header"><%= I18n.t("support.case.label.school_details.participating_schools.table.local_authority") %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @participating_schools.each do |school| %>
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header"><%= I18n.t("support.case.label.school_details.participating_schools.table.school_name") %></th>
-          <th scope="col" class="govuk-table__header"><%= I18n.t("support.case.label.school_details.participating_schools.table.address") %></th>
-          <th scope="col" class="govuk-table__header"><%= I18n.t("support.case.label.school_details.participating_schools.table.phase") %></th>
-          <th scope="col" class="govuk-table__header"><%= I18n.t("support.case.label.school_details.participating_schools.table.local_authority") %></th>
+          <th scope="row" class="govuk-table__header"><%= school.name %></th>
+          <td class="govuk-table__cell"><%= school.formatted_address %></td>
+          <td class="govuk-table__cell"><%= school.phase %></td>
+          <td class="govuk-table__cell"><%= school.local_authority %></td>
         </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% @participating_schools.each do |school| %>
-          <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header"><%= school.name %></th>
-            <td class="govuk-table__cell"><%= school.formatted_address %></td>
-            <td class="govuk-table__cell"><%= school.phase %></td>
-            <td class="govuk-table__cell"><%= school.local_authority %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+      <% end %>
+    </tbody>
+  </table>
 <% end %>

--- a/app/views/support/cases/school_details/show.html.erb
+++ b/app/views/support/cases/school_details/show.html.erb
@@ -1,114 +1,112 @@
 <%= turbo_frame_tag "school-details-frame" do %>
-  <div class="govuk-tabs__panel" id="school-details" role="tabpanel" aria-labelledby="tab_school-details">
-    <h2 class="govuk-heading-l">
-      <%= I18n.t("support.case.header.school_detail") %>
-    </h2>
+  <h2 class="govuk-heading-l">
+    <%= I18n.t("support.case.header.school_detail") %>
+  </h2>
 
-    <dl class="govuk-summary-list govuk-!-margin-bottom-5">
+  <dl class="govuk-summary-list govuk-!-margin-bottom-5">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= I18n.t("support.case.label.contact_name") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @current_case.full_name %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <% unless @current_case.closed? %>
+          <%= link_to "Change", edit_support_case_contact_details_path(@current_case), class: "govuk-link", target: "_top" %>
+        <% end %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= I18n.t("support.case.label.contact_phone") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @current_case.phone_number %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <% unless @current_case.closed? %>
+          <%= link_to "Change", edit_support_case_contact_details_path(@current_case), class: "govuk-link", target: "_top" %>
+        <% end %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= I18n.t("support.case.label.contact_extension_number") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @current_case.extension_number %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <% unless @current_case.closed? %>
+          <%= link_to "Change", edit_support_case_contact_details_path(@current_case), class: "govuk-link", target: "_top" %>
+        <% end %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= I18n.t("support.case.label.contact_email") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @current_case.email %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <% unless @current_case.closed? %>
+          <%= link_to "Change", edit_support_case_contact_details_path(@current_case), class: "govuk-link", target: "_top" %>
+        <% end %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= I18n.t("support.case.label.organisation_name") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @current_case.organisation_name if @current_case.organisation.present? %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <% unless @current_case.closed? %>
+          <%= link_to @current_case.organisation.present? ? "Change" : "Add",
+            edit_support_case_organisation_path(@current_case), class: "govuk-link", target: "_top" %>
+        <% end %>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= I18n.t("support.case.label.organisation_type") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @current_case.organisation_type_name %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+      </dd>
+    </div>
+
+    <% if @current_case.eligible_for_school_picker? %>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          <%= I18n.t("support.case.label.contact_name") %>
+          <%= I18n.t("support.case.label.participating_schools") %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @current_case.full_name %>
+          <%= @current_case.participating_schools.count %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <% unless @current_case.closed? %>
-            <%= link_to "Change", edit_support_case_contact_details_path(@current_case), class: "govuk-link", target: "_top" %>
-          <% end %>
+          <%= link_to I18n.t("support.generic.view"), support_case_school_details_participating_schools_path(@current_case), class: "govuk-link" %>
         </dd>
       </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= I18n.t("support.case.label.contact_phone") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @current_case.phone_number %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <% unless @current_case.closed? %>
-            <%= link_to "Change", edit_support_case_contact_details_path(@current_case), class: "govuk-link", target: "_top" %>
-          <% end %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= I18n.t("support.case.label.contact_extension_number") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @current_case.extension_number %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <% unless @current_case.closed? %>
-            <%= link_to "Change", edit_support_case_contact_details_path(@current_case), class: "govuk-link", target: "_top" %>
-          <% end %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= I18n.t("support.case.label.contact_email") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @current_case.email %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <% unless @current_case.closed? %>
-            <%= link_to "Change", edit_support_case_contact_details_path(@current_case), class: "govuk-link", target: "_top" %>
-          <% end %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= I18n.t("support.case.label.organisation_name") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @current_case.organisation_name if @current_case.organisation.present? %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <% unless @current_case.closed? %>
-            <%= link_to @current_case.organisation.present? ? "Change" : "Add",
-              edit_support_case_organisation_path(@current_case), class: "govuk-link", target: "_top" %>
-          <% end %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= I18n.t("support.case.label.organisation_type") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @current_case.organisation_type_name %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-        </dd>
-      </div>
-
-      <% if @current_case.eligible_for_school_picker? %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= I18n.t("support.case.label.participating_schools") %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= @current_case.participating_schools.count %>
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <%= link_to I18n.t("support.generic.view"), support_case_school_details_participating_schools_path(@current_case), class: "govuk-link" %>
-          </dd>
-        </div>
-      <% end %>
-    </dl>
-
-    <% if @current_case.organisation.present? %>
-      <p class="govuk-body">
-        <%= link_to @current_case.organisation_gias_label,
-            @current_case.organisation_gias_url,
-            class: "govuk-link", target: "_blank", rel: "noreferrer noopener"
-        %>
-      </p>
     <% end %>
-  </div>
+  </dl>
+
+  <% if @current_case.organisation.present? %>
+    <p class="govuk-body">
+      <%= link_to @current_case.organisation_gias_label,
+          @current_case.organisation_gias_url,
+          class: "govuk-link", target: "_blank", rel: "noreferrer noopener"
+      %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/support/cases/show/_school_details.html.erb
+++ b/app/views/support/cases/show/_school_details.html.erb
@@ -1,5 +1,5 @@
-<%= turbo_frame_tag "school-details-frame", src: support_case_school_details_path(@current_case) do %>
-  <div id="school-details" class="govuk-tabs__panel govuk-tabs__panel--hidden">
+<div id="school-details" class="govuk-tabs__panel govuk-tabs__panel--hidden">
+  <%= turbo_frame_tag "school-details-frame", src: support_case_school_details_path(@current_case) do %>
     <p class="govuk-body">Loading...</p>
-  </div>
-<% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
## Changes in this PR
- fixes a bug where the content of the School Details tab was being shown in other tabs if the tab is specified in the URL hash