### PR TITLE
1657 - fix(cms): duplicate email attachments not displaying correctly

### DIFF
--- a/app/cores/case_files/unique_attachments_for_case.rb
+++ b/app/cores/case_files/unique_attachments_for_case.rb
@@ -30,10 +30,10 @@ module CaseFiles
 
     def query
       Support::EmailAttachment
-        .unique_files
         .for_case(case_id: @case_id)
         .where(hidden: false, **filter_to_apply)
-        .order(is_inline: :asc, created_at: :desc)
+        .unique_files
+        .reorder(is_inline: :asc, created_at: :desc)
     end
   end
 end

--- a/app/models/support/email_attachment/de_dupable.rb
+++ b/app/models/support/email_attachment/de_dupable.rb
@@ -2,37 +2,22 @@ module Support::EmailAttachment::DeDupable
   extend ActiveSupport::Concern
 
   included do
-    scope :unique_files, lambda { |first_instance_only: true|
-      joins(
-        <<-SQL,
-        INNER JOIN (
-          SELECT
-            support_email_attachments.id,
-            active_storage_blobs.checksum,
-            ROW_NUMBER() OVER(
-              PARTITION BY active_storage_blobs.checksum, active_storage_blobs.filename
-              ORDER BY support_email_attachments.updated_at DESC
-            ) AS rank
-          FROM support_email_attachments
-          JOIN active_storage_attachments
-            ON active_storage_attachments.record_type = 'Support::EmailAttachment'
-            AND active_storage_attachments.record_id = support_email_attachments.id
-          JOIN active_storage_blobs
-            ON active_storage_blobs.id = active_storage_attachments.blob_id
-        ) attachment_files
-        ON attachment_files.id = support_email_attachments.id
-        #{'AND attachment_files.rank = 1' if first_instance_only}
-      SQL
-      )
+    scope :unique_files, lambda {
+      unique_attachments = map { |att| all_instances(att).order("created_at DESC").first }.uniq
+      where(id: unique_attachments)
+    }
+
+    scope :all_instances, lambda { |email_attachment|
+      joins(file_attachment: :blob)
+      .where("active_storage_blobs.checksum = ?", email_attachment.checksum)
+      .where("active_storage_blobs.filename = ?", email_attachment.file_name)
     }
   end
 
   class_methods do
     def find_duplicates_of(email_attachment)
-      unique_files(first_instance_only: false)
-        .for_case(case_id: email_attachment.case_id)
-        .where(attachment_files: { checksum: email_attachment.checksum },
-               file_name: email_attachment.file_name)
+      for_case(case_id: email_attachment.case_id)
+      .all_instances(email_attachment)
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -340,8 +340,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_10_122627) do
     t.string "title"
     t.text "body"
     t.string "slug"
-    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "created_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", precision: nil, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.string "contentful_id"
     t.text "sidebar"
     t.string "breadcrumbs", default: [], array: true
@@ -761,7 +761,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_10_122627) do
     t.string "ukprn"
     t.string "telephone_number"
     t.jsonb "local_authority"
-    t.datetime "opened_date"
+    t.datetime "opened_date", precision: nil
     t.string "number"
     t.string "rsc_region"
     t.string "trust_name"

--- a/spec/models/support/email_attachment_spec.rb
+++ b/spec/models/support/email_attachment_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Support::EmailAttachment, type: :model do
   end
 
   describe ".unique_files" do
-    let!(:attachment_1) { create(:support_email_attachment, file: fixture_file_upload(Rails.root.join("spec/fixtures/support/text-file.txt"), "text/plain")) }
-    let!(:attachment_2) { create(:support_email_attachment, file: fixture_file_upload(Rails.root.join("spec/fixtures/support/text-file.txt"), "text/plain")) }
+    let!(:attachment_1) { create(:support_email_attachment, file: fixture_file_upload(Rails.root.join("spec/fixtures/support/text-file.txt"), "text/plain"), created_at: 1.week.ago) }
+    let!(:attachment_2) { create(:support_email_attachment, file: fixture_file_upload(Rails.root.join("spec/fixtures/support/text-file.txt"), "text/plain"), created_at: 1.day.ago) }
     let!(:attachment_3) { create(:support_email_attachment, file: fixture_file_upload(Rails.root.join("spec/fixtures/support/another-text-file.txt"), "text/plain")) }
 
     it "removes repeating duplicate files" do
@@ -44,15 +44,22 @@ RSpec.describe Support::EmailAttachment, type: :model do
       expect(results).to include(attachment_2)
       expect(results).to include(attachment_3)
     end
+  end
 
-    context "when first_instance_only is false" do
-      it "provides repeating duplicate files, so they can be hidden" do
-        results = described_class.unique_files(first_instance_only: false).to_a
+  describe ".all_instances" do
+    let!(:attachment_1) { create(:support_email_attachment, file: fixture_file_upload(Rails.root.join("spec/fixtures/support/text-file.txt"), "text/plain"), created_at: 1.week.ago) }
+    let!(:attachment_2) { create(:support_email_attachment, file: fixture_file_upload(Rails.root.join("spec/fixtures/support/text-file.txt"), "text/plain"), created_at: 1.day.ago) }
+    let!(:attachment_3) { create(:support_email_attachment, file: fixture_file_upload(Rails.root.join("spec/fixtures/support/another-text-file.txt"), "text/plain")) }
 
-        expect(results).to include(attachment_1)
-        expect(results).to include(attachment_2)
-        expect(results).to include(attachment_3)
-      end
+    it "provides repeating duplicate files, so they can be hidden" do
+      results = described_class.all_instances(attachment_1).to_a
+      expect(results).to include(attachment_1)
+      expect(results).to include(attachment_2)
+      results = described_class.all_instances(attachment_2).to_a
+      expect(results).to include(attachment_1)
+      expect(results).to include(attachment_2)
+      results = described_class.all_instances(attachment_3).to_a
+      expect(results).to include(attachment_3)
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR

Fixes 3 bugs:
- Duplicate e-mail attachments not showing correctly (should be 1 of each duplicate within a case) in CMS -> Attachments -> All Files
- Duplicate e-mail attachments missing in CMS -> Attachments -> Received Files / Sent Files even when they're correctly listed in that case's All Files
- Duplicate e-mail attachments going missing between cases

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
