### PR TITLE
1691 - fix(rfh): remove back link from show view

### DIFF
--- a/app/controllers/framework_requests_controller.rb
+++ b/app/controllers/framework_requests_controller.rb
@@ -9,7 +9,6 @@ class FrameworkRequestsController < ApplicationController
 
   def show
     @current_user = UserPresenter.new(current_user)
-    @back_url = edit_framework_request_origin_path
 
     if framework_request.submitted?
       redirect_to framework_request_submission_path(framework_request)

--- a/spec/features/specify/framework_requests/edit_framework_request_dsi_spec.rb
+++ b/spec/features/specify/framework_requests/edit_framework_request_dsi_spec.rb
@@ -16,11 +16,6 @@ RSpec.feature "Editing a 'Find a Framework' request as a user" do
     visit "/procurement-support/#{request.id}"
   end
 
-  it "goes back to the origin page" do
-    click_on "Back"
-    expect(page).to have_current_path "/procurement-support/#{request.id}/origin/edit"
-  end
-
   it "has submission information" do
     expect(find("h1.govuk-heading-l", text: "Send your request")).to be_present
     expect(find("p.govuk-body", text: "Once you send this request, we will review it and get in touch within 2 working days.")).to be_present

--- a/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
@@ -20,11 +20,6 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
     visit "/procurement-support/#{request.id}"
   end
 
-  it "goes back to the origin page" do
-    click_on "Back"
-    expect(page).to have_current_path "/procurement-support/#{request.id}/origin/edit"
-  end
-
   it "has submission information" do
     expect(find("h1.govuk-heading-l", text: "Send your request")).to be_present
     expect(find("p.govuk-body", text: "Once you send this request, we will review it and get in touch within 2 working days.")).to be_present


### PR DESCRIPTION
## Changes in this PR
- removed the Back link from the `framework_request` show ( a.k.a. Check Your Answers) view

Jira: PWNN-1691