### PR TITLE
RFH & CMS bugfixes

### DIFF
--- a/app/controllers/framework_request_submissions_controller.rb
+++ b/app/controllers/framework_request_submissions_controller.rb
@@ -8,6 +8,7 @@ class FrameworkRequestSubmissionsController < ApplicationController
       SubmitFrameworkRequest.new(request: framework_request, referrer: session[:faf_referrer]).call
     end
 
+    session.delete(:framework_request_id)
     session.delete(:faf_referrer)
 
     redirect_to framework_request_submission_path(framework_request)

--- a/app/controllers/framework_requests/origins_controller.rb
+++ b/app/controllers/framework_requests/origins_controller.rb
@@ -6,7 +6,6 @@ module FrameworkRequests
       if @form.valid?
         @form.save!
         session.delete(:support_journey) unless current_user.guest?
-        session.delete(:framework_request_id)
         redirect_to framework_request_path(@form.framework_request)
       else
         render :index

--- a/app/views/support/interactions/forms/_contact.html.erb
+++ b/app/views/support/interactions/forms/_contact.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-l"><%= I18n.t("support.interaction.header.contact_with_school") %></h1>
 
-<%= form.govuk_collection_radio_buttons :event_type, form.object.contact_options, :id, :label,
+<%= form.govuk_collection_radio_buttons :event_type, @interaction.contact_options, :id, :label,
                                         legend: { text: I18n.t("support.interaction.header.type_of_contact"), size: "m" }
 %>
 

--- a/spec/lib/specify/school/information_call_spec.rb
+++ b/spec/lib/specify/school/information_call_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe School::Information, "#call" do
     before do
       travel_to Time.zone.local(2004, 11, 24, 0o1, 0o4, 44)
 
-      stub_request(:get, "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/edubasealldata20041124.csv")
+      stub_request(:get, "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/edubasealldata20041124.csv").to_return(body: "")
     end
 
     it "downloads the current GIAS CSV data" do

--- a/spec/lib/support/establishment_groups/information_call_spec.rb
+++ b/spec/lib/support/establishment_groups/information_call_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Support::EstablishmentGroups::Information, "#call" do
     before do
       travel_to Time.zone.local(2004, 11, 24, 0o1, 0o4, 44)
 
-      stub_request(:get, "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/allgroupsdata20041124.csv")
+      stub_request(:get, "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/allgroupsdata20041124.csv").to_return(body: "")
     end
 
     it "downloads the current GIAS establishment groups CSV data" do

--- a/spec/services/support/messages/outlook/synchronisation/message_attachment_importer_spec.rb
+++ b/spec/services/support/messages/outlook/synchronisation/message_attachment_importer_spec.rb
@@ -9,11 +9,7 @@ describe Support::Messages::Outlook::Synchronisation::MessageAttachmentImporter 
     let!(:existing_email_attachment) { create(:support_email_attachment, email:, outlook_id: "123") }
 
     it "does not import the attachment again" do
-      starting_updated_at = existing_email_attachment.updated_at
-
-      described_class.call(message_attachment, email)
-
-      expect(existing_email_attachment.reload.updated_at).to eq(starting_updated_at)
+      expect { described_class.call(message_attachment, email) }.not_to(change { existing_email_attachment.reload.attributes })
     end
   end
 


### PR DESCRIPTION
## Changes in this PR
- [fix(rfh): remove request id later in the journey](https://github.com/DFE-Digital/buy-for-your-school/commit/fecc8c64c99f7a9823e3caaa4595766cdbb3c7d6)
Some users like to use the browser back button to go back to the questions once they've completed the RFH form. Until now the `framework_request_id` has been removed from the session when the last question is answered, so if the user used the browser back button to go back and change an existing answer or refresh the page on an answered question, a new `framework_request` would be created and the user would be filling out a new `framework_request`, but backwards. The thing would eventually crash because some questions depend on previous answers and a new `framework_request` wouldn't have these answers. The `framework_request_id` is now removed from the session once the request is submitted.

- [fix(cms): correct case interaction object in log contact](https://github.com/DFE-Digital/buy-for-your-school/commit/db42397693ecbead77759cbd753f3dda9e0e0051)
`form.object` no longer returns `InteractionPresenter`, but the underlying `Interaction` model. This causes the "Log contact with school" page to crash when calling `contact_options`, which is defined on the presenter, not the model. This is a recent issue. I suspect this is due to the [changes made to ActionView as of Rails 7.1.0](https://github.com/rails/rails/blob/v7.1.1/actionview/CHANGELOG.md#rails-710beta1-september-13-2023), in particular these bits:
  - Move `convert_to_model` call from `form_for` into `form_with`
  - Ensure models passed to `form_for` attempt to call `to_model`

- Fixes for broken tests