### PR TITLE
fix: case insensitive email lookup for agent login

### DIFF
--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -69,7 +69,7 @@ private
   end
 
   def current_support_agent
-    Support::Agent.find_by(email:)
+    Support::Agent.where("lower(email) = lower(?)", email).first
   end
 
   def update_support_agent!
@@ -132,7 +132,7 @@ private
 
   # @return [String] Unique identifier for the user
   def email
-    auth.dig("info", "email")
+    auth.dig("info", "email").downcase
   end
 
   # @return [String] Unique identifier for the user

--- a/spec/services/specify/create_user_spec.rb
+++ b/spec/services/specify/create_user_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe CreateUser do
     end
 
     context "when they have updated their details" do
+      let(:email) { "User@Example.com" }
+
       let(:omniauth_hash) do
         {
           "uid" => dfe_sign_in_uid,
@@ -72,6 +74,10 @@ RSpec.describe CreateUser do
       it "updates the user record" do
         expect(result.first_name).to eq "New First"
         expect(result.last_name).to eq "New Last"
+      end
+
+      it "downcases the email" do
+        expect(result.email).to eq("user@example.com")
       end
     end
 
@@ -116,8 +122,8 @@ RSpec.describe CreateUser do
 
     context "when they already have a support agent record" do
       let(:dfe_sign_in_uid) { "something-else-4caa-9ff2-07faff7351d2" }
-      let!(:existing_user) { create(:user, dfe_sign_in_uid:, email:) }
-      let!(:support_agent) { create(:support_agent, email:) }
+      let!(:existing_user) { create(:user, dfe_sign_in_uid:, email: email.upcase) }
+      let!(:support_agent) { create(:support_agent, email: email.downcase) }
       let(:orgs) { [] }
 
       context "when the user already exists (regardless of org)" do
@@ -131,6 +137,10 @@ RSpec.describe CreateUser do
 
         it "creates a new user record" do
           expect(result).to eq User.find_by(dfe_sign_in_uid:)
+        end
+
+        it "downcases the email on the created user" do
+          expect(result.email).to eq("user@example.com")
         end
 
         it "updates the agent to have the dsi uid of the user" do


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

When logging in for the first time with a pre-created agent, the service looks up the agent by email in a case sensitive way. This PR attempts to make the lookup case insensitive.