### PR TITLE
POC Email OTP codes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "3.3.0"
 
 gem "aasm"
+gem "active_model_otp"
 gem "application_insights"
 gem "ar-sequence"
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_model_otp (2.3.2)
+      activemodel
+      rotp (~> 6.2.0)
     activejob (7.1.3)
       activesupport (= 7.1.3)
       globalid (>= 0.3.6)
@@ -561,6 +564,7 @@ GEM
       rack (>= 1.4)
     rexml (3.2.6)
     rollbar (3.5.1)
+    rotp (6.2.2)
     rouge (4.2.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -752,6 +756,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
+  active_model_otp
   application_insights
   ar-sequence
   aws-sdk-s3

--- a/app/controllers/proof_of_concept/application_controller.rb
+++ b/app/controllers/proof_of_concept/application_controller.rb
@@ -1,0 +1,7 @@
+class ProofOfConcept::ApplicationController < ApplicationController
+  include SupportAgents
+
+private
+
+  def authorize_agent_scope = :access_proof_of_concepts?
+end

--- a/app/controllers/proof_of_concept/otp_portal/application_controller.rb
+++ b/app/controllers/proof_of_concept/otp_portal/application_controller.rb
@@ -1,0 +1,18 @@
+class ProofOfConcept::OtpPortal::ApplicationController < ProofOfConcept::ApplicationController
+
+private
+
+  def current_otp_user
+    if session[:otp_user_id]
+      OtpUser.find(session[:otp_user_id])
+    end
+  end
+
+  def current_otp_user=(otp_user)
+    session[:otp_user_id] = otp_user.id
+  end
+
+  def log_out_current_otp_user
+    session.delete(:otp_user_id)
+  end
+end

--- a/app/controllers/proof_of_concept/otp_portal/homes_controller.rb
+++ b/app/controllers/proof_of_concept/otp_portal/homes_controller.rb
@@ -1,0 +1,4 @@
+class ProofOfConcept::OtpPortal::HomesController < ProofOfConcept::OtpPortal::ApplicationController
+  def show
+  end
+end

--- a/app/controllers/proof_of_concept/otp_portal/passcodes_controller.rb
+++ b/app/controllers/proof_of_concept/otp_portal/passcodes_controller.rb
@@ -1,0 +1,9 @@
+class ProofOfConcept::OtpPortal::PasscodesController < ProofOfConcept::OtpPortal::ApplicationController
+  def show
+    @back_url = proof_of_concept_otp_portal_path
+    
+    # only creating user for conveinince in POC - Dont do in production!
+    otp_user = OtpUser.find_or_create_by!(email: current_user.email)
+    @code = otp_user.otp_code
+  end
+end

--- a/app/controllers/proof_of_concept/otp_portal/sessions_controller.rb
+++ b/app/controllers/proof_of_concept/otp_portal/sessions_controller.rb
@@ -1,0 +1,55 @@
+class ProofOfConcept::OtpPortal::SessionsController < ProofOfConcept::OtpPortal::ApplicationController
+  before_action { @form = SessionForm.new(sessions_params) }
+
+  def new; end
+
+  def passcode
+    if @form.valid?
+      # only creating user for conveinince in POC - Dont do in production!
+      otp_user = OtpUser.find_or_create_by(email: @form.email)
+      otp_user.send_passcode_in_email
+    else
+      render :new
+    end
+  end
+
+  def create
+    if @form.valid?(context: :passcode_entry)
+      self.current_otp_user = OtpUser.find_by(email: @form.email)
+
+      redirect_to proof_of_concept_otp_portal_welcomes_path
+    else
+      render :passcode
+    end
+  end
+
+  def destroy
+    log_out_current_otp_user
+    redirect_to proof_of_concept_otp_portal_path
+  end
+
+private
+
+  def sessions_params
+    params.fetch(:session, {}).permit(:email, :passcode)
+  end
+
+  class SessionForm
+    include ActiveModel::Model
+    include ActiveModel::Validations
+
+    attr_accessor :email, :passcode
+
+    validates :email, presence: true
+    validates :passcode, presence: true, on: :passcode_entry
+    validate :passcode_is_correct, on: :passcode_entry
+
+    def passcode_is_correct
+      user = OtpUser.find_by(email:)
+
+      unless user.authenticate_email_otp(otp_code: passcode)
+        errors.add(:passcode, "Invalid code")
+      end
+    end
+  end
+end

--- a/app/controllers/proof_of_concept/otp_portal/welcomes_controller.rb
+++ b/app/controllers/proof_of_concept/otp_portal/welcomes_controller.rb
@@ -1,0 +1,7 @@
+class ProofOfConcept::OtpPortal::WelcomesController < ProofOfConcept::OtpPortal::ApplicationController
+  before_action { redirect_to new_proof_of_concept_otp_portal_sessions_path unless current_otp_user.present? }
+
+  def show
+    @back_url = proof_of_concept_otp_portal_path
+  end
+end

--- a/app/models/otp_user.rb
+++ b/app/models/otp_user.rb
@@ -1,0 +1,12 @@
+class OtpUser < ApplicationRecord
+  has_one_time_password after_column_name: :last_otp_at
+
+  def send_passcode_in_email
+    Emails::EmailPasscode.new(passcode: otp_code, recipient: self).call
+  end
+
+  def authenticate_email_otp(otp_code:)
+    email_time_allowance_to_use_code = 5.minutes
+    authenticate_otp(otp_code, drift: email_time_allowance_to_use_code)
+  end
+end

--- a/app/policies/cms_portal_policy.rb
+++ b/app/policies/cms_portal_policy.rb
@@ -13,6 +13,10 @@ class CmsPortalPolicy
   def access_establishment_search? = access_proc_ops_portal? || access_e_and_o_portal?
   def access_frameworks_portal? = allow_any_of(%w[global_admin framework_evaluator_admin framework_evaluator procops_admin procops internal])
 
+  # Proof of concepts
+
+  def access_proof_of_concepts? = allow_any_of(%w[global_admin internal])
+
   # Agent management
 
   def manage_agents? = allow_any_of(%w[global_admin procops_admin e_and_o_admin])

--- a/app/services/emails/email_passcode.rb
+++ b/app/services/emails/email_passcode.rb
@@ -1,0 +1,12 @@
+require "notify/email"
+
+class Emails::EmailPasscode < Notify::Email
+  option :template, Types::String, default: proc { Support::EmailTemplates::IDS[:email_passcode] }
+  option :passcode, Types::String
+
+private
+
+  def template_params
+    { passcode: }
+  end
+end

--- a/app/services/support/email_templates.rb
+++ b/app/services/support/email_templates.rb
@@ -12,6 +12,7 @@ module Support
       all_cases_survey_resolved: "a56e5c50-78d1-4b5f-a2ff-73df78b7ad99",
       confirmation_energy: "a771c164-422a-4d70-8d2f-64f66c329dfa",
       customer_satisfaction_survey: "bbee99cd-c718-42ef-9d2c-b8fc9b442bbf",
+      email_passcode: "667b6e48-1c4d-467a-9251-1750977f0f77",
     }.freeze
 
     def self.label_for(id)

--- a/app/views/proof_of_concept/otp_portal/homes/show.html.erb
+++ b/app/views/proof_of_concept/otp_portal/homes/show.html.erb
@@ -1,0 +1,13 @@
+<h1 class="govuk-heading-xl">
+  Email OTP (One time passcode) proof of concept
+</h1>
+
+<p class="govuk-body">Steps:</p>
+
+<ol class="govuk-list govuk-list--number">
+  <li>Attempt to access the protected resource <%= govuk_link_to "here", proof_of_concept_otp_portal_welcomes_path %>, if you have not already followed the steps below you should be redirected to the <%= govuk_link_to "login page", new_proof_of_concept_otp_portal_sessions_path %>.</li>
+  <li>Enter your email address and click "Continue".</li>
+  <li>At this point, you may receive an email from Notify with a passcode in it. NOTE: if you are not in the GHBS team on Notify you will not receive an email at all. In this case <%= govuk_link_to "visit a page that is designed to simulate the email", proof_of_concept_otp_portal_passcodes_path %> to get your code.</li>
+  <li>Enter the passcode into the system and click "Continue".</li>
+  <li>If your passcode was correct you should now see the protected resource from step 1.</li>
+</ol>

--- a/app/views/proof_of_concept/otp_portal/passcodes/show.html.erb
+++ b/app/views/proof_of_concept/otp_portal/passcodes/show.html.erb
@@ -1,0 +1,22 @@
+<h1 class="govuk-heading-xl">
+  Pass codes demo
+</h1>
+
+<p class="govuk-body">An example email:</p>
+
+<%= govuk_summary_card(title: "to: #{current_agent.email}") do |card| %>
+
+  <%= govuk_header %>
+
+  <br />
+  <br />
+
+  <p class="govuk-body">Use this code to confirm your email address:</p>
+  <p class="govuk-body govuk-!-font-weight-bold"><%= @code %></p>
+  <p class="govuk-body">The code will expire after 5 minutes.</p>
+  <p class="govuk-body">This email address has been used for the Get Help Buying for Schools service. If this was not you, you can ignore this email.</p>
+  <p class="govuk-body">Department for Education</p>
+
+<% end %>
+
+<%= govuk_link_to "Log in with passcode &raquo;".html_safe, new_proof_of_concept_otp_portal_sessions_path %>

--- a/app/views/proof_of_concept/otp_portal/sessions/new.html.erb
+++ b/app/views/proof_of_concept/otp_portal/sessions/new.html.erb
@@ -1,0 +1,10 @@
+<h1 class="govuk-heading-xl">
+  Please enter your email address
+</h1>
+
+<p class="govuk-body">We will send a passcode to this email address </p>
+
+<%= form_with model: @form, scope: :session, url: passcode_proof_of_concept_otp_portal_sessions_path do |f| %>
+  <%= f.govuk_text_field :email, label: { size: "s" }, width: "two-thirds" %>
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/proof_of_concept/otp_portal/sessions/passcode.html.erb
+++ b/app/views/proof_of_concept/otp_portal/sessions/passcode.html.erb
@@ -1,0 +1,18 @@
+<h1 class="govuk-heading-xl">
+  Confirm your email address
+</h1>
+
+<p class="govuk-body">We've emailed a confirmation code to <%= @form.email %>.</p>
+
+<%= form_with model: @form, scope: :session, method: :post, url: proof_of_concept_otp_portal_sessions_path do |f| %>
+  <%= f.govuk_text_field :passcode, label: { text: "Confirmation Code", size: "s" }, width: 5 %>
+  <%= f.hidden_field :email %>
+  <%= f.govuk_submit %>
+<% end %>
+
+<hr />
+
+<p class="govuk-body">
+  Note for team mates: If your email is not added to the "Notify" team, you will not receive an email.
+  If you do not receive an email for this reason <%= govuk_link_to "I have simulated the email here", proof_of_concept_otp_portal_passcodes_path %>.
+</p>

--- a/app/views/proof_of_concept/otp_portal/welcomes/show.html.erb
+++ b/app/views/proof_of_concept/otp_portal/welcomes/show.html.erb
@@ -1,0 +1,10 @@
+<h1 class="govuk-heading-xl">
+  Protected information
+</h1>
+
+<p class="govuk-body">Congratulations your passcode worked!</p>
+<p class="govuk-body">Here is some information you wouldn't have been able to see otherwise...</p>
+
+<p class="govuk-body govuk-!-font-size-80">🕵️‍♀️</p>
+
+<p class="govuk-body">To log out and try the process again <%= govuk_link_to "Click here", proof_of_concept_otp_portal_sessions_path, method: :delete %>.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -376,6 +376,19 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :proof_of_concept do
+    namespace :otp_portal, constraints: -> { Flipper.enabled?(:poc_otp_portal) } do
+      get "/", to: "homes#show"
+
+      resource :home
+      resource :sessions do
+        post "/passcode", to: "sessions#passcode", as: :passcode
+      end
+      resource :passcodes
+      resource :welcomes
+    end
+  end
+
   resources :tickets, only: %i[index]
   scope module: :tickets do
     resource :messages, path: "/messages/:message_id", only: %i[update destroy] do

--- a/db/migrate/20231215150654_create_otp_users.rb
+++ b/db/migrate/20231215150654_create_otp_users.rb
@@ -1,0 +1,11 @@
+class CreateOtpUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :otp_users, id: :uuid do |t|
+      t.string :email
+      t.string :otp_secret_key
+      t.integer :last_otp_at
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/otp_users.rb
+++ b/spec/factories/otp_users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :otp_user do
+    email { "MyString" }
+    otp_secret_key { "MyString" }
+    last_otp_at { 1 }
+  end
+end

--- a/spec/models/otp_user_spec.rb
+++ b/spec/models/otp_user_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe OtpUser do
+  let(:user) { described_class.new(otp_secret_key: described_class.otp_random_secret) }
+
+  describe "#authenticate_email_otp" do
+    context "when the otp_code was generated within the last 5 minutes" do
+      let(:otp_code) { user.otp_code(time: (4.minutes + 30.seconds).ago) }
+
+      it "fails the code under normal circumstances as it is over the default interval of 30 seconds" do
+        # intentionally calling authenticate_otp
+        expect(user.authenticate_otp(otp_code)).to eq(false)
+      end
+
+      it "accepts the code to allow 5 minutes for email users" do
+        expect(user.authenticate_email_otp(otp_code:)).to eq(true)
+      end
+
+      it "allows use of the code only once" do
+        expect(user.authenticate_email_otp(otp_code:)).to eq(true)
+        expect(user.authenticate_email_otp(otp_code:)).to eq(false)
+      end
+    end
+
+    context "when the otp_code was generated more than 5 minutes and 30 seconds ago (grace period to allow receipt of email)" do
+      let(:otp_code) { user.otp_code(time: (5.minutes + 31.second).ago) }
+
+      it "does not accept the code" do
+        expect(user.authenticate_email_otp(otp_code:)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Demonstration of Email OTP codes.

It emails the user their current 2fa code so they can enter it back into the system. They have 5 minutes grace to do this.

If you want to implement true 2fa you need to:
- Display the QR code for their authentication app
- Add in a new page on login to accept a code and then use `user.authenticate_otp(otp_code)`
- Redirect if incorrect