### PR TITLE
fix: missing is_energy_or_services? method

### DIFF
--- a/app/controllers/engagement/case_requests/same_suppliers_controller.rb
+++ b/app/controllers/engagement/case_requests/same_suppliers_controller.rb
@@ -13,7 +13,7 @@ module Engagement
 
         if @same_supplierer.valid?
           @same_supplierer.save!
-          if @case_request.category.is_energy_or_services?
+          if @case_request.is_energy_or_services?
             redirect_to edit_engagement_case_request_contract_start_date_path(@case_request)
           else
             redirect_to engagement_case_request_path(@case_request)

--- a/app/controllers/engagement/case_requests/school_pickers_controller.rb
+++ b/app/controllers/engagement/case_requests/school_pickers_controller.rb
@@ -15,7 +15,7 @@ module Engagement
       def update
         @school_picker = @case_request.school_picker(school_urns: form_params[:school_urns].compact_blank.excluding("all"))
         @school_picker.save!
-        if @case_request.school_urns.count < 2 && @case_request.category.is_energy_or_services?
+        if @case_request.school_urns.count < 2 && @case_request.is_energy_or_services?
           redirect_to edit_engagement_case_request_contract_start_date_path(@case_request)
         elsif @case_request.school_urns.count > 1
           redirect_to edit_engagement_case_request_same_supplier_path(@case_request)

--- a/app/controllers/engagement/case_requests_controller.rb
+++ b/app/controllers/engagement/case_requests_controller.rb
@@ -22,7 +22,7 @@ module Engagement
         @case_request.save!
         if @case_request.eligible_for_school_picker? && @case_request.school_urns.empty?
           redirect_to edit_engagement_case_request_school_picker_path(@case_request)
-        elsif @case_request.category.is_energy_or_services?
+        elsif @case_request.is_energy_or_services?
           redirect_to edit_engagement_case_request_contract_start_date_path(@case_request)
         else
           redirect_to engagement_case_request_path(@case_request)

--- a/app/models/case_request.rb
+++ b/app/models/case_request.rb
@@ -35,6 +35,8 @@ class CaseRequest < ApplicationRecord
     result
   end
 
+  delegate :is_energy_or_services?, to: :category
+
 private
 
   def request_type_validation

--- a/app/models/framework_request.rb
+++ b/app/models/framework_request.rb
@@ -67,6 +67,10 @@ class FrameworkRequest < Request
     FrameworkRequestFlow.new(self)
   end
 
+  def is_energy_or_services?
+    flow&.is_energy_or_services? || category.is_energy_or_services?
+  end
+
 private
 
   def sat_selected?

--- a/app/models/request_for_help_category.rb
+++ b/app/models/request_for_help_category.rb
@@ -62,4 +62,6 @@ class RequestForHelpCategory < ApplicationRecord
   def gas? = slug == "gas"
 
   def electricity? = slug == "electricity"
+
+  def is_energy_or_services? = flow.in?(%w[energy services])
 end

--- a/app/models/support/category.rb
+++ b/app/models/support/category.rb
@@ -42,7 +42,7 @@ module Support
     end
 
     def is_energy_or_services?
-      request_for_help_categories.first&.flow.in?(%w[energy services])
+      request_for_help_categories.first&.is_energy_or_services?
     end
   end
 end

--- a/app/views/engagement/case_requests/show.html.erb
+++ b/app/views/engagement/case_requests/show.html.erb
@@ -141,7 +141,7 @@
         </dd>
       </div>
     </dl>
-    
+
     <h2 class="govuk-heading-m">
       <%= I18n.t("support.case.label.discovery_method.legend") %>
     </h2>
@@ -159,7 +159,7 @@
           <%= link_to I18n.t("generic.button.change_answer"), edit_engagement_case_request_path, class: "govuk-link govuk-link--no-visited-state" %>
         </dd>
       </div>
-    </dl>    
+    </dl>
 
     <h2 class="govuk-heading-m">
       <%= I18n.t("support.case_hub_migration.edit.section.case") %>
@@ -205,7 +205,7 @@
         </div>
       <% end %>
     </dl>
-    
+
     <h2 class="govuk-heading-m">
       <%= I18n.t("support.case_hub_migration.edit.section.request_text") %>
     </h2>
@@ -240,7 +240,7 @@
           <%= link_to I18n.t("generic.button.change_answer"), edit_engagement_case_request_path, class: "govuk-link govuk-link--no-visited-state" %>
         </dd>
       </div>
-      <% if @case_request.category.is_energy_or_services? %>
+      <% if @case_request.is_energy_or_services? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             <%= I18n.t("faf.check_answers.details.contract_start_date") %>
@@ -255,7 +255,7 @@
       <% end %>
       <% if @case_request.school_urns.count > 1 %>
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"> 
+          <dt class="govuk-summary-list__key">
             <%= I18n.t("faf.check_answers.details.same_supplier_used") %>
           </dt>
           <dd class="govuk-summary-list__value">

--- a/app/views/support/cases/request_details/show.html.erb
+++ b/app/views/support/cases/request_details/show.html.erb
@@ -117,7 +117,7 @@
             <dd class="govuk-summary-list__actions"></dd>
           </div>
         <% end %>
-        <% if @request.flow.present? && @request.flow.energy_or_services? || @request.category.is_energy_or_services? %>
+        <% if @request.is_energy_or_services? %>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
               <%= I18n.t("support.case.label.contract_start_date") %>

--- a/spec/models/request_for_help_category_spec.rb
+++ b/spec/models/request_for_help_category_spec.rb
@@ -190,4 +190,11 @@ describe RequestForHelpCategory, type: :model do
       end
     end
   end
+
+  describe "#is_energy_or_services?" do
+    it { expect(described_class.new(flow: :services).is_energy_or_services?).to be(true) }
+    it { expect(described_class.new(flow: :goods).is_energy_or_services?).to be(false) }
+    it { expect(described_class.new(flow: :energy).is_energy_or_services?).to be(true) }
+    it { expect(described_class.new(flow: :not_fully_supported).is_energy_or_services?).to be(false) }
+  end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

Added `is_energy_or_services?` to `RequestForHelpCategory` to fix error as view previously assumed request category was a `Category`.

Moved `is_energy_or_services?` to `CaseRequest` + `FrameworkRequest` to avoid needing to call the `Category` / `RequestForHelpCategory`