### PR TITLE
ci: allow new prod read only to check ssl verification

### DIFF
--- a/.github/workflows/support-update-ssl-cert-validation-implementation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation-implementation.yml
@@ -1,0 +1,118 @@
+name: "Support - Update SSL Cert Validation - Implementation"
+
+on:
+  workflow_call:
+    inputs:
+      chosen_environment:
+        required: true
+        type: string
+
+jobs:
+  check_need_for_validation_update:
+    runs-on: ubuntu-20.04
+
+    environment: ${{ inputs.chosen_environment == 'az-production' && 'az-production-read-only' ||  inputs.chosen_environment }}
+
+    outputs:
+      customDomainName: ${{ steps.vars.outputs.customDomainName }}
+      profileName: ${{ steps.vars.outputs.profileName }}
+      zoneName: ${{ steps.vars.outputs.zoneName }}
+      resourceGroup: ${{ steps.vars.outputs.resourceGroup }}
+      needsToReEvaluate: ${{ steps.checkValidationState.outputs.needsToReEvaluate }}
+
+    steps:
+      - name: Setup variables
+        id: vars
+        run: |
+          # To avoid adding multiple variables into the environment when the names
+          # are based on convention and therefor can be built programmatically
+
+          if [[ "${{ inputs.chosen_environment }}" == "az-dev" ]]; then
+            customDomainName="devghbscustom-domain0"
+            profileName="devghbscdn"
+            zoneName="dev.get-help-buying-for-schools.service.gov.uk"
+          elif [[ "${{ inputs.chosen_environment }}" == "az-staging" ]]; then
+            customDomainName="stagingghbscustom-domain0"
+            profileName="stagingghbscdn"
+            zoneName="staging.get-help-buying-for-schools.service.gov.uk"
+          elif [[ "${{ inputs.chosen_environment }}" == "az-production" ]]; then
+            customDomainName="prodghbscustom-domain0"
+            profileName="prodghbscdn"
+            zoneName="www.get-help-buying-for-schools.service.gov.uk"
+          fi
+
+          echo customDomainName=$customDomainName >> $GITHUB_OUTPUT
+          echo profileName=$profileName >> $GITHUB_OUTPUT
+          echo zoneName=$zoneName >> $GITHUB_OUTPUT
+          echo resourceGroup=${{ secrets.RESOURCE_GROUP_NAME }} >> $GITHUB_OUTPUT
+
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_SP_CREDENTIALS }}
+
+      - name: Check need for validation
+        id: checkValidationState
+        uses: azure/CLI@v1
+        with:
+          azcliversion: 2.51.0
+          inlineScript: |
+            domainValidationState=$(az afd custom-domain show \
+              --profile-name ${{ steps.vars.outputs.profileName }} \
+              --resource-group ${{ steps.vars.outputs.resourceGroup }} \
+              --custom-domain-name ${{ steps.vars.outputs.customDomainName }} \
+              --only-show-errors | jq --raw-output .domainValidationState)
+
+            needsToReEvaluate=$([ -z "$(echo $domainValidationState | grep "PendingRevalidation")" ] && echo "no" || echo "yes")
+            echo needsToReEvaluate=$needsToReEvaluate >> $GITHUB_OUTPUT
+
+  update_validation:
+    runs-on: ubuntu-20.04
+
+    needs: [check_need_for_validation_update]
+
+    environment: ${{ inputs.chosen_environment }}
+
+    if: needs.check_need_for_validation_update.outputs.needsToReEvaluate == 'yes'
+
+    steps:
+      - name: Setup variables
+        id: vars
+        run: |
+          # Just to shorten the variable name paths
+          echo customDomainName=${{ needs.check_need_for_validation_update.outputs.customDomainName }} >> $GITHUB_OUTPUT
+          echo profileName=${{ needs.check_need_for_validation_update.outputs.profileName }} >> $GITHUB_OUTPUT
+          echo zoneName=${{ needs.check_need_for_validation_update.outputs.zoneName }} >> $GITHUB_OUTPUT
+          echo resourceGroup=${{ needs.check_need_for_validation_update.outputs.resourceGroup }} >> $GITHUB_OUTPUT
+          echo needsToReEvaluate=${{ needs.check_need_for_validation_update.outputs.needsToReEvaluate }} >> $GITHUB_OUTPUT
+
+      - name: Regenerate validation token
+        id: regenerateValidationToken
+        uses: azure/CLI@v1
+        with:
+          azcliversion: 2.51.0
+          inlineScript: |
+            az afd custom-domain regenerate-validation-token \
+              --profile-name ${{ steps.vars.outputs.profileName }} \
+              --resource-group ${{ steps.vars.outputs.resourceGroup }} \
+              --custom-domain-name ${{ steps.vars.outputs.customDomainName }} \
+              --only-show-errors
+
+            newValidationToken=$(az afd custom-domain show \
+              --profile-name ${{ steps.vars.outputs.profileName }} \
+              --resource-group ${{ steps.vars.outputs.resourceGroup }} \
+              --custom-domain-name ${{ steps.vars.outputs.customDomainName }} \
+              --only-show-errors | jq --raw-output .validationProperties.validationToken)
+
+            echo newValidationToken=$newValidationToken >> $GITHUB_OUTPUT
+
+      - name: Update dns auth TXT record
+        uses: azure/CLI@v1
+        with:
+          azcliversion: 2.51.0
+          inlineScript: |
+            az network dns record-set txt update \
+              --zone-name ${{ steps.vars.outputs.zoneName }} \
+              --name "_dnsauth" \
+              --resource-group ${{ steps.vars.outputs.resourceGroup }} \
+              --set "txt_records[0].value=['${{ steps.regenerateValidationToken.outputs.newValidationToken }}']"

--- a/.github/workflows/support-update-ssl-cert-validation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation.yml
@@ -2,93 +2,23 @@ name: "Support - Update SSL Cert Validation"
 
 on:
   workflow_dispatch:
+  schedule:
+    # At 09:00 on Monday. https://crontab.guru/#0_9_*_*_MON
+    - cron: '0 9 * * MON'
 
 jobs:
-  update_validation:
-    runs-on: ubuntu-20.04
-
+  check_need_to_validate_and_potentially_update:
     strategy:
+      fail-fast: false
       matrix:
         environment: [az-dev, az-staging, az-production]
 
-    environment: ${{ matrix.environment }}
+    # we must use a shared workflow in order to have 2 environments for prod (read only and normal)
+    # this is so we can check the status of the validation without needing deployment approval.
+    # Also so we can use matrix strategy with sequential jobs and keep outputs intact.
+    uses: ./.github/workflows/support-update-ssl-cert-validation-implementation.yml
 
-    steps:
-      - name: Setup variables
-        id: vars
-        run: |
-          # To avoid adding multiple variables into the environment when the names
-          # are based on convention and therefor can be built programmatically
+    with:
+      chosen_environment: ${{ matrix.environment }}
 
-          if [[ "${{ matrix.environment }}" == "az-dev" ]]; then
-            customDomainName="devghbscustom-domain0"
-            profileName="devghbscdn"
-            zoneName="dev.get-help-buying-for-schools.service.gov.uk"
-          elif [[ "${{ matrix.environment }}" == "az-staging" ]]; then
-            customDomainName="stagingghbscustom-domain0"
-            profileName="stagingghbscdn"
-            zoneName="staging.get-help-buying-for-schools.service.gov.uk"
-          elif [[ "${{ matrix.environment }}" == "az-production" ]]; then
-            customDomainName="prodghbscustom-domain0"
-            profileName="prodghbscdn"
-            zoneName="www.get-help-buying-for-schools.service.gov.uk"
-          fi
-
-          echo customDomainName=$customDomainName >> $GITHUB_OUTPUT
-          echo profileName=$profileName >> $GITHUB_OUTPUT
-          echo zoneName=$zoneName >> $GITHUB_OUTPUT
-
-      - name: Azure login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_SP_CREDENTIALS }}
-
-      - name: Check need for validation
-        id: checkValidationState
-        uses: azure/CLI@v1
-        with:
-          azcliversion: 2.51.0
-          inlineScript: |
-            domainValidationState=$(az afd custom-domain show \
-              --profile-name ${{ steps.vars.outputs.profileName }} \
-              --resource-group ${{ secrets.RESOURCE_GROUP_NAME }} \
-              --custom-domain-name ${{ steps.vars.outputs.customDomainName }} \
-              --only-show-errors | jq --raw-output .domainValidationState)
-
-            needsToReEvaluate=$([ -z "$(echo $domainValidationState | grep "PendingRevalidation")" ] && echo "no" || echo "yes")
-            echo needsToReEvaluate=$needsToReEvaluate >> $GITHUB_OUTPUT
-
-      - name: Regenerate validation token
-        id: regenerateValidationToken
-        if: steps.checkValidationState.outputs.needsToReEvaluate == 'yes'
-        uses: azure/CLI@v1
-        with:
-          azcliversion: 2.51.0
-          inlineScript: |
-            az afd custom-domain regenerate-validation-token \
-              --profile-name ${{ steps.vars.outputs.profileName }} \
-              --resource-group ${{ secrets.RESOURCE_GROUP_NAME }} \
-              --custom-domain-name ${{ steps.vars.outputs.customDomainName }} \
-              --only-show-errors
-
-            newValidationToken=$(az afd custom-domain show \
-              --profile-name ${{ steps.vars.outputs.profileName }} \
-              --resource-group ${{ secrets.RESOURCE_GROUP_NAME }} \
-              --custom-domain-name ${{ steps.vars.outputs.customDomainName }} \
-              --only-show-errors | jq --raw-output .validationProperties.validationToken)
-
-            echo newValidationToken=$newValidationToken >> $GITHUB_OUTPUT
-
-      - name: Update dns auth TXT record
-        if: steps.checkValidationState.outputs.needsToReEvaluate == 'yes'
-        uses: azure/CLI@v1
-        with:
-          azcliversion: 2.51.0
-          inlineScript: |
-            newValidationToken="${{ steps.regenerateValidationToken.outputs.newValidationToken }}"
-
-            az network dns record-set txt update \
-              --zone-name ${{ steps.vars.outputs.zoneName }} \
-              --name "_dnsauth" \
-              --resource-group ${{ secrets.RESOURCE_GROUP_NAME }} \
-              --set "txt_records[0].value=['$newValidationToken']"
+    secrets: inherit


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Fixes the issue with github actions that we need to approve a deployment to production in order to first check if we need to update the ssl validation.

This PR makes it so that we are able to check the validation status with a read-only azure log in, and then moves to a production environment only when it needs to make the change - and therefor correctly require approval (and send slack messages etc).

Sets the job to run every Monday so we can't forget to check the validation status.
