### PR TITLE
1841 - feat: end-of-journey survey

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -49,3 +49,4 @@ MS_GRAPH_SHARED_MAILBOX_ADDRESS="test@mailbox.com"
 
 # FaF
 FAF_FRAMEWORK_ENDPOINT=http://faf.test
+FAF_WEBHOOK_SECRET=test

--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -142,6 +142,7 @@ jobs:
             -e QUALTRICS_SURVEY_URL=https://dferesearch.fra1.qualtrics.com \
             -e SUPPORT_EMAIL=email@example.gov.uk \
             -e FAF_FRAMEWORK_ENDPOINT=http://faf.test \
+            -e FAF_WEBHOOK_SECRET=test \
             -e CI_NODE_TOTAL=${{ matrix.ci_node_total }} \
             -e CI_NODE_INDEX=${{ matrix.ci_node_index }} \
             ${{ needs.build_test.outputs.docker_image }} \
@@ -205,6 +206,7 @@ jobs:
             -e QUALTRICS_SURVEY_URL=https://dferesearch.fra1.qualtrics.com \
             -e SUPPORT_EMAIL=email@example.gov.uk \
             -e FAF_FRAMEWORK_ENDPOINT=http://faf.test \
+            -e FAF_WEBHOOK_SECRET=test \
             ${{ needs.build_test.outputs.docker_image }} \
             bash -c "bundle exec rspec --tag flaky || bundle exec rspec --only-failure"
 

--- a/app/assets/stylesheets/base/_misc.scss
+++ b/app/assets/stylesheets/base/_misc.scss
@@ -83,3 +83,8 @@
   color: $govuk-link-colour;
   cursor: pointer;
 }
+
+.divider-bottom {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(4);
+}

--- a/app/controllers/end_of_journey_surveys/thank_yous_controller.rb
+++ b/app/controllers/end_of_journey_surveys/thank_yous_controller.rb
@@ -1,0 +1,3 @@
+class EndOfJourneySurveys::ThankYousController < ApplicationController
+  skip_before_action :authenticate_user!
+end

--- a/app/controllers/end_of_journey_surveys_controller.rb
+++ b/app/controllers/end_of_journey_surveys_controller.rb
@@ -1,0 +1,50 @@
+class EndOfJourneySurveysController < ApplicationController
+  skip_before_action :authenticate_user!
+  before_action :authenticate_feedback_from_faf!
+
+  def new
+    @end_of_journey_survey = EndOfJourneySurveyResponse.new(service: params[:service])
+  end
+
+  def create
+    respond_to do |format|
+      format.html do
+        @end_of_journey_survey = EndOfJourneySurveyResponse.new(form_params)
+        if @end_of_journey_survey.valid?
+          @end_of_journey_survey.save!
+          redirect_to end_of_journey_surveys_thank_you_path
+        else
+          render :new
+        end
+      end
+
+      format.json do
+        @end_of_journey_survey = EndOfJourneySurveyResponse.new(json_params)
+        if @end_of_journey_survey.valid?
+          @end_of_journey_survey.save!
+          head :ok
+        else
+          head :unprocessable_entity
+        end
+      end
+    end
+  end
+
+private
+
+  def form_params
+    params.fetch(:end_of_journey_survey, {}).permit(:easy_to_use_rating, :improvements, :service)
+  end
+
+  def json_params
+    params.permit(:easy_to_use_rating, :improvements, :service)
+  end
+
+  def authenticate_feedback_from_faf!
+    return unless request.format.json?
+
+    authenticate_or_request_with_http_token do |token, _options|
+      token == ENV["FAF_WEBHOOK_SECRET"]
+    end
+  end
+end

--- a/app/models/end_of_journey_survey_response.rb
+++ b/app/models/end_of_journey_survey_response.rb
@@ -1,0 +1,6 @@
+class EndOfJourneySurveyResponse < ApplicationRecord
+  enum :easy_to_use_rating, { strongly_disagree: 0, disagree: 1, neutral: 2, agree: 3, strongly_agree: 4 }, prefix: true
+  enum :service, { find_a_framework: 0, request_for_help_form: 1 }, prefix: true
+
+  validates :easy_to_use_rating, presence: { message: "Select how strongly you agree that this form was easy to use" }
+end

--- a/app/views/end_of_journey_surveys/new.html.erb
+++ b/app/views/end_of_journey_surveys/new.html.erb
@@ -1,0 +1,26 @@
+<%= turbo_frame_tag "end-of-journey-feedback-frame" do %>
+  <h2 class="govuk-heading-m"><%= I18n.t("end_of_journey_survey.new.heading") %></h2>
+  <p class="govuk-body"><%= I18n.t("end_of_journey_survey.new.body") %></p>
+
+  <%= form_with model: @end_of_journey_survey, scope: :end_of_journey_survey, url: end_of_journey_surveys_path do |form| %>
+    <%= form.govuk_error_summary %> 
+    <%= form.hidden_field :service, value: @end_of_journey_survey.service %>
+          
+    <%= form.govuk_radio_buttons_fieldset :easy_to_use_rating, legend: { text: I18n.t("end_of_journey_survey.new.easy_to_use_rating"), size: "s" } do %>
+      <% EndOfJourneySurveyResponse.easy_to_use_ratings.keys.reverse.each do |rating| %>
+        <%= form.govuk_radio_button :easy_to_use_rating, rating, label: { text: rating.humanize } %>
+      <% end %>
+    <% end %>
+
+    <%= form.govuk_text_area :improvements,
+      rows: 10,
+      label: { text: I18n.t("end_of_journey_survey.new.improvements"), size: "s" }
+    %>
+
+    <%= form.submit I18n.t("end_of_journey_survey.new.send"), class: "govuk-button" %>
+  <% end %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to "Privacy policy", "/privacy", no_visited_state: true %>
+  </p>
+<% end %>

--- a/app/views/end_of_journey_surveys/thank_yous/show.html.erb
+++ b/app/views/end_of_journey_surveys/thank_yous/show.html.erb
@@ -1,0 +1,4 @@
+<%= turbo_frame_tag "end-of-journey-feedback-frame" do %>
+  <h2 class="govuk-heading-m"><%= I18n.t("end_of_journey_survey.thank_you.heading") %></h2>
+  <p class="govuk-body"><%= I18n.t("end_of_journey_survey.thank_you.body") %></p>
+<% end %>

--- a/app/views/framework_request_submissions/show.html.erb
+++ b/app/views/framework_request_submissions/show.html.erb
@@ -18,6 +18,14 @@
       <% else %>
         <%= render "default" %>
       <% end %>
+
+      <% if Flipper.enabled?(:rfh_usability_survey) %>
+        <div class="divider-bottom"></div>
+
+        <%= turbo_frame_tag "end-of-journey-feedback-frame", src: new_end_of_journey_survey_path(service: :request_for_help_form) do %>
+          <p class="govuk-body">Loading...</p>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,6 +379,16 @@ en:
       job_title:
         question: What is your job title?
         hint: We'll only use this to tell you about opportunities to take part in user research that is relevant to you.
+  end_of_journey_survey:
+    new:
+      heading: Before you go
+      body: Please could you let us know how easy it was to use the form? Your feedback helps us make our service better.
+      easy_to_use_rating: This form was easy to use
+      improvements: How could we improve this form?
+      send: Send feedback
+    thank_you:
+      heading: Thank you for your feedback
+      body: We will use your feedback to make our services better.
   faf:
     bill_uploads:
       header:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -436,6 +436,14 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :end_of_journey_surveys, only: %i[new create] do
+    scope module: :end_of_journey_surveys, as: :end_of_journey_surveys do
+      collection do
+        resource :thank_you, only: %i[show]
+      end
+    end
+  end
+
   if Rails.env.development?
     require "sidekiq/web"
     mount Sidekiq::Web, at: "/sidekiq"

--- a/db/migrate/20240126153454_create_end_of_journey_survey_responses.rb
+++ b/db/migrate/20240126153454_create_end_of_journey_survey_responses.rb
@@ -1,0 +1,11 @@
+class CreateEndOfJourneySurveyResponses < ActiveRecord::Migration[7.1]
+  def change
+    create_table :end_of_journey_survey_responses, id: :uuid do |t|
+      t.integer :easy_to_use_rating
+      t.text :improvements
+      t.integer :service
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_131833) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_26_153454) do
   create_sequence "evaluation_refs"
   create_sequence "framework_refs"
 
@@ -188,6 +188,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_131833) do
     t.datetime "updated_at", null: false
     t.index ["framework_request_id"], name: "index_documents_on_framework_request_id"
     t.index ["support_case_id"], name: "index_documents_on_support_case_id"
+  end
+
+  create_table "end_of_journey_survey_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "easy_to_use_rating"
+    t.text "improvements"
+    t.integer "service"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "energy_bills", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/end_of_journey_survey_response_spec.rb
+++ b/spec/models/end_of_journey_survey_response_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe EndOfJourneySurveyResponse do
+  subject(:survey_response) { described_class.new }
+
+  describe "Validations" do
+    it "is not valid without an easy to use rating" do
+      expect(survey_response).not_to be_valid(:easy_to_use_rating)
+      expect(survey_response.errors.messages[:easy_to_use_rating]).to eq(["Select how strongly you agree that this form was easy to use"])
+    end
+  end
+end

--- a/spec/requests/end_of_journey_survey/end_of_journey_survey_flow_spec.rb
+++ b/spec/requests/end_of_journey_survey/end_of_journey_survey_flow_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe "Filling out an end-of-journey survey" do
+  let(:params) { { end_of_journey_survey: { easy_to_use_rating: "agree", improvements: "do better", service: "request_for_help_form" } } }
+
+  it "creates the survey response and redirects to the thank you page" do
+    expect { post end_of_journey_surveys_path, params: }.to change(EndOfJourneySurveyResponse, :count).by(1)
+    expect(response).to redirect_to(end_of_journey_surveys_thank_you_path)
+
+    survey = EndOfJourneySurveyResponse.last
+    expect(survey.easy_to_use_rating).to eq("agree")
+    expect(survey.improvements).to eq("do better")
+    expect(survey.service).to eq("request_for_help_form")
+  end
+end

--- a/spec/requests/end_of_journey_survey/end_of_journey_survey_for_service_spec.rb
+++ b/spec/requests/end_of_journey_survey/end_of_journey_survey_for_service_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe "Filling out an end-of-journey survey for a specific service" do
+  let(:service) { nil }
+  let(:params) { { end_of_journey_survey: { easy_to_use_rating: "agree", service: } } }
+
+  context "when the service is Find a Framework" do
+    let(:params) { { easy_to_use_rating: "agree", improvements: "do better", service: "find_a_framework" } }
+
+    context "when the request is unauthenticated" do
+      let(:headers) { { "Content-Type" => "application/json", "Accept" => "application/json" } }
+
+      before { post end_of_journey_surveys_path, params:, headers:, as: :json }
+
+      it "returns unauthorized and does not save the feedback" do
+        expect(response).to have_http_status(:unauthorized)
+        expect(EndOfJourneySurveyResponse.count).to be_zero
+      end
+    end
+
+    context "when the request is authenticated" do
+      let(:auth_token) { ActionController::HttpAuthentication::Token.encode_credentials("test") }
+      let(:headers) { { "Content-Type" => "application/json", "Accept" => "application/json", "Authorization" => auth_token } }
+
+      before { post end_of_journey_surveys_path, params:, headers:, as: :json }
+
+      it "saves Find a Framework feedback" do
+        expect(response).to have_http_status(:ok)
+        expect(EndOfJourneySurveyResponse.first.easy_to_use_rating).to eq("agree")
+        expect(EndOfJourneySurveyResponse.first.improvements).to eq("do better")
+        expect(EndOfJourneySurveyResponse.first.service).to eq("find_a_framework")
+      end
+    end
+  end
+
+  context "when the service is the Request For Help form" do
+    let(:service) { "request_for_help_form" }
+
+    before { post end_of_journey_surveys_path, params: }
+
+    it "saves Request For Help as the service" do
+      expect(EndOfJourneySurveyResponse.first.service).to eq("request_for_help_form")
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR
- add the `end_of_journey_survey_responses` table to store user feedback collected at the end of the RfH and FaF journeys
- allow JSON POST requests to come in from FaF and store user feedback