### PR TITLE
1894 - fix(cms): add ability to remove framework

### DIFF
--- a/app/javascript/controllers/framework_edit_controller.js
+++ b/app/javascript/controllers/framework_edit_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="framework-edit"
+export default class extends Controller {
+    static targets = [ "input", "output", "hidden" ]
+  
+    connect() {
+      if (this.hiddenTarget.value == "") {
+        this.hideClearFrameworkLink();
+      }
+      this.inputTarget.addEventListener("change", this.toggle.bind(this));
+    }
+
+    hideClearFrameworkLink() {
+      this.outputTarget.classList.add("govuk-!-display-none");
+      this.outputTarget.setAttribute("disabled", true);
+    }  
+
+    showClearFrameworkLink() {
+      this.outputTarget.classList.remove("govuk-!-display-none");
+      this.outputTarget.removeAttribute("disabled");
+    }
+  
+    toggle() {
+      if (this.hiddenTarget.value != null) {
+        this.showClearFrameworkLink();
+      }
+    }
+
+    clearFramework(e) {
+      e.preventDefault()
+      this.inputTarget.querySelector("#framework-autocomplete").value = "";
+      this.hiddenTarget.value = null;
+      this.hideClearFrameworkLink();
+    }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -58,6 +58,9 @@ application.register("error-summary", ErrorSummaryController)
 import ExpanderController from "./expander_controller"
 application.register("expander", ExpanderController)
 
+import FrameworkEditController from "./framework_edit_controller"
+application.register("framework-edit", FrameworkEditController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -1,4 +1,5 @@
-<div
+<div  
+  <%= tag.attributes defined?(element_html) ? element_html : nil %>
   id="<%= container_id %>"
   data-component="autocomplete"
   data-autocomplete-label-text="<%= label_text %>"
@@ -15,7 +16,7 @@
 
   <% if defined?(hidden_fields) %>
     <% hidden_fields.each do |field_name, key_or_key_and_default| %>
-      <input type="hidden" name="<%= field_name %>" value="<%= Array.wrap(key_or_key_and_default)[1] %>">
+      <input type="hidden" name="<%= field_name %>" value="<%= Array.wrap(key_or_key_and_default)[1] %>"<%= tag.attributes defined?(element_hidden_html) ? element_hidden_html : nil %>>
     <% end %>
   <% end %>
 </div>

--- a/app/views/support/cases/procurement_details/edit.html.erb
+++ b/app/views/support/cases/procurement_details/edit.html.erb
@@ -30,19 +30,26 @@
         </div>
       <% end %>
 
-      <%= render "components/autocomplete",
-              container_id: "case-procurement-details-form-framework-field",
-              label_text: I18n.t("support.procurement_details.edit.framework_name.header"),
-              label_class: "govuk-!-font-weight-bold govuk-!-font-size-24 govuk-!-margin-bottom-2",
-              element_id: "framework-autocomplete",
-              element_name: "case_procurement_details_form[framework_name]",
-              template_suggestion: "{{display_status}} <strong>{{reference_and_name}}</strong>, {{provider_name}}<br />{{category_names}}<br />Provider start: {{display_provider_start_date}}, Provider end: {{display_provider_end_date}}",
-              value_field: :reference_and_name,
-              default_value: form.object.framework_name,
-              hidden_fields: {
-                'case_procurement_details_form[frameworks_framework_id]' => [:id, form.object.frameworks_framework_id]
-              },
-              query_url: support_frameworks_path(format: :json, q: "{{QUERY}}") %>
+      <div data-controller="framework-edit" class="govuk-form-group">    
+          <%= render "components/autocomplete",
+                element_html: { "data-framework-edit-target" => "input" },
+                element_hidden_html: { "data-framework-edit-target" => "hidden" },
+                container_id: "case-procurement-details-form-framework-field",
+                label_text: I18n.t("support.procurement_details.edit.framework_name.header"),
+                label_class: "govuk-!-font-weight-bold govuk-!-font-size-24 govuk-!-margin-bottom-2",
+                element_id: "framework-autocomplete",
+                element_name: "case_procurement_details_form[framework_name]",
+                template_suggestion: "{{display_status}} <strong>{{reference_and_name}}</strong>, {{provider_name}}<br />{{category_names}}<br />Provider start: {{display_provider_start_date}}, Provider end: {{display_provider_end_date}}",
+                value_field: :reference_and_name,
+                default_value: form.object.framework_name,
+                hidden_fields: {
+                  'case_procurement_details_form[frameworks_framework_id]' => [:id, form.object.frameworks_framework_id]
+                },
+                query_url: support_frameworks_path(format: :json, q: "{{QUERY}}") %>
+          <a data-framework-edit-target="output" class="govuk-link govuk-link--no-visited-state" href="#" data-action="click->framework-edit#clearFramework">
+            Clear selected framework
+          </a>
+      </div>
 
       <%= form.govuk_date_field :started_at, legend: { text: I18n.t("support.procurement_details.edit.started_at.header") } %>
 

--- a/spec/features/support/procurement_details/edit_procurment_details_spec.rb
+++ b/spec/features/support/procurement_details/edit_procurment_details_spec.rb
@@ -3,6 +3,7 @@ RSpec.feature "Edit case procurement details" do
 
   let(:support_case) { create(:support_case, :opened, procurement: support_procurement) }
   let(:support_procurement) { create(:support_procurement, :blank) }
+  let(:framework) { create(:frameworks_framework, reference: "F123", short_name: "Example Framework") }
 
   before do
     visit edit_support_case_procurement_details_path(support_case)
@@ -43,6 +44,31 @@ RSpec.feature "Edit case procurement details" do
     within(all("div.govuk-form-group")[3]) do
       expect(find("label.govuk-label")).to have_text "Framework name"
       expect(page).to have_field "case_procurement_details_form[framework_name]"
+    end
+  end
+
+  context "when the framework dropdown does not contain a value", js: true do
+    it "does not have a clear framework link" do
+      within(all("div.govuk-form-group")[3]) do
+        expect(page).to have_css(".govuk-\\!-display-none")
+      end
+    end
+  end
+
+  context "when the framework dropdown contains a value", js: true do
+    let(:support_procurement) { create(:support_procurement, stage: :market_analysis, register_framework: framework) }
+
+    it "has a clear framework link, which removes the framework and link when clicked" do
+      within(all("div.govuk-form-group")[3]) do
+        expect(page).not_to have_css(".govuk-\\!-display-none", text: "Clear selected framework")
+      end
+
+      find("a.govuk-link", text: "Clear selected framework").click
+
+      within(all("div.govuk-form-group")[3]) do
+        expect(find("#framework-autocomplete")).to have_text ""
+        expect(page).to have_css(".govuk-\\!-display-none", text: "Clear selected framework")
+      end
     end
   end
 


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Ability to clear framework from case
- If there is no framework in the case then there is no clear framework link, if there is a framework then there is a clear framework link that removes the value, clears the box, and removes the clear framework link
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
![Screenshot 2024-02-14 at 09 54 29](https://github.com/DFE-Digital/buy-for-your-school/assets/77166906/7a313587-d8b2-422b-8641-5488b5452dc0)

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
