### PR TITLE
fix(cms): case request details without category

### DIFF
--- a/app/models/case_request.rb
+++ b/app/models/case_request.rb
@@ -35,7 +35,11 @@ class CaseRequest < ApplicationRecord
     result
   end
 
-  delegate :is_energy_or_services?, to: :category
+  def is_energy_or_services?
+    return false if category.nil?
+
+    category.is_energy_or_services?
+  end
 
 private
 


### PR DESCRIPTION
## Changes in this PR
- prevent the Request Details view from failing when a case request does not have a category - it may have a query instead