### PR TITLE
1170 - feat: change dash to no for accessibility requirements answer display

### DIFF
--- a/app/presenters/request_presenter.rb
+++ b/app/presenters/request_presenter.rb
@@ -10,7 +10,7 @@ class RequestPresenter < BasePresenter
 
   # return [String]
   def special_requirements
-    return "-" if super.blank?
+    return "No" if super.blank?
 
     super
   end

--- a/spec/features/specify/support_requests/edit_support_request_spec.rb
+++ b/spec/features/specify/support_requests/edit_support_request_spec.rb
@@ -317,7 +317,7 @@ RSpec.feature "Editing a 'Digital Support' request" do
       end
 
       it "updates the special requirements" do
-        expect(answers[7]).to have_text "-"
+        expect(answers[7]).to have_text "No"
         expect(support_request.reload.special_requirements).to eq ""
       end
     end

--- a/spec/presenters/self-serve/request_presenter_spec.rb
+++ b/spec/presenters/self-serve/request_presenter_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe RequestPresenter do
     context "when there are no special_requirements" do
       let(:support_request) { build(:support_request, special_requirements: nil) }
 
-      it "returns a dash" do
-        expect(presenter.special_requirements).to eq "-"
+      it "returns no" do
+        expect(presenter.special_requirements).to eq "No"
       end
     end
   end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Changes "-" to "No" for accessibility answer display for requests (/support-requests and /procurement-support)
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
<img width="691" alt="Screenshot 2024-03-21 at 15 54 49" src="https://github.com/DFE-Digital/buy-for-your-school/assets/77166906/56c5eea5-74b8-4e17-8ee9-293d4508bde9">

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
