### PR TITLE
pwnn-1952 fix(cms): filter panel substages in wrong order

### DIFF
--- a/app/helpers/support/filter_helper.rb
+++ b/app/helpers/support/filter_helper.rb
@@ -50,7 +50,7 @@ module Support
     def available_procurement_stages
       CheckboxOption
         .from(
-          Support::ProcurementStage.all.map { |s| Support::ProcurementStagePresenter.new(s) },
+          Support::ProcurementStage.all.by_lifecycle_order.map { |s| Support::ProcurementStagePresenter.new(s) },
           title_field: :detailed_title_short,
           include_all: true,
           include_unspecified: true,


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Reordered the ProcementStage substages within the ProcOps CMS filter panel, to be in lifecycle order

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
