### PR TITLE
pwnn-2018 - message bugs and performance issues

### DIFF
--- a/app/controllers/support/email_read_status_controller.rb
+++ b/app/controllers/support/email_read_status_controller.rb
@@ -18,7 +18,7 @@ module Support
   private
 
     def find_email
-      @email = Support::Email.find(params[:email_id])
+      @email = ::Email.find(params[:email_id])
     end
 
     def new_status

--- a/app/views/support/cases/message_threads/stream_events/_marked_as_read.turbo_stream.erb
+++ b/app/views/support/cases/message_threads/stream_events/_marked_as_read.turbo_stream.erb
@@ -2,6 +2,11 @@
   <%= render "support/cases/message_threads/message", message: %>
 <% end %>
 
-<%= turbo_stream.replace("action-flag") do %>
-  <%= render "support/cases/action_flag", badge: true if kase.action_required? && !kase.closed? %>
+<% if kase.action_required? && !kase.closed? %>
+  <%= turbo_stream.append("case-badges") do %>
+    <%= render "support/cases/action_flag", badge: true %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.remove("action-flag") do %>
+  <% end %>
 <% end %>

--- a/app/views/support/cases/show/_tabs.html.erb
+++ b/app/views/support/cases/show/_tabs.html.erb
@@ -11,7 +11,7 @@
 
 <%= turbo_stream_from "case_status_updates" %>
 
-<div class="flex-gap-5px govuk-!-margin-bottom-7">
+<div id="case-badges" class="flex-gap-5px govuk-!-margin-bottom-7">
   <%= render "support/cases/status_badge", state: @current_case.state %>
   <%= render "support/cases/with_school_badge" if @current_case.with_school %>
   <%= render "support/cases/accessibility_flag" if @current_case.has_special_requirements? %>

--- a/db/migrate/20240702145517_add_support_emails_indexes.rb
+++ b/db/migrate/20240702145517_add_support_emails_indexes.rb
@@ -1,0 +1,9 @@
+class AddSupportEmailsIndexes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :support_emails, %i[ticket_id ticket_type], algorithm: :concurrently
+    add_index :support_emails, %i[outlook_conversation_id sent_at], order: { sent_at: :desc }, algorithm: :concurrently
+    add_index :support_emails, %i[outlook_conversation_id ticket_id ticket_type], algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240703155237_add_support_email_attachments_indexes.rb
+++ b/db/migrate/20240703155237_add_support_email_attachments_indexes.rb
@@ -1,0 +1,7 @@
+class AddSupportEmailAttachmentsIndexes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :support_email_attachments, :email_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_145023) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_03_155237) do
   create_sequence "evaluation_refs"
   create_sequence "framework_refs"
 
@@ -661,6 +661,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_145023) do
     t.string "custom_name"
     t.string "description"
     t.boolean "hidden", default: false
+    t.index ["email_id"], name: "index_support_email_attachments_on_email_id"
   end
 
   create_table "support_email_template_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -731,7 +732,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_145023) do
     t.uuid "ticket_id"
     t.boolean "is_draft", default: false
     t.index ["in_reply_to_id"], name: "index_support_emails_on_in_reply_to_id"
+    t.index ["outlook_conversation_id", "sent_at"], name: "index_support_emails_on_outlook_conversation_id_and_sent_at", order: { sent_at: :desc }
+    t.index ["outlook_conversation_id", "ticket_id", "ticket_type"], name: "idx_on_outlook_conversation_id_ticket_id_ticket_typ_9df6d5a50e"
     t.index ["template_id"], name: "index_support_emails_on_template_id"
+    t.index ["ticket_id", "ticket_type"], name: "index_support_emails_on_ticket_id_and_ticket_type"
   end
 
   create_table "support_establishment_group_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/support/emails/agent_can_mark_email_as_read_spec.rb
+++ b/spec/features/support/emails/agent_can_mark_email_as_read_spec.rb
@@ -30,7 +30,7 @@ describe "Agent sees emails in messages", js: true do
     it "allows to mark the email as read" do
       click_link "Mark as read"
       sleep 0.5
-      expect(email.reload.is_read).to be(true)
+      expect(page).to have_css(".email-read-status", text: "Read")
     end
   end
 
@@ -44,7 +44,7 @@ describe "Agent sees emails in messages", js: true do
     it "allows to mark the email as unread" do
       click_link "Mark as unread"
       sleep 0.5
-      expect(email.reload.is_read).to be(false)
+      expect(page).to have_css(".email-read-status", text: "Unread")
     end
   end
 end


### PR DESCRIPTION
## Changes in this PR
### Performance issues

After trying out different combinations of indexes for the `support_emails` table and inspecting the query plan outputted by `EXPLAIN ANALYSE`, I've found that the Postgres planner seems to prefer the 3 indexes I've added to the schema.

Tested on local data only (significantly smaller number of rows than production), I see these reductions in **execution time**:
- for the`support_message_threads` view, down from ~180 ms to 15-20 ms
- for a query that fetches all the threads for a case with 35 threads and 64 emails (where `ticket_id` and `ticket_type` are specified in the `WHERE` clause), down from ~20 ms to ~1.5 ms
- for a query that fetches all the emails for a case with 64 emails (where `ticket_id` and `ticket_type` are specified in the `WHERE` clause), down from ~0.4 ms to ~0.1 ms

`support_email_attachments` also gets an index on `email_id`, which should speed up the loading of attachments when viewing an email. Postgres didn't seem to take advantage of multi-column indexes here, though we do use `hidden` and `is_inline` in our queries.

### Bugs

Fixed a bug where `turbo-stream` was not reloading messages to show their new read/unread status after clicking "Mark as read" or "Mark as unread" in a thread. This was due to the controller initialising the email as a `Support::Email` whereas the messages in the thread view are initialised as `Email`, thus resulting in a different ID when calling `dom_id` and preventing `turbo-stream` from locating the `div` for the relevant message.