### PR TITLE
1980 - ci: add data regression testing jobs

### DIFF
--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -350,3 +350,48 @@ jobs:
           az_credentials: ${{ secrets.AZURE_SP_CREDENTIALS }}
           container_app_name: ${{ secrets.CONTAINER_APP_NAME }}
           resource_group_name: ${{ secrets.RESOURCE_GROUP_NAME }}
+
+  data_regression_copy_to_original:
+    name: Data regression testing - trigger copy to pre-release-original-data
+    needs: release_production
+    runs-on: ubuntu-20.04
+    environment: az-production
+
+    steps:
+      - uses: Azure/pipelines@v1.2
+        with:
+          azure-devops-project-url: "https://dfe-ssp.visualstudio.com/S174-Get%20Help%20Buying%20for%20Schools"
+          azure-pipeline-name: "Pre-release Original Data sync"
+          azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+
+  data_regression_copy_to_modified:
+    name: Data regression testing - trigger copy to pre-release-modified-data
+    needs: release_production
+    runs-on: ubuntu-20.04
+    environment: az-production
+
+    steps:
+      - uses: Azure/pipelines@v1.2
+        with:
+          azure-devops-project-url: "https://dfe-ssp.visualstudio.com/S174-Get%20Help%20Buying%20for%20Schools"
+          azure-pipeline-name: "Pre-release Modified Data sync"
+          azure-devops-token: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+
+  data_regression_migrate_modified:
+    name: Data regression testing - apply migrations to pre-release-modified-data
+    needs: release_staging
+    runs-on: ubuntu-20.04
+    environment: az-staging
+    env:
+      PRE_RELEASE_MODIFIED_DATA_DB_URL: ${{ secrets.PRE_RELEASE_MODIFIED_DATA_DB_URL }}
+
+    steps:
+      - name: Run migrations against pre-release-modified-data
+        run: |
+          docker run --rm \
+            -e RAILS_ENV=production \
+            -e DATABASE_URL=${{ env.PRE_RELEASE_MODIFIED_DATA_DB_URL }} \
+            -e DOCKER=true \
+            -e SECRET_KEY_BASE=production \
+            ${{ needs.build_test.outputs.docker_image }} \
+            bash -c "bundle exec rails db:migrate"      


### PR DESCRIPTION
## Changes in this PR
### New CI pipeline jobs
Added 3 new jobs to the CI/CD - Full Pipeline:
1. **Data regression testing - trigger copy to pre-release-original-data**
This triggers the "Pre-release Original Data sync" pipeline in Azure DevOps to apply a copy of the production database to the `pre_release_original_data` database in the production Postgres reporting server upon successful deployment to production.
2. **Data regression testing - trigger copy to pre-release-modified-data**
This triggers the "Pre-release Modified Data sync" pipeline in Azure DevOps to apply a copy of the production database to the `pre_release_modified_data` database in the production Postgres reporting server upon successful deployment to production.
3. **Data regression testing - apply migrations to pre-release-modified-data**
This runs the database migrations against the `pre_release_modified_data` database in the production Postgres reporting server upon successful deployment to staging.
### New secrets
`AZURE_DEVOPS_TOKEN` - a personal access token (PAT) used to access Azure DevOps and trigger pipelines from GitHub Actions.
`PRE_RELEASE_MODIFIED_DATA_DB_URL` - Postgres URL for the `pre_release_modified_data` database.