### PR TITLE
1980 - ci: update data regression job dependencies

### DIFF
--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -377,7 +377,7 @@ jobs:
 
   data_regression_migrate_modified:
     name: Data regression testing - apply migrations to pre-release-modified-data
-    needs: release_staging
+    needs: [build_release, release_staging]
     runs-on: ubuntu-20.04
     env:
       PRE_RELEASE_MODIFIED_DATA_DB_URL: ${{ secrets.PRE_RELEASE_MODIFIED_DATA_DB_URL }}


### PR DESCRIPTION
## Changes in this PR
- Updated the dependencies for job `data_regression_migrate_modified` to include `build_release` so that we can access the release Docker image.