### PR TITLE
1980 - ci: set prod url on data regression env

### DIFF
--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -390,5 +390,6 @@ jobs:
             -e DATABASE_URL=${{ env.PRE_RELEASE_MODIFIED_DATA_DB_URL }} \
             -e DOCKER=true \
             -e SECRET_KEY_BASE=production \
+            -e APPLICATION_URL=https://www.get-help-buying-for-schools.service.gov.uk \
             ${{ needs.build_release.outputs.docker_image }} \
             bash -c "bundle exec rails db:migrate"      


### PR DESCRIPTION
## Changes in this PR
- Add `APPLICATION_URL` and set it to the production URL on the data_regression_migrate_modified job. This is to ensure that migrations only meant for certain environments (ones that check `APPLICATION_URL`) are executed when needed. We will want production migrations to be applied to `pre-release-modified-data`.