### PR TITLE
build: downgrade node from 22.5.0 to 22.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN npm install --global yarn
 # ------------------------------------------------------------------------------
 # Assets
 # ------------------------------------------------------------------------------
-FROM node:alpine as assets
+FROM node:22.4.1-alpine as assets
 
 ENV NODE_ENV ${NODE_ENV:-production}
 


### PR DESCRIPTION
## Changes in this PR
- Specified Node version 22.4.1 in Dockerfile after build failures related to `node:alpine` being upgraded to 22.5.0.