### PR TITLE
feat(crm): scrolling the main page where last filter was select

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -73,6 +73,9 @@ application.register("school-picker", SchoolPickerController)
 import SchoolPickerFiltersController from "./school_picker_filters_controller"
 application.register("school-picker-filters", SchoolPickerFiltersController)
 
+import ScrollController from "./scroll_controller"
+application.register("scroll", ScrollController)
+
 import SelectOptionFilterController from "./select_option_filter_controller"
 application.register("select-option-filter", SelectOptionFilterController)
 

--- a/app/javascript/controllers/scroll_controller.js
+++ b/app/javascript/controllers/scroll_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["status", "subCategory", "assignee", "stage", "level"]
+
+  saveScrollPosition(event) {
+    localStorage.setItem('scrollPosition', window.scrollY);
+
+    this.constructor.targets.forEach(target => {
+      if (this[`has${this.capitalize(target)}Target`]) {
+        const content = this[`${target}Target`]?.querySelector('.expander__content');
+        if (content) {
+          localStorage.setItem(`${target}ScrollPosition`, content.scrollTop);
+        }
+      }
+    });
+  }
+  
+  connect() {
+    setTimeout(() => {
+      const savedScrollPosition = localStorage.getItem('scrollPosition');
+      if (savedScrollPosition) {
+        window.scrollTo(0, parseInt(savedScrollPosition, 10));
+      }
+
+      this.constructor.targets.forEach(target => {
+        if (this[`has${this.capitalize(target)}Target`]) {
+          const content = this[`${target}Target`]?.querySelector('.expander__content');
+          const savedScrollPosition = localStorage.getItem(`${target}ScrollPosition`);
+          if (content && savedScrollPosition) {
+            content.scrollTo(0, parseInt(savedScrollPosition, 10));
+          }
+        }
+      });
+    }, 100); // 100ms delay to ensure DOM is fully loaded
+  }
+
+  capitalize(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  }
+}

--- a/app/views/support/cases/case_list/_filters.html.erb
+++ b/app/views/support/cases/case_list/_filters.html.erb
@@ -1,27 +1,28 @@
-<div class="filters-panel">
+<div class="filters-panel" data-controller="scroll">
   <h2 class="govuk-heading-m"><%= I18n.t("support.case.label.filters") %></h2>
 
-  <%= form_with model: filter_form, scope: filter_form_scope, id: :case_filters, method: :get, url: filter_url, html: { "data-controller" => "case-filters" } do |form| %>
-    <%= link_to I18n.t("support.case.filter.buttons.clear"), clear_url, class: "govuk-button govuk-button--secondary", role: "button" %>
+  <%= form_with model: filter_form, scope: filter_form_scope, id: :case_filters, method: :get, url: filter_url, html: { "data-controller" => "case-filters", "data-action" => "submit->scroll#saveScrollPosition" } do |form| %>
+    <%= link_to I18n.t("support.case.filter.buttons.clear"), clear_url, class: "govuk-button govuk-button--secondary", role: "button", "data-action" => "click->scroll#saveScrollPosition" %>
 
     <%= form.govuk_select :sort_by,
         options_for_select(available_sort_options, filter_form.sort_by),
-        label: { text: I18n.t("support.case.label.sort_by"), size: "s" } %>
+        label: { text: I18n.t("support.case.label.sort_by"), size: "s" }, html_options: { "data-action" => "change->scroll#saveScrollPosition" } %>
     
     <%= form.govuk_collection_radio_buttons :sort_order,
         available_sort_orders,
         :id,
         :title,
         legend: nil,
-        small: true %>
+        small: true, html_options: { "data-action" => "change->scroll#saveScrollPosition" } %>
     
     <% unless tab == "new-cases" %>
       <%= expander title: I18n.t("support.case.label.status"),
                   subtitle: I18n.t("support.case.filter.labels.selected", count: Array(form.object.state).length),
-                  expanded: true do %>
+                  expanded: true, html: { "data-scroll-target" => "status" } do %>
         <%= form.govuk_check_boxes_fieldset :state, legend: nil, small: true, form_group: { class: "govuk-!-margin-bottom-0" } do %>
           <% available_states.each do |state| %>
-            <%= form.govuk_check_box :state, state.id, exclusive: state.exclusive, label: { text: state.title } %>
+            <%= form.govuk_check_box :state, state.id, exclusive: state.exclusive, label: { text: state.title }, 
+              html_options: { "data-action" => "change->scroll#saveScrollPosition click->scroll#setScrollTarget" } %>
           <% end %>
         <% end %>
       <% end %>
@@ -29,10 +30,11 @@
 
     <%= expander title: I18n.t("support.case.label.sub_category"),
                  subtitle: I18n.t("support.case.filter.labels.selected", count: Array(form.object.category).length),
-                 expanded: true do %>
+                 expanded: true, html: { "data-scroll-target" => "subCategory" } do %>
       <%= form.govuk_check_boxes_fieldset :category, legend: nil, small: true, form_group: { class: "govuk-!-margin-bottom-0" } do %>
         <% available_categories(form.object.tower).each do |category| %>
-          <%= form.govuk_check_box :category, category.id, exclusive: category.exclusive, label: { text: category.title } %>
+          <%= form.govuk_check_box :category, category.id, exclusive: category.exclusive, label: { text: category.title },
+            html_options: { "data-action" => "change->scroll#saveScrollPosition click->scroll#setScrollTarget" } %>
         <% end %>
       <% end %>
     <% end %>
@@ -40,10 +42,11 @@
     <% unless tab == "my-cases" %>
       <%= expander title: I18n.t("support.case.label.assignee"),
                   subtitle: I18n.t("support.case.filter.labels.selected", count: Array(form.object.agent).length),
-                  expanded: true do %>
+                  expanded: true, html: { "data-scroll-target" => "assignee" } do %>
         <%= form.govuk_check_boxes_fieldset :agent, legend: nil, small: true, form_group: { class: "govuk-!-margin-bottom-0" } do %>
           <% available_agents.each do |agent| %>
-            <%= form.govuk_check_box :agent, agent.id, exclusive: agent.exclusive, label: { text: agent.title } %>
+            <%= form.govuk_check_box :agent, agent.id, exclusive: agent.exclusive, label: { text: agent.title },
+              html_options: { "data-action" => "change->scroll#saveScrollPosition click->scroll#setScrollTarget" } %>
           <% end %>
         <% end %>
       <% end %>
@@ -51,20 +54,22 @@
 
     <%= expander title: I18n.t("support.case.label.stage"),
                  subtitle: I18n.t("support.case.filter.labels.selected", count: Array(form.object.procurement_stage).length),
-                 expanded: true do %>
+                 expanded: true, html: { "data-scroll-target" => "stage" } do %>
       <%= form.govuk_check_boxes_fieldset :procurement_stage, legend: nil, small: true, form_group: { class: "govuk-!-margin-bottom-0" } do %>
         <% available_procurement_stages.each do |stage| %>
-          <%= form.govuk_check_box :procurement_stage, stage.id, exclusive: stage.exclusive, label: { text: stage.title } %>
+          <%= form.govuk_check_box :procurement_stage, stage.id, exclusive: stage.exclusive, label: { text: stage.title },
+            html_options: { "data-action" => "change->scroll#saveScrollPosition click->scroll#setScrollTarget" } %>
         <% end %>
       <% end %>
     <% end %>
 
     <%= expander title: I18n.t("support.case.label.level"),
                  subtitle: I18n.t("support.case.filter.labels.selected", count: Array(form.object.level).length),
-                 expanded: true do %>
+                 expanded: true, html: { "data-scroll-target" => "level" } do %>
       <%= form.govuk_check_boxes_fieldset :level, legend: nil, small: true, form_group: { class: "govuk-!-margin-bottom-0" } do %>
         <% available_levels.each do |level| %>
-          <%= form.govuk_check_box :level, level.id, exclusive: level.exclusive, label: { text: level.title } %>
+          <%= form.govuk_check_box :level, level.id, exclusive: level.exclusive, label: { text: level.title },
+            html_options: { "data-action" => "change->scroll#saveScrollPosition click->scroll#setScrollTarget" } %>
         <% end %>
       <% end %>
     <% end %>


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
scroll on the last clicked filter upon reloading
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
