### PR TITLE
Remove broken attempt to find hostname on Linux

### DIFF
--- a/spec/support/capybara_driver_helper.rb
+++ b/spec/support/capybara_driver_helper.rb
@@ -29,12 +29,8 @@ Capybara.configure do |config|
   Capybara.app_host = "http://www.example.com:3000"
   Capybara.asset_host = "http://www.example.com"
 
-  config.server_host = ENV.fetch("CAPYBARA_SERVER_HOST") do
-    if RUBY_PLATFORM.match?(/linux/)
-      `/sbin/ip route|awk '/scope/ { print $9 }'`.chomp
-    else
-      "127.0.0.1"
-    end
+  if ENV.key?("CAPYBARA_SERVER_HOST")
+    config.server_host = ENV.fetch("CAPYBARA_SERVER_HOST")
   end
 end
 


### PR DESCRIPTION
This snippet didn't work on Linux, at least for me: instead of returning a hostname, the shell snippet returned multiple lines which could not be resolved.

Hypothesis: the default behaviour of not specifying the Capybara host will result in a sensible default of localhost. By setting `server_host` iff the environment variable is set, we can fall back to Capybara's reasonable default.

## Changes in this PR

Removes the shell snippet used to find the Capybara hostname on Linux and the `127.0.0.1` used otherwise, and does not configure `server_host` at all unless explicitly set via the `CAPYBARA_SERVER_HOST` environment variable. As Capybara starts the server, it does not usually need help to find it.