### PR TITLE
2025 - feat(cms): add proposed open and closed status and date to establishm…

### DIFF
--- a/app/models/support/establishment_search.rb
+++ b/app/models/support/establishment_search.rb
@@ -2,6 +2,8 @@ module Support
   class EstablishmentSearch < ApplicationRecord
     include Presentable
 
+    enum :organisation_status, Organisation.statuses, prefix: :organisation
+
     scope :omnisearch, lambda { |query|
       sql = <<-SQL
         urn LIKE :q OR

--- a/app/models/support/establishment_search/presentable.rb
+++ b/app/models/support/establishment_search/presentable.rb
@@ -10,7 +10,17 @@ private
   def autocomplete_template_vars
     case source
     when "LocalAuthority" then { name:, establishment_type:, code: }
-    else { name:, postcode:, establishment_type:, urn:, ukprn: }
+    else { name:, postcode:, establishment_type:, proposed_open_or_closed:, urn:, ukprn: }
+    end
+  end
+
+  def proposed_open_or_closed
+    case organisation_status
+    when "opening"
+      I18n.t(organisation_status, scope: "support.organisation_statuses", date: I18n.l(opened_date, format: :compact))
+    when "closing"
+      I18n.t(organisation_status, scope: "support.organisation_statuses", date: I18n.l(closed_date, format: :compact))
+    else ""
     end
   end
 end

--- a/app/views/support/establishment_search/support/organisation/_autocomplete_template.html.erb
+++ b/app/views/support/establishment_search/support/organisation/_autocomplete_template.html.erb
@@ -1,1 +1,6 @@
-<strong><%= name %></strong>, <%= postcode %><br /><%= establishment_type %><br />URN: <%= urn %> - UKPRN: <%= ukprn %>
+<%= safe_join([
+  "<strong>#{h(name)}</strong>, #{h(postcode)}".html_safe,
+  establishment_type,
+  proposed_open_or_closed,
+  "URN: #{urn} - UKPRN: #{ukprn}"
+].compact_blank, "<br />".html_safe) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,14 @@ en:
       x_years:
         one: "%{count} year"
         other: "%{count} years"
+  date:
+    formats:
+      compact: "%d %b %y"
+      default: "%-d %b %Y"
+      presenter: "%e %B %Y"
+  time:
+    formats:
+      compact: "%d %b %y"   
   admin:
     activity_log_header: Activity log
     body:
@@ -169,11 +177,7 @@ en:
     existing:
       body: Continue with a draft specification, and review completed specifications.
       header: Existing specifications
-    header: Specifications dashboard
-  date:
-    formats:
-      default: "%-d %b %Y"
-      presenter: "%e %B %Y"
+    header: Specifications dashboard 
   design:
     category_selection_header: Choose a category
     not_found: No categories found
@@ -1980,6 +1984,11 @@ en:
         header: Select all roles applicable to this individual
       organisation:
         header: Organisation (optional)
+    organisation_statuses:
+      opened: Open
+      closing: Open, but proposed to close %{date}
+      opening: Proposed to open %{date}
+      closed: Closed
 
   support_request:
     button:

--- a/db/migrate/20241016093636_update_support_establishment_searches_to_version_4.rb
+++ b/db/migrate/20241016093636_update_support_establishment_searches_to_version_4.rb
@@ -1,0 +1,15 @@
+class UpdateSupportEstablishmentSearchesToVersion4 < ActiveRecord::Migration[7.1]
+  def up
+    replace_view :support_establishment_searches, version: 4, revert_to_version: 3
+  end
+
+  def down
+    drop_view :ticket_searches
+    drop_view :support_case_searches
+    drop_view :support_establishment_searches
+
+    create_view :support_establishment_searches, version: 3
+    create_view :support_case_searches, version: 4
+    create_view :ticket_searches, version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_04_084539) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_16_093636) do
   create_sequence "evaluation_refs"
   create_sequence "framework_refs"
 
@@ -1076,60 +1076,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_04_084539) do
   add_foreign_key "user_journeys", "framework_requests"
   add_foreign_key "user_journeys", "support_cases", column: "case_id"
 
-  create_view "support_establishment_searches", sql_definition: <<-SQL
-      SELECT organisations.id,
-      organisations.name,
-      (organisations.address ->> 'postcode'::text) AS postcode,
-      organisations.urn,
-      organisations.ukprn,
-      etypes.name AS establishment_type,
-      'Support::Organisation'::text AS source,
-      NULL::text AS code
-     FROM (support_organisations organisations
-       JOIN support_establishment_types etypes ON ((etypes.id = organisations.establishment_type_id)))
-    WHERE (organisations.status <> 2)
-  UNION ALL
-   SELECT egroups.id,
-      egroups.name,
-      (egroups.address ->> 'postcode'::text) AS postcode,
-      NULL::character varying AS urn,
-      egroups.ukprn,
-      egtypes.name AS establishment_type,
-      'Support::EstablishmentGroup'::text AS source,
-      NULL::text AS code
-     FROM (support_establishment_groups egroups
-       JOIN support_establishment_group_types egtypes ON ((egtypes.id = egroups.establishment_group_type_id)))
-    WHERE (egroups.status <> 2)
-  UNION ALL
-   SELECT local_authorities.id,
-      local_authorities.name,
-      NULL::text AS postcode,
-      NULL::character varying AS urn,
-      NULL::character varying AS ukprn,
-      'Local authority'::character varying AS establishment_type,
-      'LocalAuthority'::text AS source,
-      local_authorities.la_code AS code
-     FROM local_authorities;
-  SQL
-  create_view "support_case_searches", sql_definition: <<-SQL
-      SELECT sc.id AS case_id,
-      sc.ref AS case_ref,
-      sc.created_at,
-      sc.updated_at,
-      sc.state AS case_state,
-      sc.email AS case_email,
-      ses.name AS organisation_name,
-      ses.urn AS organisation_urn,
-      ses.ukprn AS organisation_ukprn,
-      (((sa.first_name)::text || ' '::text) || (sa.last_name)::text) AS agent_name,
-      sa.first_name AS agent_first_name,
-      sa.last_name AS agent_last_name,
-      cat.title AS category_title
-     FROM (((support_cases sc
-       LEFT JOIN support_agents sa ON ((sa.id = sc.agent_id)))
-       LEFT JOIN support_establishment_searches ses ON (((sc.organisation_id = ses.id) AND ((sc.organisation_type)::text = ses.source))))
-       LEFT JOIN support_categories cat ON ((sc.category_id = cat.id)));
-  SQL
   create_view "support_message_threads", sql_definition: <<-SQL
       SELECT DISTINCT ON (se.outlook_conversation_id, se.ticket_id) se.outlook_conversation_id AS conversation_id,
       se.case_id,
@@ -1146,40 +1092,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_04_084539) do
             ORDER BY se2.sent_at DESC
            LIMIT 1) AS last_updated
      FROM support_emails se;
-  SQL
-  create_view "ticket_searches", sql_definition: <<-SQL
-      SELECT scs.case_id AS id,
-      scs.case_ref AS reference,
-      scs.organisation_name,
-      scs.organisation_urn,
-      scs.organisation_ukprn,
-      NULL::character varying AS framework_name,
-      NULL::character varying AS framework_provider,
-      scs.agent_name,
-      scs.agent_first_name,
-      scs.agent_last_name,
-      scs.created_at,
-      scs.updated_at,
-      'Support::Case'::text AS source
-     FROM support_case_searches scs
-  UNION ALL
-   SELECT fe.id,
-      fe.reference,
-      NULL::character varying AS organisation_name,
-      NULL::character varying AS organisation_urn,
-      NULL::character varying AS organisation_ukprn,
-      ff.name AS framework_name,
-      fp.short_name AS framework_provider,
-      (((sa.first_name)::text || ' '::text) || (sa.last_name)::text) AS agent_name,
-      sa.first_name AS agent_first_name,
-      sa.last_name AS agent_last_name,
-      fe.created_at,
-      fe.updated_at,
-      'Frameworks::Evaluation'::text AS source
-     FROM (((frameworks_evaluations fe
-       LEFT JOIN frameworks_frameworks ff ON ((ff.id = fe.framework_id)))
-       LEFT JOIN frameworks_providers fp ON ((fp.id = ff.provider_id)))
-       LEFT JOIN support_agents sa ON ((sa.id = fe.assignee_id)));
   SQL
   create_view "frameworks_framework_data", sql_definition: <<-SQL
       SELECT ff.id AS framework_id,
@@ -1440,5 +1352,104 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_04_084539) do
             WHERE ((i.event_type = 8) AND (i.case_id = sc.id))
             ORDER BY i.created_at
            LIMIT 1))));
+  SQL
+  create_view "support_establishment_searches", sql_definition: <<-SQL
+      SELECT organisations.id,
+      organisations.name,
+      (organisations.address ->> 'postcode'::text) AS postcode,
+      organisations.urn,
+      organisations.ukprn,
+      etypes.name AS establishment_type,
+      'Support::Organisation'::text AS source,
+      NULL::text AS code,
+      organisations.status AS organisation_status,
+      organisations.opened_date,
+      organisations.closed_date
+     FROM (support_organisations organisations
+       JOIN support_establishment_types etypes ON ((etypes.id = organisations.establishment_type_id)))
+    WHERE ((organisations.status <> 2) AND (organisations.archived IS NOT TRUE))
+  UNION ALL
+   SELECT egroups.id,
+      egroups.name,
+      (egroups.address ->> 'postcode'::text) AS postcode,
+      NULL::character varying AS urn,
+      egroups.ukprn,
+      egtypes.name AS establishment_type,
+      'Support::EstablishmentGroup'::text AS source,
+      NULL::text AS code,
+      NULL::integer AS organisation_status,
+      egroups.opened_date,
+      egroups.closed_date
+     FROM (support_establishment_groups egroups
+       JOIN support_establishment_group_types egtypes ON ((egtypes.id = egroups.establishment_group_type_id)))
+    WHERE ((egroups.status <> 2) AND (egroups.archived IS NOT TRUE))
+  UNION ALL
+   SELECT local_authorities.id,
+      local_authorities.name,
+      NULL::text AS postcode,
+      NULL::character varying AS urn,
+      NULL::character varying AS ukprn,
+      'Local authority'::character varying AS establishment_type,
+      'LocalAuthority'::text AS source,
+      local_authorities.la_code AS code,
+      NULL::integer AS organisation_status,
+      NULL::timestamp without time zone AS opened_date,
+      NULL::date AS closed_date
+     FROM local_authorities
+    WHERE (local_authorities.archived IS NOT TRUE)
+    ORDER BY 9;
+  SQL
+  create_view "support_case_searches", sql_definition: <<-SQL
+      SELECT sc.id AS case_id,
+      sc.ref AS case_ref,
+      sc.created_at,
+      sc.updated_at,
+      sc.state AS case_state,
+      sc.email AS case_email,
+      ses.name AS organisation_name,
+      ses.urn AS organisation_urn,
+      ses.ukprn AS organisation_ukprn,
+      (((sa.first_name)::text || ' '::text) || (sa.last_name)::text) AS agent_name,
+      sa.first_name AS agent_first_name,
+      sa.last_name AS agent_last_name,
+      cat.title AS category_title
+     FROM (((support_cases sc
+       LEFT JOIN support_agents sa ON ((sa.id = sc.agent_id)))
+       LEFT JOIN support_establishment_searches ses ON (((sc.organisation_id = ses.id) AND ((sc.organisation_type)::text = ses.source))))
+       LEFT JOIN support_categories cat ON ((sc.category_id = cat.id)));
+  SQL
+  create_view "ticket_searches", sql_definition: <<-SQL
+      SELECT scs.case_id AS id,
+      scs.case_ref AS reference,
+      scs.organisation_name,
+      scs.organisation_urn,
+      scs.organisation_ukprn,
+      NULL::character varying AS framework_name,
+      NULL::character varying AS framework_provider,
+      scs.agent_name,
+      scs.agent_first_name,
+      scs.agent_last_name,
+      scs.created_at,
+      scs.updated_at,
+      'Support::Case'::text AS source
+     FROM support_case_searches scs
+  UNION ALL
+   SELECT fe.id,
+      fe.reference,
+      NULL::character varying AS organisation_name,
+      NULL::character varying AS organisation_urn,
+      NULL::character varying AS organisation_ukprn,
+      ff.name AS framework_name,
+      fp.short_name AS framework_provider,
+      (((sa.first_name)::text || ' '::text) || (sa.last_name)::text) AS agent_name,
+      sa.first_name AS agent_first_name,
+      sa.last_name AS agent_last_name,
+      fe.created_at,
+      fe.updated_at,
+      'Frameworks::Evaluation'::text AS source
+     FROM (((frameworks_evaluations fe
+       LEFT JOIN frameworks_frameworks ff ON ((ff.id = fe.framework_id)))
+       LEFT JOIN frameworks_providers fp ON ((fp.id = ff.provider_id)))
+       LEFT JOIN support_agents sa ON ((sa.id = fe.assignee_id)));
   SQL
 end

--- a/db/views/support_establishment_searches_v04.sql
+++ b/db/views/support_establishment_searches_v04.sql
@@ -1,0 +1,51 @@
+SELECT
+organisations.id,
+organisations.name,
+organisations.address->>'postcode' as postcode,
+organisations.urn,
+organisations.ukprn,
+etypes.name as establishment_type,
+'Support::Organisation' as source,
+NULL as code,
+organisations.status as organisation_status,
+organisations.opened_date,
+organisations.closed_date
+FROM support_organisations organisations
+JOIN support_establishment_types etypes
+  ON etypes.id = organisations.establishment_type_id
+WHERE organisations.status != 2
+AND organisations.archived IS NOT TRUE
+UNION ALL
+SELECT
+egroups.id,
+egroups.name,
+egroups.address->>'postcode' as postcode,
+NULL as urn,
+egroups.ukprn,
+egtypes.name as establishment_type,
+'Support::EstablishmentGroup' as source,
+NULL as code,
+NULL as organisation_status,
+egroups.opened_date,
+egroups.closed_date
+FROM support_establishment_groups egroups
+JOIN support_establishment_group_types egtypes
+  ON egtypes.id = egroups.establishment_group_type_id
+WHERE egroups.status != 2
+AND egroups.archived IS NOT TRUE
+UNION ALL
+SELECT
+local_authorities.id,
+local_authorities.name,
+NULL AS postcode,
+NULL AS urn,
+NULL AS ukprn,
+'Local authority' AS establishment_type,
+'LocalAuthority' as source,
+local_authorities.la_code AS code,
+NULL AS organisation_status,
+NULL AS opened_date,
+NULL AS closed_date
+FROM local_authorities
+WHERE local_authorities.archived IS NOT TRUE
+ORDER BY organisation_status ASC

--- a/spec/models/support/establishment_search/presentable_spec.rb
+++ b/spec/models/support/establishment_search/presentable_spec.rb
@@ -3,27 +3,43 @@ require "rails_helper"
 describe Support::EstablishmentSearch::Presentable do
   subject(:presentable) { Support::EstablishmentSearch }
 
-  let!(:school) { create(:support_organisation, :with_address, name: "Test Primary School", urn: "1", ukprn: "123", establishment_type: create(:support_establishment_type, name: "Community school")) }
+  let!(:opening_school) { create(:support_organisation, :with_address, name: "Test Opening School", urn: "3", ukprn: "333", status: 4, opened_date: "2024-07-30", establishment_type: create(:support_establishment_type, name: "Foundation school")) }
+  let!(:closing_school) { create(:support_organisation, :with_address, name: "Test Closing School", urn: "2", ukprn: "222", status: 3, opened_date: "2000-08-30", closed_date: "2024-08-30", establishment_type: create(:support_establishment_type, name: "Academy sponsor led")) }
+  let!(:open_school) { create(:support_organisation, :with_address, name: "Test Primary School", urn: "1", ukprn: "123", status: 1, opened_date: "2000-09-30", establishment_type: create(:support_establishment_type, name: "Community school")) }
   let!(:group) { create(:support_establishment_group, :with_address, name: "Test MAT", uid: "2", ukprn: "456", establishment_group_type: create(:support_establishment_group_type, name: "Multi-academy Trust")) }
   let!(:local_authority) { create(:local_authority, name: "Camden", la_code: "3") }
 
   describe "#autocomplete_template" do
-    context "when the search result is a school" do
-      it "returns the correct autocomplete template" do
-        search_result = presentable.omnisearch(school.urn).to_a.first
-        expect(search_result.autocomplete_template).to eq("<strong>Test Primary School</strong>, EC3A 5DE<br />Community school<br />URN: 1 - UKPRN: 123\n")
+    context "when the search result is an opening school with a date" do
+      it "returns an autocomplete template with the name, postcode, school type, status, open date, urn and ukprn" do
+        search_result = presentable.omnisearch(opening_school.urn).to_a.first
+        expect(search_result.autocomplete_template).to eq("<strong>Test Opening School</strong>, EC3A 5DE<br />Foundation school<br />Proposed to open 30 Jul 24<br />URN: 3 - UKPRN: 333")
+      end
+    end
+
+    context "when the search result is a closing school with a date" do
+      it "returns an autocomplete template with the name, postcode, school type, status, closed date, urn and ukprn" do
+        search_result = presentable.omnisearch(closing_school.urn).to_a.first
+        expect(search_result.autocomplete_template).to eq("<strong>Test Closing School</strong>, EC3A 5DE<br />Academy sponsor led<br />Open, but proposed to close 30 Aug 24<br />URN: 2 - UKPRN: 222")
+      end
+    end
+
+    context "when the search result is an open school" do
+      it "returns an autocomplete template with the name, postcode, school type, urn and ukprn" do
+        search_result = presentable.omnisearch(open_school.urn).to_a.first
+        expect(search_result.autocomplete_template).to eq("<strong>Test Primary School</strong>, EC3A 5DE<br />Community school<br />URN: 1 - UKPRN: 123")
       end
     end
 
     context "when the search result is a group" do
-      it "returns the correct autocomplete template" do
+      it "returns an autocomplete template with the name, postcode, group type, urn and ukprn" do
         search_result = presentable.omnisearch(group.name).to_a.first
         expect(search_result.autocomplete_template).to eq("<strong>Test MAT</strong>, EC1M 6HR<br />Multi-academy Trust<br />URN:  - UKPRN: 456\n")
       end
     end
 
     context "when the search result is a local authority" do
-      it "returns the correct autocomplete template" do
+      it "returns an autocomplete template with the name, org type (Local Authority) and LA code" do
         search_result = presentable.omnisearch(local_authority.name).to_a.first
         expect(search_result.autocomplete_template).to eq("<strong>Camden</strong><br />Local authority<br />Code: 3\n")
       end

--- a/spec/models/support/establishment_search_spec.rb
+++ b/spec/models/support/establishment_search_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe Support::EstablishmentSearch do
+  before do
+    create(:support_organisation, :with_address, name: "Test Opening School", urn: "1231", ukprn: "5", status: 4)
+    create(:support_organisation, :with_address, name: "Test Closed School", urn: "1232", ukprn: "6", status: 2)
+    create(:support_organisation, :with_address, name: "Test Open School", urn: "1233", ukprn: "7", status: 1)
+    create(:support_organisation, :with_address, name: "Test Archived School", urn: "1234", ukprn: "7", status: 1, archived: true)
+    create(:support_establishment_group, :with_address, name: "Test MAT", uid: "1", ukprn: "8")
+    create(:local_authority, name: "Camden", la_code: "456")
+  end
+
+  describe "establishment search" do
+    context "when searching for an establishment by name" do
+      it "returns establishments that contain the same string and are not closed or archived" do
+        results = described_class.omnisearch("Tes")
+        expect(results.count).to eq(3)
+        expect(results.pluck(:name)).to contain_exactly("Test Opening School", "Test Open School", "Test MAT")
+      end
+    end
+
+    context "when searching for an establishment by urn" do
+      it "returns establishments that contain the same urn string and are not closed or archived" do
+        results = described_class.omnisearch("123")
+        expect(results.count).to eq(2)
+        expect(results.pluck(:name)).to contain_exactly("Test Opening School", "Test Open School")
+      end
+    end
+
+    context "when searching for an establishment by code" do
+      it "returns establishments that contain the same string and are not closed or archived" do
+        results = described_class.omnisearch("456")
+        expect(results.count).to eq(1)
+        expect(results.pluck(:name)).to contain_exactly("Camden")
+      end
+    end
+
+    context "when searching for an establishment by postcode" do
+      it "returns establishments that contain the same string and are not closed or archived" do
+        results = described_class.omnisearch("EC3A 5DE") # postcode from organisation with_address trait
+        expect(results.count).to eq(2)
+        expect(results.pluck(:name)).to contain_exactly("Test Opening School", "Test Open School")
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Adds proposed to open and proposed to close status to the organisation drop down alongside the open/closed date if there is one
- Excludes archived records from being shown
- Orders by organisation status
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
![Screenshot 2024-10-28 at 12 01 09](https://github.com/user-attachments/assets/71a5abea-d0d9-4e93-a074-40723beacbc0)

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
