### PR TITLE
fix(cms): Revert broken additional contact emails

### DIFF
--- a/app/assets/stylesheets/base/_frontend.scss
+++ b/app/assets/stylesheets/base/_frontend.scss
@@ -13,7 +13,3 @@ $govuk-new-organisation-colours: true;
 td.govuk-table__cell :first-child {
    margin-top: 0;
 }
-
-.recipient-spacing {
-   margin-right: 8px; /* Adjust as needed */
-}

--- a/app/controllers/support/cases/message_threads_controller.rb
+++ b/app/controllers/support/cases/message_threads_controller.rb
@@ -26,7 +26,7 @@ module Support
       end
 
       def new
-        @to_recipients = Array(current_case.email + @current_case.additional_contacts.pluck(:email)).to_json
+        @to_recipients = Array(current_case.email).to_json
       end
 
       def edit
@@ -34,14 +34,12 @@ module Support
       end
 
       def create
-        contact_email = [[current_case.email, current_case.is_evaluator ? "Lead, Evaluator" : "Lead"]] if current_case.email.present?
-        emails = Array(contact_email + current_case.additional_contacts_emails)
         draft = Email::Draft.new(
           default_content: default_template,
           default_subject:,
           template_id: params[:template_id],
           ticket: current_case.to_model,
-          to_recipients: emails.to_json,
+          to_recipients: Array(current_case.email).to_json,
         ).save_draft!
 
         redirect_to edit_support_case_message_thread_path(id: draft.id)
@@ -50,10 +48,6 @@ module Support
       def submit
         @reply_form = Email::Draft.find(params[:id])
         @reply_form.attributes = new_thread_params
-        emails = @reply_form.to_recipients.map(&:first)
-        @reply_form.to_recipients = emails.to_json
-        @reply_form.cc_recipients = @reply_form.cc_recipients.map(&:first).to_json if @reply_form.cc_recipients.present?
-        @reply_form.bcc_recipients = @reply_form.bcc_recipients.map(&:first).to_json if @reply_form.bcc_recipients.present?
         if @reply_form.valid?(:new_message)
           @reply_form.save_draft!
           @reply_form.deliver_as_new_message

--- a/app/controllers/support/cases/messages/replies_controller.rb
+++ b/app/controllers/support/cases/messages/replies_controller.rb
@@ -15,8 +15,7 @@ module Support
         default_content: default_template,
         template_id: params[:template_id],
         ticket: current_case.to_model,
-        reply_to_email: [current_email],
-        role: %w[Lead] + [current_case.is_evaluator == true ? "Evaulator" : ""],
+        reply_to_email: current_email,
       ).save_draft!
 
       redirect_to redirect_url
@@ -24,17 +23,8 @@ module Support
 
     def submit
       @reply_form = Email::Draft.find(params[:id])
-      emails = @reply_form.to_recipients.map(&:first)
-      to_recipients_email = current_email.to_recipients.instance_of?(Array) ? current_email.to_recipients.map { |recipient| recipient["address"] } : [current_email.to_recipients["address"]]
-      cc_recipients_email = current_email.cc_recipients.instance_of?(Array) ? current_email.cc_recipients.map { |recipient| recipient["address"] } : [current_email.cc_recipients["address"]]
-      bcc_recipients_email = current_email.bcc_recipients.instance_of?(Array) ? current_email.bcc_recipients.map { |recipient| recipient["address"] } : [current_email.bcc_recipients["address"]]
       @reply_form.reply_to_email = current_email
-      @reply_form.to_recipients = emails.present? ? emails.uniq.to_json : to_recipients_email.to_json
-      @reply_form.cc_recipients =  @reply_form.cc_recipients.present? ? @reply_form.cc_recipients.map(&:first).to_json : cc_recipients_email.to_json
-      @reply_form.bcc_recipients = @reply_form.bcc_recipients.present? ? @reply_form.bcc_recipients.map(&:first).to_json : bcc_recipients_email.to_json
       @reply_form.attributes = form_params
-      @reply_form.email.to_recipients = emails
-      @reply_form.reply_to_email.to_recipients = emails
       if @reply_form.valid?
         @reply_form.save_draft!
         @reply_form.delivery_as_reply
@@ -55,51 +45,6 @@ module Support
       return Base64.encode64(edit_support_case_message_reply_path(case_id: current_case.id, message_id: current_email.id, id: params[:id])) if action_name == "submit"
 
       current_url_b64
-    end
-
-    def add_recipient
-      @reply_form = Email::Draft.find(params[:id])
-      sender_email = current_email.sender.instance_of?(Array) ? [current_email.sender.map { |recipient| [recipient["address"], [""]] }] : [[current_email.sender["address"], [""]]]
-      @sender_email = current_email.sender.instance_of?(Array) ? current_email.sender.map { |recipient| recipient["address"] } : [current_email.sender["address"]]
-      current_case_role = current_case.is_evaluator ? ["Lead, Evaluator"] : %w[Lead]
-      emails = [[current_case.email, current_case_role]] + current_case.additional_contacts_emails + sender_email
-      emails.each do |email|
-        # Extract the email part from @reply_form.to_recipients for comparison
-        existing_emails = @reply_form.to_recipients.map { |recipient| recipient[0] }
-        # Add the email only if it's not already in the list (ignoring roles)
-        @reply_form.to_recipients << email unless existing_emails.include?(email[0])
-      end
-      if current_email.cc_recipients.present? && !@reply_form.cc_recipients.map { |recipient| recipient[0] }.include?(current_email.cc_recipients[0]["address"])
-        sender_cc_recipients = current_email.cc_recipients.instance_of?(Array) ? current_email.cc_recipients.map { |recipient| [recipient["address"], [""]] } : current_email.cc_recipients[0]["address"] if current_email.cc_recipients.present?
-        @reply_form.cc_recipients = Array(@reply_form.cc_recipients + sender_cc_recipients).to_json if sender_cc_recipients.present?
-      end
-      if current_email.bcc_recipients.present? && !@reply_form.bcc_recipients.map { |recipient| recipient[0] }.include?(current_email.bcc_recipients[0]["address"])
-        sender_bcc_recipients = current_email.bcc_recipients.instance_of?(Array) ? current_email.bcc_recipients[0]["address"] : [[current_email.bcc_recipients[0]["address"], [""]]] if current_email.bcc_recipients.present?
-        @reply_form.bcc_recipients = Array(@reply_form.bcc_recipients + sender_bcc_recipients).to_json if sender_bcc_recipients.present?
-      end
-      @reply_form.save_draft!
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.replace("recipient-frame",
-                                                    partial: "support/cases/message_threads/recipient_table",
-                                                    locals: { email: @reply_form })
-        end
-      end
-    end
-
-    def remove_recipient
-      @reply_form = Email::Draft.find(params[:id])
-      @sender_email = current_email.sender.instance_of?(Array) ? current_email.sender.map { |recipient| recipient["address"] } : [current_email.sender["address"]]
-      recipient_to_remove = [params[:email], params[:role]]
-      @reply_form.to_recipients.reject! { |recipient| recipient == recipient_to_remove }
-      @reply_form.save_draft!
-      respond_to do |format|
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.replace("recipient-frame",
-                                                    partial: "support/cases/message_threads/recipient_table",
-                                                    locals: { email: @reply_form })
-        end
-      end
     end
 
   private

--- a/app/controllers/tickets/message_threads_controller.rb
+++ b/app/controllers/tickets/message_threads_controller.rb
@@ -38,11 +38,6 @@ class Tickets::MessageThreadsController < ApplicationController
   def submit
     @draft = Email::Draft.find(params[:id])
     @draft.attributes = new_thread_params
-    emails = @draft.to_recipients.map(&:first)
-    @draft.to_recipients = emails.uniq.to_json
-    @draft.cc_recipients = @draft.cc_recipients.map(&:first).to_json if @draft.cc_recipients.present?
-    @draft.bcc_recipients = @draft.bcc_recipients.map(&:first).to_json if @draft.bcc_recipients.present?
-    @draft.email.to_recipients = emails.uniq.to_json
     if @draft.valid?(:new_message)
       @draft.save_draft!
       @draft.deliver_as_new_message

--- a/app/javascript/components/add-recipients.js
+++ b/app/javascript/components/add-recipients.js
@@ -6,9 +6,7 @@ function getCollectionValues(collectionName) {
 function removeRecipient(value, collectionName) {
   const collection = document.getElementsByName(collectionName)[0];
   const collectionValues = getCollectionValues(collectionName);
-  collection.value = JSON.stringify(
-    collectionValues.filter(v => JSON.stringify(v) !== JSON.stringify(value))
-  );
+  collection.value = JSON.stringify(collectionValues.filter(v => v !== value));
 }
 
 function createRemoveLink(tableId, inputValue, collectionName) {
@@ -35,36 +33,20 @@ function createRecipientRow(tableId, label, value, collectionName) {
   labelTh.scope = "row";
   labelTh.appendChild(document.createTextNode(label));
 
-  const recipientEmailTd = document.createElement("td");
-  recipientEmailTd.classList.add("govuk-table__cell");
-  const recipientEmail = document.createTextNode(value[0]);
-  recipientEmailTd.appendChild(recipientEmail);
-
-  const recipientRoleTd = document.createElement("td");
-  recipientRoleTd.classList.add("govuk-table__cell", "recipient-spacing");
-  const rolevalue = value[1] && value[1].length > 0 
-  ? (value[1][1] && value[1][1].length > 1) 
-      ? [capitalizeFirstLetter(value[1][0]), capitalizeFirstLetter(value[1][1])] 
-      : value[1][0].length > 1
-        ? [capitalizeFirstLetter(value[1][0])] // Handle the single element correctly here
-        : [capitalizeFirstLetter(value[1])]
-  : "";  const recipientRole = document.createTextNode(rolevalue);
-  recipientRoleTd.appendChild(recipientRole);
+  const recipientTd = document.createElement("td");
+  recipientTd.classList.add("govuk-table__cell");
+  const recipientEmail = document.createTextNode(value);
+  recipientTd.appendChild(recipientEmail);
 
   const recipientRemoveTd = document.createElement("td");
   recipientRemoveTd.classList.add("govuk-table__cell", "govuk-table__cell--numeric");
   recipientRemoveTd.appendChild(createRemoveLink(tableId, value, collectionName));
 
   recipientRow.appendChild(labelTh);
-  recipientRow.appendChild(recipientEmailTd);
-  recipientRow.appendChild(recipientRoleTd);
+  recipientRow.appendChild(recipientTd);
   recipientRow.appendChild(recipientRemoveTd);
 
   return recipientRow;
-}
-
-function capitalizeFirstLetter(string) {
-  return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
 }
 
 function showTables(inputFieldName) {
@@ -87,18 +69,13 @@ function addRecipient(inputFieldName) {
   const inputField = document.getElementsByName(inputFieldName)[0];
   const collection = document.getElementsByName(inputField.dataset.collection)[0];
   var collectionValues = collection.value ? JSON.parse(collection.value) : [];
-
   const inputValue = inputField.value;
-  const newRecipient = [inputValue, []];
-  collectionValues.push(newRecipient);
-  collectionValues = collectionValues.filter((item, index, self) => 
-    item[0] && self.findIndex(r => r[0] === item[0]) === index
-  );
+  collectionValues.push(inputValue);
+  collectionValues = [...new Set(collectionValues)].filter(Boolean) // ensure values are unique and non-null
   collection.value = JSON.stringify(collectionValues);
   buildTable(inputField.dataset.table, inputField.dataset.collection);
   inputField.value = "";
 }
-
 
 function getRecipientsButtons() {
   return document.querySelectorAll('[data-component="add-recipients"]');

--- a/app/models/email/draft.rb
+++ b/app/models/email/draft.rb
@@ -7,7 +7,6 @@ class Email::Draft
   attribute :mailbox, default: -> { Email.default_mailbox }
   attribute :microsoft_graph, default: -> { MicrosoftGraph.client }
   attribute :reply_to_email
-  attribute :role
   attribute :ticket
   attribute :template_id
   attribute :template_parser, default: -> { Email::TemplateParser.new }

--- a/app/models/frameworks/evaluation/email_ticketable.rb
+++ b/app/models/frameworks/evaluation/email_ticketable.rb
@@ -14,8 +14,7 @@ module Frameworks::Evaluation::EmailTicketable
   end
 
   def default_recipients
-    emails = contact.try(:email) || ""
-    Array([[emails, ""]]).to_json if emails.present?
+    Array(contact.try(:email)).to_json
   end
 
   def unique_attachments(folder: "all")

--- a/app/models/support/case.rb
+++ b/app/models/support/case.rb
@@ -203,9 +203,5 @@ module Support
       update!(agent:)
       agent.notify_assigned_to_case(support_case: self, assigned_by:)
     end
-
-    def additional_contacts_emails
-      case_additional_contacts.pluck(:email, :role)
-    end
   end
 end

--- a/app/views/support/cases/message_threads/_recipient_table.html.erb
+++ b/app/views/support/cases/message_threads/_recipient_table.html.erb
@@ -1,9 +1,11 @@
-<%= turbo_frame_tag "recipient-frame" do %>
-  <table id="recipient-table" class="govuk-table added_recipients_table">
-    <tbody id="recipient-table-body" class="govuk-table__body">
-      <%= render "support/cases/message_threads/recipients", recipients: email.to_recipients, recipient_type: "TO" %>
-      <%= render "support/cases/message_threads/recipients", recipients: email.cc_recipients, recipient_type: "CC" %>
-      <%= render "support/cases/message_threads/recipients", recipients: email.bcc_recipients, recipient_type: "BCC" %>
-    </tbody>
-  </table>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <table id="recipient-table" class="govuk-table added_recipients_table">
+      <tbody class="govuk-table__body">
+        <%= render "support/cases/message_threads/recipients", recipients: email.to_recipients, recipient_type: "TO" %>
+        <%= render "support/cases/message_threads/recipients", recipients: email.cc_recipients, recipient_type: "CC" %>
+        <%= render "support/cases/message_threads/recipients", recipients: email.bcc_recipients, recipient_type: "BCC" %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/support/cases/message_threads/_recipients.html.erb
+++ b/app/views/support/cases/message_threads/_recipients.html.erb
@@ -1,24 +1,6 @@
-<% if recipients.present?%>
-  <%if params[:action] == "add_recipient" || params[:action] == "remove_recipient"%>
-    <%recipients.each do |recipient|%>
-      <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header"><%= recipient_type %></th>
-        <td class="govuk-table__cell"><%= recipient[0] %></td>
-        <td class="govuk-table__cell"><%= recipient[1].join(", ").titleize %></td>
-        <td class="govuk-table__cell">
-        <% unless @sender_email.present? && (@sender_email.include?(recipient[0]))%>
-          <%= link_to "remove", 
-            remove_recipient_support_case_message_replies_path(id: params[:id], email: recipient[0], role: recipient[1]), 
-            data: { turbo_frame: "recipient-frame", turbo_method: "post" }, 
-            class: "govuk-link" %>
-          <%end%>  
-        </td>
-      </tr>
-    <%end%>
-  <%else%>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header"><%= recipient_type %></th>
-      <td class="govuk-table__cell"><%= recipients %></td>
-    </tr>
-  <%end%>
-<%end%>
+<% if recipients.present? %>
+  <tr class="govuk-table__row">
+    <th scope="row" class="govuk-table__header"><%= recipient_type %></th>
+    <td class="govuk-table__cell"><%= recipients %></td>
+  </tr>
+<% end %>

--- a/app/views/support/cases/messages/replies/_form.html.erb
+++ b/app/views/support/cases/messages/replies/_form.html.erb
@@ -22,13 +22,8 @@
       <%= I18n.t("support.case.label.message_threads.using_template", template: @reply_form.template.title) %>
     </div>
   <% end %>
+
   <% if reply %>
-    <div class="govuk-button-group">
-      <%= link_to "Add Additional Contacts", 
-          add_recipient_support_case_message_replies_path(id: params[:id]), 
-          data: { turbo_frame: "recipient-frame", turbo_method: "post" }, 
-          class: "govuk-button" %>
-    </div>
     <%= render "support/cases/message_threads/recipient_table", email: %>
   <% else %>
     <%= render "support/cases/messages/replies/new_message_components", form:, unique_id: %>

--- a/app/views/support/cases/messages/replies/add_recipient.html.erb
+++ b/app/views/support/cases/messages/replies/add_recipient.html.erb
@@ -1,1 +1,0 @@
-<%= render "support/cases/message_threads/recipient_table", email: @reply_form%>

--- a/app/views/support/cases/messages/replies/edit.html.erb
+++ b/app/views/support/cases/messages/replies/edit.html.erb
@@ -8,5 +8,6 @@
       </strong>
     </div>
   <% end %>
+
   <%= render "support/cases/messages/replies/form", email: @last_received_reply, reply: true %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,8 +253,6 @@ Rails.application.routes.draw do
           scope module: :messages do
             resources :replies, only: %i[create edit] do
               post "submit", on: :member
-              post "add_recipient", on: :collection
-              post "remove_recipient", on: :collection
             end
           end
         end

--- a/lib/microsoft_graph/client.rb
+++ b/lib/microsoft_graph/client.rb
@@ -139,11 +139,13 @@ module MicrosoftGraph
 
     def create_and_send_new_message(mailbox:, draft:)
       message_id = create_message(user_id: mailbox.user_id, http_headers: DEFAULT_EMAIL_HEADERS)
+
       add_content_and_send_message(draft, user_id: mailbox.user_id, message_id:, details: details_for_new_message(draft, mailbox))
     end
 
     def create_and_send_new_reply(mailbox:, draft:)
       draft_message = create_reply_all_message(user_id: mailbox.user_id, reply_to_id: draft.reply_to_id, http_headers: DEFAULT_EMAIL_HEADERS)
+
       add_content_and_send_message(draft, user_id: mailbox.user_id, message_id: draft_message.id, details: details_for_reply(draft, draft_message))
     end
 
@@ -155,6 +157,7 @@ module MicrosoftGraph
       draft.attachments.each do |file_attachment|
         add_file_attachment_to_message(user_id:, file_attachment:, message_id:)
       end
+
       send_message(user_id:, message_id:)
       get_message(user_id:, message_id:)
     end
@@ -183,10 +186,6 @@ module MicrosoftGraph
     end
 
     def details_for_reply(draft, draft_message)
-      email_addresses = lambda do |recipients|
-        recipients.map { |email| { "emailAddress" => { "address" => email } } }
-      end
-
       {
         body: {
           "ContentType" => "HTML",
@@ -194,9 +193,6 @@ module MicrosoftGraph
           # for it to appear under a "fold" in the email client
           "content" => "<html><body>#{draft.body}</body></html>#{draft_message.body.content}",
         },
-        toRecipients: email_addresses[draft.to_recipients],
-        ccRecipients: email_addresses[draft.cc_recipients],
-        bccRecipients: email_addresses[draft.bcc_recipients],
       }
     end
 

--- a/spec/features/support/emails/agent_can_send_attachments_spec.rb
+++ b/spec/features/support/emails/agent_can_send_attachments_spec.rb
@@ -37,10 +37,10 @@ describe "Agent can add attachments to replies", :with_csrf_protection, js: true
       end
 
       it "allows agent to remove attachments" do
-        within(".draft-email__attachment-remove") do
+        within("#reply-frame") do
           click_on "Remove"
+          expect(page).not_to have_text "attachment.txt"
         end
-        expect(page).not_to have_text "attachment.txt"
       end
     end
   end


### PR DESCRIPTION
This change isn't working properly, and is causing replies not to be sent to the person being replied to.

As this code is complicated, untested, and not working, we will revert it until it can be fixed and tested properly.

## Changes in this PR

This reverts #1932 PWNN-1996