### PR TITLE
Skip very flaky test

### DIFF
--- a/spec/features/support/case_assignment_spec.rb
+++ b/spec/features/support/case_assignment_spec.rb
@@ -12,6 +12,8 @@ RSpec.feature "Case worker assignment", :js, bullet: :skip do
     end
 
     it "assigns the agent and redirects to the case" do
+      # TODO: Revisit if/when we switch to Playwright
+      skip "Flaky test of mature functionality"
       expect(support_case.reload.agent).to eq(agent)
       expect(page).to have_current_path(support_case_path(support_case), ignore_query: true)
     end


### PR DESCRIPTION
The code being tested is mature and not being worked on, but this test fails so often due to JavaScript-related timing issues that it's wasting a lot of time re-running specs on CI.

Revisit if/when we switch from Capybara to Playwright.