### PR TITLE
2012 - feat(cms): Remove archived establishments from selection options

### DIFF
--- a/app/controllers/support/establishment_groups_controller.rb
+++ b/app/controllers/support/establishment_groups_controller.rb
@@ -6,9 +6,10 @@ module Support
 
     def index
       query = <<-SQL
-        ukprn LIKE :q OR
+        (ukprn LIKE :q OR
         uid LIKE :q OR
-        lower(name) LIKE lower(:q)
+        lower(name) LIKE lower(:q)) AND
+        archived != true
       SQL
 
       respond_to do |format|

--- a/app/controllers/support/establishment_groups_controller.rb
+++ b/app/controllers/support/establishment_groups_controller.rb
@@ -6,15 +6,15 @@ module Support
 
     def index
       query = <<-SQL
-        (ukprn LIKE :q OR
+        ukprn LIKE :q OR
         uid LIKE :q OR
-        lower(name) LIKE lower(:q)) AND
-        archived != true
+        lower(name) LIKE lower(:q)
       SQL
 
       respond_to do |format|
         format.json do
           render json: EstablishmentGroup
+            .active
             .where(query, q: "%#{params.fetch(:q)}%")
             .limit(50)
             .each { |g| g.ukprn = "N/A" if g.ukprn.nil? }

--- a/app/controllers/support/organisations_controller.rb
+++ b/app/controllers/support/organisations_controller.rb
@@ -6,13 +6,13 @@ module Support
 
     def index
       query = <<-SQL
-        (urn LIKE :q OR
+        urn LIKE :q OR
         lower(name) LIKE lower(:q) OR
-        lower(address->>'postcode') LIKE lower(:q)) AND
-        archived != true
+        lower(address->>'postcode') LIKE lower(:q)
       SQL
 
       results = Organisation
+        .active
         .includes([:establishment_type])
         .where(query, q: "%#{params.fetch(:q)}%")
         .limit(50)

--- a/app/controllers/support/organisations_controller.rb
+++ b/app/controllers/support/organisations_controller.rb
@@ -6,9 +6,10 @@ module Support
 
     def index
       query = <<-SQL
-        urn LIKE :q OR
+        (urn LIKE :q OR
         lower(name) LIKE lower(:q) OR
-        lower(address->>'postcode') LIKE lower(:q)
+        lower(address->>'postcode') LIKE lower(:q)) AND
+        archived != true
       SQL
 
       results = Organisation

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -9,7 +9,7 @@ class LocalAuthority < ApplicationRecord
   end
 
   def organisations_for_multi_school_picker
-    organisations.local_authority_maintained
+    organisations.local_authority_maintained.where.not(archived: true)
   end
 
   def org_type

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -9,7 +9,7 @@ class LocalAuthority < ApplicationRecord
   end
 
   def organisations_for_multi_school_picker
-    organisations.local_authority_maintained.where.not(archived: true)
+    organisations.local_authority_maintained.active
   end
 
   def org_type

--- a/app/models/support/category.rb
+++ b/app/models/support/category.rb
@@ -5,6 +5,8 @@ module Support
   # Types of procurement or "categories of spend"
   #
   class Category < ApplicationRecord
+    include Support::Concerns::ScopeActive
+
     belongs_to :tower, class_name: "Support::Tower", foreign_key: "support_tower_id", optional: true
     has_many :cases, class_name: "Support::Case"
     belongs_to :parent, class_name: "Support::Category", optional: true
@@ -24,7 +26,6 @@ module Support
     scope :sub_categories, -> { where.not(parent_id: nil) }
     scope :ordered_by_title, -> { order(Arel.sql("case when support_categories.title = 'Or' then 1 else 0 end ASC, support_categories.title ASC")) }
     scope :except_for, ->(title) { where.not(title:) }
-    scope :active, -> { where(archived: false) }
     scope :with_live_cases, -> { joins(:cases).merge(Case.live) }
 
     delegate :title, to: :tower, prefix: true, allow_nil: true

--- a/app/models/support/concerns/scope_active.rb
+++ b/app/models/support/concerns/scope_active.rb
@@ -1,0 +1,7 @@
+module Support::Concerns::ScopeActive
+  extend ActiveSupport::Concern
+
+  included do
+    scope :active, -> { where(archived: false) }
+  end
+end

--- a/app/models/support/email_template.rb
+++ b/app/models/support/email_template.rb
@@ -1,5 +1,7 @@
 module Support
   class EmailTemplate < ApplicationRecord
+    include Support::Concerns::ScopeActive
+
     STAGE_VALUES = [0, 1, 2, 3, 4].freeze
 
     belongs_to :group, class_name: "Support::EmailTemplateGroup", foreign_key: "template_group_id"
@@ -12,7 +14,6 @@ module Support
 
     default_scope { order(:title) }
 
-    scope :active, -> { where(archived: false) }
     scope :by_groups, ->(template_group_ids) { where(template_group_id: template_group_ids) }
     scope :by_stages, ->(stages, include_null: false) { include_null ? where(stage: stages).or(where(stage: nil)) : where(stage: stages) }
     scope :without_stage, -> { where(stage: nil) }

--- a/app/models/support/establishment_group.rb
+++ b/app/models/support/establishment_group.rb
@@ -32,6 +32,6 @@ class Support::EstablishmentGroup < ApplicationRecord
   end
 
   def organisations_for_multi_school_picker
-    organisations
+    organisations.where.not(archived: true)
   end
 end

--- a/app/models/support/establishment_group.rb
+++ b/app/models/support/establishment_group.rb
@@ -1,4 +1,6 @@
 class Support::EstablishmentGroup < ApplicationRecord
+  include Support::Concerns::ScopeActive
+
   belongs_to :establishment_group_type, class_name: "Support::EstablishmentGroupType"
   has_many :cases, class_name: "Support::Case", as: :organisation
 

--- a/app/models/support/establishment_group.rb
+++ b/app/models/support/establishment_group.rb
@@ -32,6 +32,6 @@ class Support::EstablishmentGroup < ApplicationRecord
   end
 
   def organisations_for_multi_school_picker
-    organisations.where.not(archived: true)
+    organisations.active
   end
 end

--- a/app/models/support/organisation.rb
+++ b/app/models/support/organisation.rb
@@ -14,6 +14,7 @@ module Support
   #
   class Organisation < ApplicationRecord
     include Filterable
+    include Support::Concerns::ScopeActive
 
     belongs_to :establishment_type,
                counter_cache: true,

--- a/db/migrate/20241127115728_update_archived_columns.rb
+++ b/db/migrate/20241127115728_update_archived_columns.rb
@@ -1,0 +1,39 @@
+class UpdateArchivedColumns < ActiveRecord::Migration[7.2]
+  def up
+    tables = %w[
+      support_establishment_groups
+      support_email_template_groups
+      support_categories
+      support_procurement_stages
+      request_for_help_categories
+      support_organisations
+      local_authorities
+      support_email_templates
+    ]
+
+    tables.each do |table|
+      execute "UPDATE #{table} SET archived = false WHERE archived IS NULL;"
+
+      change_column_default table, :archived, false
+      change_column_null table, :archived, false
+    end
+  end
+
+  def down
+    tables = %w[
+      support_establishment_groups
+      support_email_template_groups
+      support_categories
+      support_procurement_stages
+      request_for_help_categories
+      support_organisations
+      local_authorities
+      support_email_templates
+    ]
+
+    tables.each do |table|
+      change_column_default table, :archived, nil
+      change_column_null table, :archived, true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_25_131721) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_27_115728) do
   create_sequence "evaluation_refs"
   create_sequence "framework_refs"
 
@@ -403,7 +403,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_131721) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "archived"
+    t.boolean "archived", default: false, null: false
     t.datetime "archived_at"
     t.index ["la_code"], name: "index_local_authorities_on_la_code", unique: true
     t.index ["name"], name: "index_local_authorities_on_name", unique: true
@@ -644,7 +644,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_131721) do
     t.uuid "parent_id"
     t.string "tower"
     t.uuid "support_tower_id"
-    t.boolean "archived", default: false
+    t.boolean "archived", default: false, null: false
     t.index ["slug"], name: "index_support_categories_on_slug", unique: true
     t.index ["support_tower_id"], name: "index_support_categories_on_support_tower_id"
     t.index ["title", "parent_id"], name: "index_support_categories_on_title_and_parent_id", unique: true
@@ -779,7 +779,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_131721) do
     t.uuid "establishment_group_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "archived"
+    t.boolean "archived", default: false, null: false
     t.datetime "archived_at"
     t.date "opened_date"
     t.date "closed_date"
@@ -901,7 +901,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_131721) do
     t.string "federation_name"
     t.string "federation_code"
     t.uuid "local_authority_id"
-    t.boolean "archived"
+    t.boolean "archived", default: false, null: false
     t.datetime "archived_at"
     t.date "closed_date"
     t.string "reason_establishment_opened"

--- a/spec/factories/support/organisation.rb
+++ b/spec/factories/support/organisation.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     phase  { (0..7).to_a.sample }
     gender { (0..3).to_a.sample }
     status { 1 }
+    archived { false }
 
     association :establishment_type,
                 factory: :support_establishment_type

--- a/spec/factories/support/support_establishment_group.rb
+++ b/spec/factories/support/support_establishment_group.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
                 factory: :support_establishment_group_type
 
     address { {} }
+    archived { false }
 
     trait :with_no_address do
       address { { "town": "", "county": "", "street": "", "locality": "", "postcode": "" } }

--- a/spec/features/engagement/create_case_spec.rb
+++ b/spec/features/engagement/create_case_spec.rb
@@ -54,9 +54,15 @@ RSpec.feature "Create case", :js do
 
       before do
         create_list(:support_organisation, 3, trust_code: group.uid)
+        create(:support_organisation, name: "Archived School", archived: true, trust_code: group.uid)
         select_organisation "Group 1"
         valid_form_data_without_organisation
         click_on "Save and continue"
+      end
+
+      it "does not show an archived school as an option to select" do
+        expect(page).to have_text "0 of 3 schools"
+        expect(page).not_to have_text "Archived School"
       end
 
       it "navigates to the same supplier question when more than one school is chosen and saves answers" do

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -101,13 +101,18 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
 
         expect(page).not_to have_text "There is a problem"
         expect(find("h1.govuk-heading-l")).to have_text "Search for an academy trust or federation"
-
         autocomplete_group_step
 
         expect(find("h1.govuk-heading-l")).to have_text "Is this the academy trust or federation you're buying for?"
 
         expect(values[0]).to have_text "Testing Multi Academy Trust"
         expect(values[1]).to have_text "Boundary House Shr, 91 Charter House Street, EC1M 6HR"
+      end
+
+      it "doesn't include archived schools in the dropdown" do
+        fill_in "Enter the name, postcode or unique reference number (URN) of your school", with: "10025"
+        expect(page).to have_text "Greendale Academy for Bright Sparks"
+        expect(page).not_to have_text "Archived Org"
       end
     end
 
@@ -343,6 +348,12 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
 
         expect(values[0]).to have_text "Greendale Academy for Bright Sparks, St James's Passage, Duke's Place, EC3A 5DE"
       end
+
+      it "doesn't include archived establishment groups in the dropdown" do
+        fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "10025"
+        expect(page).to have_text "Testing Multi Academy Trust"
+        expect(page).not_to have_text "Archived Group"
+      end
     end
 
     describe "the group confirmation page" do
@@ -379,16 +390,19 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
       end
 
       describe "allows to select and confirm schools in the group" do
-        before do
+        it "does not show an archived school as an option to select" do
+          expect(page).to have_text "0 of 2 schools"
+          expect(page).not_to have_text "Archived Org"
+        end
+
+        it "saves selected schools" do
           check "Specialist School for Testing"
           check "Greendale Academy for Bright Sparks"
           click_continue
 
           choose "Yes"
           click_continue
-        end
 
-        it "saves selected schools" do
           expect(FrameworkRequest.first.school_urns).to match_array(%w[100253 100254])
         end
       end

--- a/spec/support/shared/user_with_many_orgs.rb
+++ b/spec/support/shared/user_with_many_orgs.rb
@@ -30,6 +30,14 @@ RSpec.shared_context "with schools and groups" do
            trust_code: "2314",
            local_authority:)
 
+    create(:support_organisation, :with_address,
+           urn: "100255",
+           name: "Archived Org",
+           establishment_type: foundation,
+           trust_code: "2314",
+           local_authority:,
+           archived: true)
+
     create(:support_establishment_group, :with_address,
            uid: "2314",
            name: "Testing Multi Academy Trust",
@@ -39,5 +47,11 @@ RSpec.shared_context "with schools and groups" do
            uid: "2315",
            name: "New Academy Trust",
            establishment_group_type: sat)
+
+    create(:support_establishment_group, :with_address,
+           uid: "2316",
+           name: "Archived Group",
+           establishment_group_type: sat,
+           archived: true)
   end
 end


### PR DESCRIPTION
Archived organisations and establishment groups are those that are in our databases but are no longer in the GIAS data download for various reasons, such as a school never opening. We do not want Procurement Operations or school users to be able to select archived schools from any of the dropdowns or school pickers as there should be an alternate correct establishment to choose from.

<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Removes archived schools from the selection in the multi school picker
- Removes archived school from the organisation and establishment group searches
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
