### PR TITLE
SC-80 Add tasklist tab to case

### DIFF
--- a/app/controllers/support/cases/tasklists_controller.rb
+++ b/app/controllers/support/cases/tasklists_controller.rb
@@ -1,0 +1,11 @@
+module Support
+  module Cases
+    class TasklistsController < Cases::ApplicationController
+    private
+
+      def current_case
+        @current_case ||= CasePresenter.new(super)
+      end
+    end
+  end
+end

--- a/app/views/support/cases/show.html.erb
+++ b/app/views/support/cases/show.html.erb
@@ -1,15 +1,17 @@
-<%= render "support/cases/show/tabs" do %>
-  <%= render "support/cases/show/school_details", current_case: @current_case %>
-  <%= render "support/cases/show/case_details", current_case: @current_case %>
-  <%= render "support/cases/show/request_details", current_case: @current_case %>
+    <%= render "support/cases/show/tabs" do %>
+      <%= render "support/cases/show/tasklist", current_case: @current_case %>
+      <%= render "support/cases/show/school_details", current_case: @current_case %>
+      <%= render "support/cases/show/case_details", current_case: @current_case %>
+      <%= render "support/cases/show/request_details", current_case: @current_case %>
 
-  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="messages" role="tabpanel" aria-labelledby="tab_messages" aria-live="polite">
-    <%= turbo_frame_tag "messages-frame", src: params[:messages_tab_url].presence || support_case_message_threads_path(@current_case) do %>
-      <p class="govuk-body">Loading...</p>
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="messages" role="tabpanel" aria-labelledby="tab_messages" aria-live="polite">
+        <%= turbo_frame_tag "messages-frame", src: params[:messages_tab_url].presence || support_case_message_threads_path(@current_case) do %>
+          <p class="govuk-body">Loading...</p>
+        <% end %>
+      </div>
+
+      <%= render "support/cases/show/case_history", interactions: @current_case.case_history_interactions, current_case: @current_case %>
+      <%= render "support/cases/show/case_attachments", current_case: @current_case %>
+      <%= render "support/cases/show/case_files", current_case: @current_case %>
     <% end %>
-  </div>
-
-  <%= render "support/cases/show/case_history", interactions: @current_case.case_history_interactions, current_case: @current_case %>
-  <%= render "support/cases/show/case_attachments", current_case: @current_case %>
-  <%= render "support/cases/show/case_files", current_case: @current_case %>
-<% end %>
+    

--- a/app/views/support/cases/show/_tabs.html.erb
+++ b/app/views/support/cases/show/_tabs.html.erb
@@ -25,6 +25,13 @@
 
 <div class="govuk-tabs" data-module="govuk-tabs" data-component="select-tab">
   <ul class="govuk-tabs__list">
+    <% if Flipper.enabled?(:sc_tasklist_tab) %>
+      <% if @current_case.L4? || @current_case.L5? %>
+        <li class="govuk-tabs__list-item <%= "govuk-tabs__list-item--selected" if tab == "tasklist" || tab.nil? %>">
+          <%= link_to I18n.t("support.case.header.tasklist"), "#tasklist", class: "govuk-tabs__tab" %>
+        </li>
+      <% end %>
+    <% end %>
     <li class="govuk-tabs__list-item <%= "govuk-tabs__list-item--selected" if tab == "school_detail" || tab.nil? %>">
       <%= link_to I18n.t("support.case.header.school_detail"), "#school-details", class: "govuk-tabs__tab" %>
     </li>
@@ -52,4 +59,3 @@
 </div>
 
 <%= render "support/cases/show/case_actions" %>
-

--- a/app/views/support/cases/show/_tasklist.html.erb
+++ b/app/views/support/cases/show/_tasklist.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="tasklist">
+  <h2 class="govuk-heading-l">
+    <%= I18n.t("support.case.header.procurement_task_list") %>
+  </h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <h3 class="govuk-heading-m">
+        <%= I18n.t("support.case.label.tasklist.complete_evaluation") %>
+      </h3>
+      <%= govuk_task_list(id_prefix: "complete-evaluation") do |task_list|
+        task_list.with_item(title: I18n.t("support.case.label.tasklist.item.add_evaluators"), href: '#', status: govuk_tag(text: I18n.t("support.case.label.tasklist.status.to_do")))
+        task_list.with_item(title: I18n.t("support.case.label.tasklist.item.set_due_date"), href: '#', status: govuk_tag(text: I18n.t("support.case.label.tasklist.status.to_do")))
+        task_list.with_item(title: I18n.t("support.case.label.tasklist.item.upload_documents"), href: '#', status: govuk_tag(text: I18n.t("support.case.label.tasklist.status.to_do")))
+        task_list.with_item(title: I18n.t("support.case.label.tasklist.item.email_evaluators")) do | item | 
+        item.with_status(text: I18n.t("support.case.label.tasklist.status.cannot_start"), cannot_start_yet: true)
+        end
+        task_list.with_item(title: I18n.t("support.case.label.tasklist.item.review_evaluations")) do | item | 
+        item.with_status(text: I18n.t("support.case.label.tasklist.status.cannot_start"), cannot_start_yet: true)
+        end
+      end %>
+    </div>      
+  </div>    
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -933,6 +933,8 @@ en:
         request: Request
         request_details: Request details
         school_detail: School details
+        tasklist: Tasklist
+        procurement_task_list: Procurement task list
       label:
         actions:
           transfer_to_framework_evaluation: Transfer to framework evaluation
@@ -1220,6 +1222,19 @@ en:
           L5: 5 - DfE buying by getting quotes or bids
           header: Case level
           unspecified: Not specified
+        tasklist:
+          complete_evaluation: Complete evaluation
+          item:
+            add_evaluators: Add evaluators
+            set_due_date: Set due date
+            upload_documents: Upload documents
+            email_evaluators: Email evaluators
+            review_evaluations: Review evaluations  
+          status:
+            to_do: To do
+            in_progress: In progress
+            complete: Complete
+            cannot_start: Cannot start  
         transfer_to_framework_evaluation:
           title: Buy for your school | Case %{reference} | Transfer to framework evaluation
           header: Do you want to transfer Case %{reference} to a framework evaluation case?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,7 @@ Rails.application.routes.draw do
             resource :participating_schools, only: %i[show]
           end
         end
+        resource :tasklist, only: %i[show]
         get :transfer_to_framework_evaluation, to: "transfer_to_framework_evaluation#index"
         post :transfer_to_framework_evaluation, to: "transfer_to_framework_evaluation#create"
         get "move_emails/", to: "move_emails#index", as: "move_emails"

--- a/spec/features/support/case_tabs_spec.rb
+++ b/spec/features/support/case_tabs_spec.rb
@@ -99,4 +99,32 @@ RSpec.feature "Case summary", :js do
       end
     end
   end
+
+  context "when the case is level 4" do
+    let(:support_case) { create(:support_case, support_level: "L4") }
+
+    it "has 8 visible tabs" do
+      expect(all(".govuk-tabs__list-item", visible: true).count).to eq(8)
+    end
+
+    it "has the tasklist tab" do
+      expect(page).to have_css(".govuk-tabs__list-item", text: "Tasklist")
+    end
+  end
+
+  context "when the case is level 5" do
+    let(:support_case) { create(:support_case, support_level: "L5") }
+
+    it "has the tasklist tab" do
+      expect(page).to have_css(".govuk-tabs__list-item", text: "Tasklist")
+    end
+  end
+
+  context "when the case is level 1" do
+    let(:support_case) { create(:support_case, support_level: "L1") }
+
+    it "does not have the tasklist tab" do
+      expect(page).not_to have_css(".govuk-tabs__list-item", text: "Tasklist")
+    end
+  end
 end

--- a/spec/features/support/case_tasklist_spec.rb
+++ b/spec/features/support/case_tasklist_spec.rb
@@ -1,0 +1,19 @@
+describe "Case tasklist", :js do
+  include_context "with an agent"
+
+  before do
+    visit "/support/cases/#{support_case.id}#tasklist"
+  end
+
+  context "when a case is level 4 (or 5)" do
+    let(:support_case) { create(:support_case, support_level: "L4") }
+
+    it "has a tasklist tab with a tasklist and items" do
+      within "#tasklist" do
+        expect(page).to have_text("Procurement task list")
+        expect(page).to have_text("Complete evaluation")
+        expect(page).to have_css(".govuk-task-list")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,6 +79,7 @@ RSpec.configure do |config|
   config.before do
     Bullet.enable = false
     Flipper.enable(:customer_satisfaction_survey)
+    Flipper.enable(:sc_tasklist_tab)
   end
 
   config.after do


### PR DESCRIPTION
A tasklist tab is needed for the school collab project to show procops what tasks there are to complete for an evaluation. This is only for level 4 and 5 cases. At the moment, it is showing tasks but it is not functional and pages will be added one by one. It is behind a feature flag sc_tasklist_tab so the page is hidden until fully ready for procops.

<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Add tasklist tab in the case page for cases that are level 4 or 5
- Add tasks in the tasklist tab as placeholders for future work
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
![Screenshot 2024-11-25 at 12 00 01](https://github.com/user-attachments/assets/bbdc6311-4ce2-4fab-9d6d-9b7f6647f732)

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
