### PR TITLE
Fix JSON fake foreign keys

### DIFF
--- a/db/migrate/20241112114859_remove_duplicate_support_agents.rb
+++ b/db/migrate/20241112114859_remove_duplicate_support_agents.rb
@@ -38,6 +38,6 @@ class RemoveDuplicateSupportAgents < ActiveRecord::Migration[7.2]
   end
 
   def down
-    raise IrreversibleMigration
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20241112123453_normalize_support_agent_email_case.rb
+++ b/db/migrate/20241112123453_normalize_support_agent_email_case.rb
@@ -7,6 +7,6 @@ class NormalizeSupportAgentEmailCase < ActiveRecord::Migration[7.2]
   end
 
   def down
-    raise IrreversibleMigration
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20241125131721_fix_orphaned_json_fake_foreign_keys.rb
+++ b/db/migrate/20241125131721_fix_orphaned_json_fake_foreign_keys.rb
@@ -1,0 +1,18 @@
+class FixOrphanedJsonFakeForeignKeys < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE support_interactions
+      SET additional_data = additional_data || '{"assigned_to_agent_id": "9b93fe33-b9f7-417e-a0f8-51cac736b727"}'
+      WHERE additional_data->'assigned_to_agent_id' @> '"f709fe43-10f9-4dcc-972a-7262bf30911b"'
+    SQL
+    execute <<~SQL
+      UPDATE support_interactions
+      SET additional_data = additional_data || '{"assigned_to_agent_id": "afb92ef7-e01a-4a63-8797-e52e8dbf428b"}'
+      WHERE additional_data->'assigned_to_agent_id' @> '"dcda84b8-6329-4c87-90a4-884c0c55113d"'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_12_123453) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_25_131721) do
   create_sequence "evaluation_refs"
   create_sequence "framework_refs"
 


### PR DESCRIPTION
Fixes exception caused by #1971 where some references to deleted duplicate entries were hidden within JSON data columns.

The two known duplicate entries are updated to their correct values.