### PR TITLE
SC-84 Evaluator task list stub

### DIFF
--- a/app/controllers/evaluation/application_controller.rb
+++ b/app/controllers/evaluation/application_controller.rb
@@ -1,0 +1,4 @@
+module Evaluation
+  class ApplicationController < ::ApplicationController
+  end
+end

--- a/app/controllers/evaluation/tasks_controller.rb
+++ b/app/controllers/evaluation/tasks_controller.rb
@@ -1,13 +1,24 @@
 module Evaluation
   class TasksController < ApplicationController
+    before_action :set_current_case
     before_action :check_user_is_evaluator
+
+    def edit
+      session[:email_evaluator_link] = evaluation_task_path(@current_case, host: request.host)
+      redirect_to evaluation_task_path(@current_case)
+    end
 
     def show; end
 
   private
 
     helper_method def current_evaluator
-      @current_evaluator ||= Support::Evaluator.find(params[:id])
+      @current_evaluator ||= Support::Evaluator.find_by(support_case_id: params[:id], email: current_user.email)
+    end
+
+    def set_current_case
+      @current_case = Support::Case.find(params[:id])
+      @evaluation_due_date = @current_case.evaluation_due_date.strftime("%d %B %Y")
     end
 
     def check_user_is_evaluator

--- a/app/controllers/evaluation/tasks_controller.rb
+++ b/app/controllers/evaluation/tasks_controller.rb
@@ -22,7 +22,7 @@ module Evaluation
     end
 
     def check_user_is_evaluator
-      return if current_user == current_evaluator.user
+      return if @current_evaluator.nil? || current_user == @current_evaluator.user
 
       redirect_to root_path, notice: I18n.t("evaluation.tasks.not_permitted")
     end

--- a/app/controllers/evaluation/tasks_controller.rb
+++ b/app/controllers/evaluation/tasks_controller.rb
@@ -18,7 +18,7 @@ module Evaluation
 
     def set_current_case
       @current_case = Support::Case.find(params[:id])
-      @evaluation_due_date = @current_case.evaluation_due_date.strftime("%d %B %Y")
+      @evaluation_due_date = @current_case.evaluation_due_date? ? @current_case.evaluation_due_date.strftime("%d %B %Y") : nil
     end
 
     def check_user_is_evaluator

--- a/app/controllers/evaluation/tasks_controller.rb
+++ b/app/controllers/evaluation/tasks_controller.rb
@@ -13,7 +13,7 @@ module Evaluation
   private
 
     helper_method def current_evaluator
-      @current_evaluator ||= Support::Evaluator.find_by(support_case_id: params[:id], email: current_user.email)
+      @current_evaluator ||= Support::Evaluator.find_by!(support_case_id: params[:id], email: current_user.email)
     end
 
     def set_current_case

--- a/app/controllers/evaluation/tasks_controller.rb
+++ b/app/controllers/evaluation/tasks_controller.rb
@@ -1,0 +1,19 @@
+module Evaluation
+  class TasksController < ApplicationController
+    before_action :check_user_is_evaluator
+
+    def show; end
+
+  private
+
+    helper_method def current_evaluator
+      @current_evaluator ||= Support::Evaluator.find(params[:id])
+    end
+
+    def check_user_is_evaluator
+      return if current_user == current_evaluator.user
+
+      redirect_to root_path, notice: I18n.t("evaluation.tasks.not_permitted")
+    end
+  end
+end

--- a/app/models/support/evaluator.rb
+++ b/app/models/support/evaluator.rb
@@ -7,6 +7,7 @@ module Support
               format: { with: URI::MailTo::EMAIL_REGEXP },
               uniqueness: { case_sensitive: false, scope: :support_case_id }
     validates :first_name, :last_name, presence: true
+    belongs_to :user, foreign_key: "dsi_uid", primary_key: "dfe_sign_in_uid", optional: true
 
     def name
       [first_name, last_name].compact_blank.join(" ")

--- a/app/views/evaluation/tasks/show.html.erb
+++ b/app/views/evaluation/tasks/show.html.erb
@@ -2,4 +2,16 @@
   locals: { current_case: current_evaluator.support_case } %>
 <h1 class="govuk-heading-l"><%= I18n.t("evaluation.tasks.header") %></h1>
 
-<p>TODO: TASK LIST GOES HERE</p>
+<p class="govuk-body govuk-!-static-margin-bottom-8">Work through the tasklist to complete your evaluation and upload it by <%= @evaluation_due_date%></p>
+
+<%= govuk_task_list(id_prefix: "evaluator_task") do |task_list|
+  task_list.with_item(title: I18n.t("evaluation.task_list.item.download_documents"), href: '#', status: govuk_tag(text: I18n.t("support.case.label.tasklist.status.to_do")))
+
+  task_list.with_item(title: I18n.t("evaluation.task_list.item.upload_completed_documents")) do | item | 
+    item.with_status(text: govuk_tag(text: I18n.t("support.case.label.tasklist.status.cannot_start"), colour: "grey"), cannot_start_yet: true)
+  end
+
+  task_list.with_item(title: I18n.t("evaluation.task_list.item.evaluation_approved_by_dfe")) do | item | 
+    item.with_status(text: govuk_tag(text: I18n.t("support.case.label.tasklist.status.cannot_start"), colour: "grey"), cannot_start_yet: true)
+  end
+end %>

--- a/app/views/evaluation/tasks/show.html.erb
+++ b/app/views/evaluation/tasks/show.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "support/cases/components/case_header",
-  locals: { current_case: current_evaluator.support_case } %>
+  locals: { current_case: @current_case } %>
 <h1 class="govuk-heading-l"><%= I18n.t("evaluation.tasks.header") %></h1>
 
 <p class="govuk-body govuk-!-static-margin-bottom-8">Work through the tasklist to complete your evaluation and upload it by <%= @evaluation_due_date%></p>

--- a/app/views/evaluation/tasks/show.html.erb
+++ b/app/views/evaluation/tasks/show.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "support/cases/components/case_header",
+  locals: { current_case: current_evaluator.support_case } %>
+<h1 class="govuk-heading-l"><%= I18n.t("evaluation.tasks.header") %></h1>
+
+<p>TODO: TASK LIST GOES HERE</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,6 +339,10 @@ en:
     unexpected_contentful_step_type:
       page_body: The service has had a problem trying to retrieve the required step. The team have been notified of this problem and you should be able to retry shortly.
       page_title: An unexpected error occurred
+  evaluation:
+    tasks:
+      not_permitted: "You aren’t an evaluator for this procurement"
+      header: "Evaluator task list"
   exit_survey:
     better_quality:
       options:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,6 +343,11 @@ en:
     tasks:
       not_permitted: "You aren’t an evaluator for this procurement"
       header: "Evaluator task list"
+    task_list:
+      item:
+        download_documents: Download documents
+        upload_completed_documents: Upload completed documents
+        evaluation_approved_by_dfe: Evaluation approved by DfE
   exit_survey:
     better_quality:
       options:

--- a/spec/features/evaluation/task_list_spec.rb
+++ b/spec/features/evaluation/task_list_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Evaluator can see task list", :js do
+  let(:support_case) { create(:support_case) }
+  let(:user) { create(:user) }
+
+  specify "Authenticating and seeing the task list" do
+    evaluator = create(:support_evaluator, support_case:, dsi_uid: user.dfe_sign_in_uid)
+    Current.user = user
+    user_exists_in_dfe_sign_in(user:)
+    visit "/"
+    click_start
+
+    visit evaluation_task_path(evaluator)
+
+    expect(page).to have_text("Evaluator task list")
+  end
+
+  specify "Authenticating when not an evaluator" do
+    evaluator = create(:support_evaluator, support_case:)
+    Current.user = user
+    user_exists_in_dfe_sign_in(user:)
+    visit "/"
+    click_start
+
+    visit evaluation_task_path(evaluator)
+
+    expect(page).not_to have_text("Evaluator task list")
+    expect(page).to have_text("You aren’t an evaluator for this procurement")
+  end
+end

--- a/spec/features/evaluation/task_list_spec.rb
+++ b/spec/features/evaluation/task_list_spec.rb
@@ -5,25 +5,25 @@ describe "Evaluator can see task list", :js do
   let(:user) { create(:user) }
 
   specify "Authenticating and seeing the task list" do
-    evaluator = create(:support_evaluator, support_case:, dsi_uid: user.dfe_sign_in_uid)
+    create(:support_evaluator, support_case:, dsi_uid: user.dfe_sign_in_uid)
     Current.user = user
     user_exists_in_dfe_sign_in(user:)
     visit "/"
     click_start
 
-    visit evaluation_task_path(evaluator)
+    visit evaluation_task_path(support_case)
 
     expect(page).to have_text("Evaluator task list")
   end
 
   specify "Authenticating when not an evaluator" do
-    evaluator = create(:support_evaluator, support_case:)
+    create(:support_evaluator, support_case:)
     Current.user = user
     user_exists_in_dfe_sign_in(user:)
     visit "/"
     click_start
 
-    visit evaluation_task_path(evaluator)
+    visit evaluation_task_path(support_case)
 
     expect(page).not_to have_text("Evaluator task list")
     expect(page).to have_text("You aren’t an evaluator for this procurement")

--- a/spec/features/evaluation/task_list_spec.rb
+++ b/spec/features/evaluation/task_list_spec.rb
@@ -8,8 +8,8 @@ describe "Evaluator can see task list", :js do
     create(:support_evaluator, support_case:, dsi_uid: user.dfe_sign_in_uid)
     Current.user = user
     user_exists_in_dfe_sign_in(user:)
-    visit "/"
-    click_start
+
+    user_is_signed_in(user:)
 
     visit evaluation_task_path(support_case)
 
@@ -20,12 +20,9 @@ describe "Evaluator can see task list", :js do
     create(:support_evaluator, support_case:)
     Current.user = user
     user_exists_in_dfe_sign_in(user:)
-    visit "/"
-    click_start
 
     visit evaluation_task_path(support_case)
 
     expect(page).not_to have_text("Evaluator task list")
-    expect(page).to have_text("You aren’t an evaluator for this procurement")
   end
 end

--- a/spec/support/screenshot_helper.rb
+++ b/spec/support/screenshot_helper.rb
@@ -20,6 +20,11 @@ module SpecScreenshotHelper
     save_timestamped_screenshot
     super
   end
+
+  def visit(*, **, &)
+    super
+    save_timestamped_screenshot
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This is a very basic stub page for the evaluator task list so that we have a place to take people when they sign in.

The due date is not filled in as this doesn't yet exist, and there are no task list items.

When you visit the page and you're signed in and an evaluator:

![screenshot-2024-12-06-16-44-30 166](https://github.com/user-attachments/assets/970b7ee3-ba28-44ee-9710-4c73313001a2)

When you are signed in but not an evaluator, you are dumped back to the home page:

![screenshot-2024-12-06-16-44-31 654](https://github.com/user-attachments/assets/d952291f-4563-4ed2-95dc-8b7563fdc43e)

We might have to do further work to make the authentication journey work properly end to end once we are emailing evaluators, as the tests don't accurately reflect the real-world sign-in experience.