### PR TITLE
Report Azure auth error description

### DIFF
--- a/lib/microsoft_graph/application_authenticator.rb
+++ b/lib/microsoft_graph/application_authenticator.rb
@@ -31,7 +31,7 @@ module MicrosoftGraph
 
         @access_token
       else
-        raise AuthenticationFailureError, json["error"]
+        raise AuthenticationFailureError, [json["error"], json["error_description"]].compact.join(": ")
       end
     end
 


### PR DESCRIPTION
This contains useful information like the fact that keys have expired.

Before:

```
MicrosoftGraph::ApplicationAuthenticator::AuthenticationFailureError: invalid_client
```

After:

```
MicrosoftGraph::ApplicationAuthenticator::AuthenticationFailureError: invalid_client: AADSTS7000222: The provided client secret keys for app '782c68a6-e4db-4d29-802d-2c5570a475a0' are expired. Visit the Azure portal to create new keys for your app: https://aka.ms/NewClientSecret, or consider using certificate credentials for added security: https://aka.ms/certCreds. Trace ID: f6638b43-1c05-4378-99fa-408b31c86200 Correlation ID: 7c8b3745-5f50-49fe-be36-85c786d272a1 Timestamp: 2024-12-16 16:42:16Z
```