### PR TITLE
SC-207 Evaluator Login - External Evaluation user being re-directed to the Specifications dashboard screen

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -75,6 +75,10 @@ private
     session[:faf_referrer].present?
   end
 
+  def external_user_path
+    session[:email_evaluator_link].presence || dashboard_path
+  end
+
   # Routing logic for users after authentication
   #
   # @return [String]
@@ -85,7 +89,7 @@ private
     else
       # - default to the specify dashboard
       # - support request journeys start from the profile page
-      find_framework_entrypoint? ? confirm_sign_in_framework_requests_path : dashboard_path
+      find_framework_entrypoint? ? confirm_sign_in_framework_requests_path : external_user_path
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -63,5 +63,14 @@ describe SessionsController do
         expect(response).to render_template("sessions/unsupported_organisation_error")
       end
     end
+
+    context "when user logging in from unique_link evaluation journey" do
+      let(:support_case) { create(:support_case) }
+      let(:session) { { email_evaluator_link: evaluation_verify_evaluators_unique_link_path(support_case) } }
+
+      it "redirects to evaluation_verify_evaluators_unique_link_path" do
+        expect(response).to redirect_to(evaluation_verify_evaluators_unique_link_path(support_case))
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
1. app/controllers/sessions_controller.rb - Added condition to redirect evaluation task list for external user
2. spec/controllers/sessions_controller_spec.rb - Added test case for external user redirect


<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
