### PR TITLE
SC-193 Procurement task list - CSS Cannot start using incorrect GDS tag

### DIFF
--- a/app/views/support/cases/show/_tasklist.html.erb
+++ b/app/views/support/cases/show/_tasklist.html.erb
@@ -27,7 +27,7 @@
           task_list.with_item(title: I18n.t("support.case.label.tasklist.item.email_evaluators"), href: edit_support_case_email_evaluators_path(@current_case), status: govuk_tag(text: I18n.t("support.case.label.tasklist.status.to_do")))
         else
           task_list.with_item(title: I18n.t("support.case.label.tasklist.item.email_evaluators")) do | item | 
-          item.with_status(text: I18n.t("support.case.label.tasklist.status.cannot_start"), cannot_start_yet: true)
+          item.with_status(text: govuk_tag(text: I18n.t("support.case.label.tasklist.status.cannot_start"), colour: "grey"), cannot_start_yet: true)
           end
         end
 
@@ -44,7 +44,7 @@
           task_list.with_item(title: I18n.t("support.case.label.tasklist.item.review_evaluations"), href: edit_support_case_review_evaluation_path(@current_case), status: review_evaluation_Status)
         else
           task_list.with_item(title: I18n.t("support.case.label.tasklist.item.review_evaluations")) do | item | 
-          item.with_status(text: I18n.t("support.case.label.tasklist.status.cannot_start"), cannot_start_yet: true)
+          item.with_status(text: govuk_tag(text: I18n.t("support.case.label.tasklist.status.cannot_start"), colour: "grey"), cannot_start_yet: true)
           end
         end
       end %>


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

1. app/views/support/cases/show/_tasklist.html.erb -  Added GDS style tag for cannot start status

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

**Before:** 
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/f87c523d-98ce-4927-a11f-f91e86937fcb" />

**After:**
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/479c8225-0970-44e9-8101-04456b1b4523" />



<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
