### PR TITLE
Switch build to ubuntu-latest

### DIFF
--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -160,7 +160,7 @@ jobs:
           name: coverage-report-${{ matrix.ci_node_index }}
           path: coverage/.resultset-${{ matrix.ci_node_index }}.json
 
-  rspec_quarentine:
+  rspec_quarantine:
     name: Checks - Rspec (Quarantined tests)
     needs: build_test
     runs-on: ubuntu-latest
@@ -236,7 +236,7 @@ jobs:
 
   collate_test_coverage:
     name: Checks - Produce test coverage report
-    needs: [build_test, rspec, rspec_quarentine]
+    needs: [build_test, rspec, rspec_quarantine]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_test:
     name: Build (Test)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       docker_image: ${{ steps.build.outputs.docker_image }}
 
@@ -30,7 +30,7 @@ jobs:
 
   build_release:
     name: Build (Release)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       docker_image: ${{ steps.build.outputs.docker_image }}
 
@@ -48,7 +48,7 @@ jobs:
   brakeman:
     name: Checks - Brakeman
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
@@ -58,7 +58,7 @@ jobs:
   rubocop:
     name: Checks - Rubocop
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
@@ -68,7 +68,7 @@ jobs:
   jest:
     name: Checks - Jest
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4.1.6
@@ -82,7 +82,7 @@ jobs:
   rspec:
     name: Checks - Rspec
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -163,7 +163,7 @@ jobs:
   rspec_quarentine:
     name: Checks - Rspec (Quarantined tests)
     needs: build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:
@@ -237,7 +237,7 @@ jobs:
   collate_test_coverage:
     name: Checks - Produce test coverage report
     needs: [build_test, rspec, rspec_quarentine]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up Docker Buildx
@@ -278,7 +278,7 @@ jobs:
   comment_coverage:
     name: Comment coverage on PR
     needs: collate_test_coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Download coverage from current run
@@ -302,7 +302,7 @@ jobs:
 
   release_dev:
     name: Deploy release (Dev)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build_release
     environment: az-dev
 
@@ -319,7 +319,7 @@ jobs:
 
   release_staging:
     name: Deploy release (Staging)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build_release
     environment: az-staging
 
@@ -336,7 +336,7 @@ jobs:
 
   release_production:
     name: Deploy release (Production)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build_release
     environment: az-production
 
@@ -354,7 +354,7 @@ jobs:
   data_regression_copy_to_original:
     name: Data regression testing - trigger copy to pre-release-original-data
     needs: release_production
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: Azure/pipelines@v1.2
@@ -366,7 +366,7 @@ jobs:
   data_regression_copy_to_modified:
     name: Data regression testing - trigger copy to pre-release-modified-data
     needs: release_production
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: Azure/pipelines@v1.2
@@ -378,7 +378,7 @@ jobs:
   data_regression_migrate_modified:
     name: Data regression testing - apply migrations to pre-release-modified-data
     needs: [build_release, release_staging]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       PRE_RELEASE_MODIFIED_DATA_DB_URL: ${{ secrets.PRE_RELEASE_MODIFIED_DATA_DB_URL }}
 

--- a/.github/workflows/support-knapsack-generate-json.yml
+++ b/.github/workflows/support-knapsack-generate-json.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   generate_json:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:

--- a/.github/workflows/support-update-ssl-cert-validation-implementation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation-implementation.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check_need_for_validation_update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     environment: ${{ inputs.chosen_environment == 'az-production' && 'az-production-read-only' ||  inputs.chosen_environment }}
 
@@ -68,7 +68,7 @@ jobs:
             echo needsToReEvaluate=$needsToReEvaluate >> $GITHUB_OUTPUT
 
   update_validation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     needs: [check_need_for_validation_update]
 

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -349,7 +349,7 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
         expect(values[0]).to have_text "Greendale Academy for Bright Sparks, St James's Passage, Duke's Place, EC3A 5DE"
       end
 
-      it "doesn't include archived establishment groups in the dropdown" do
+      it "doesn't include archived establishment groups in the dropdown", :flaky do
         fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "10025"
         expect(page).to have_text "Testing Multi Academy Trust"
         expect(page).not_to have_text "Archived Group"


### PR DESCRIPTION
Ubuntu 20.04 is being [deprecated] by GitHub, which means that jobs will sporadically and temporarily fail. Switching to ubuntu-latest should fix this and keep the jobs working in the future.

This does not affect the deployed artefacts, as they are built on the Ruby docker containers.

[deprecated]: https://github.com/actions/runner-images/issues/11101