### PR TITLE
SC-213 Add notification list entry Proc Ops when an evaluation is submitted

### DIFF
--- a/app/models/support/case/notifiable.rb
+++ b/app/models/support/case/notifiable.rb
@@ -34,4 +34,14 @@ module Support::Case::Notifiable
       created_at: updated_at,
     )
   end
+
+  def notify_agent_of_evaluation_submitted
+    notifications.evaluation_documents_uploaded.find_or_create_by!(
+      support_case: self,
+      assigned_to: agent,
+      assigned_by_system: true,
+      subject: self,
+      created_at: updated_at,
+    )
+  end
 end

--- a/app/models/support/notification.rb
+++ b/app/models/support/notification.rb
@@ -10,6 +10,7 @@ module Support
       case_email_received: 1,
       case_reopened: 2,
       case_closed: 3,
+      evaluation_documents_uploaded: 4,
     }
 
     scope :unread, -> { where(read: false) }

--- a/app/views/support/notifications/topics/_evaluation_documents_uploaded.html.erb
+++ b/app/views/support/notifications/topics/_evaluation_documents_uploaded.html.erb
@@ -1,0 +1,10 @@
+<div class="notification-details">
+  <div class="major">
+    <span class="action">
+      <%= link_to(support_notification_read_path(notification, redirect_to: support_case_path(notification.support_case, notification.subject.ref, back_to: Base64.encode64(support_notifications_path))), method: :post, class: "govuk-link--no-visited-state") do %>
+        Case <%= notification.subject.ref %> - procurement evaluation documents submitted by <%= current_user.email %>
+      <% end %>
+    </span>
+    <span class="by">from <%= notification.subject.agent.first_name %></span>
+  </div>
+</div>

--- a/spec/features/evaluation/upload_completed_documents_spec.rb
+++ b/spec/features/evaluation/upload_completed_documents_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Evaluator can can upload completed documents", :js, :with_csrf_pr
   let(:file_name_2) { "another-text-file.txt" }
   let(:evaluator_task_status) { "#evaluator_task-2-status" }
   let(:email) { create(:support_email, :inbox, ticket: support_case, is_read: false) }
+  let(:support_agent) { create(:support_agent) }
 
   before do
     Current.user = user
@@ -62,6 +63,26 @@ RSpec.feature "Evaluator can can upload completed documents", :js, :with_csrf_pr
     email.update!(is_read: false)
 
     expect(support_case.reload).to be_action_required
+
+    support_case.update!(agent_id: nil)
+
+    visit evaluation_upload_completed_document_path(support_case)
+
+    support_case.reload
+
+    click_button "Continue"
+
+    expect(Support::Notification.count).to eq(0)
+
+    support_case.update!(agent_id: support_agent.id)
+
+    support_case.reload
+
+    visit evaluation_upload_completed_document_path(support_case)
+
+    click_button "Continue"
+
+    expect(Support::Notification.count).to eq(0)
   end
 
   specify "when files are uploaded and confirmation chosen as Yes (Complete)" do
@@ -84,6 +105,26 @@ RSpec.feature "Evaluator can can upload completed documents", :js, :with_csrf_pr
     email.update!(is_read: false)
 
     expect(support_case.reload).to be_action_required
+
+    support_case.update!(agent_id: nil)
+
+    visit evaluation_upload_completed_document_path(support_case)
+
+    support_case.reload
+
+    click_button "Continue"
+
+    expect(Support::Notification.count).to eq(0)
+
+    support_case.update!(agent_id: support_agent.id)
+
+    support_case.reload
+
+    visit evaluation_upload_completed_document_path(support_case)
+
+    click_button "Continue"
+
+    expect(Support::Notification.count).to eq(1)
   end
 
   specify "viewing uploaded files" do


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
1. app/controllers/evaluation/upload_completed_documents_controller.rb - Added methods to update notification details
2. app/models/support/case/notifiable.rb - Added a method to update notification details
3. app/models/support/notification.rb - Added new topic enum value
4.  app/views/support/notifications/topics/_evaluation_documents_uploaded.html.erb - Added new file for notification
5. spec/features/evaluation/upload_completed_documents_spec.rb - Added test case to check notification count when evaluation is submitted


<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
