### PR TITLE
Make delivery of email a background job

### DIFF
--- a/app/controllers/support/cases/email_evaluators_controller.rb
+++ b/app/controllers/support/cases/email_evaluators_controller.rb
@@ -32,7 +32,7 @@ module Support
       parse_template
       if @email_evaluators.valid?(:new_message)
         @email_evaluators.save_draft!
-        @email_evaluators.deliver_as_new_message
+        @email_evaluators.queue_delivery(:as_new_message)
 
         @current_case.update!(sent_email_to_evaluators: true)
 

--- a/app/controllers/support/cases/message_threads_controller.rb
+++ b/app/controllers/support/cases/message_threads_controller.rb
@@ -50,7 +50,7 @@ module Support
         @reply_form.attributes = new_thread_params
         if @reply_form.valid?(:new_message)
           @reply_form.save_draft!
-          @reply_form.deliver_as_new_message
+          @reply_form.queue_delivery(:as_new_message)
           redirect_to support_case_message_threads_path(case_id: current_case.id)
         else
           render :edit

--- a/app/controllers/support/cases/messages/replies_controller.rb
+++ b/app/controllers/support/cases/messages/replies_controller.rb
@@ -27,7 +27,7 @@ module Support
       @reply_form.attributes = form_params
       if @reply_form.valid?
         @reply_form.save_draft!
-        @reply_form.delivery_as_reply
+        @reply_form.queue_delivery(:as_reply)
 
         respond_to do |format|
           format.turbo_stream do

--- a/app/controllers/support/cases/messages_controller.rb
+++ b/app/controllers/support/cases/messages_controller.rb
@@ -6,7 +6,7 @@ module Support
       @reply_form = Email::Draft.new(form_params)
 
       if @reply_form.valid?(context: :new_message)
-        @reply_form.deliver_as_new_message
+        @reply_form.queue_delivery(:as_new_message)
 
         redirect_to support_case_message_threads_path(case_id: current_case.id)
       else

--- a/app/controllers/support/cases/review_evaluations_controller.rb
+++ b/app/controllers/support/cases/review_evaluations_controller.rb
@@ -117,7 +117,7 @@ module Support
       parse_template
 
       @email_evaluators.save_draft!
-      @email_evaluators.deliver_as_new_message
+      @email_evaluators.queue_delivery(:as_new_message)
     end
   end
 end

--- a/app/controllers/tickets/message_replies_controller.rb
+++ b/app/controllers/tickets/message_replies_controller.rb
@@ -28,7 +28,7 @@ class Tickets::MessageRepliesController < ApplicationController
     @reply_form.attributes = form_params
     if @reply_form.valid?
       @reply_form.save_draft!
-      @reply_form.delivery_as_reply
+      @reply_form.queue_delivery(:as_reply)
 
       respond_to do |format|
         format.turbo_stream do

--- a/app/controllers/tickets/message_threads_controller.rb
+++ b/app/controllers/tickets/message_threads_controller.rb
@@ -40,7 +40,7 @@ class Tickets::MessageThreadsController < ApplicationController
     @draft.attributes = new_thread_params
     if @draft.valid?(:new_message)
       @draft.save_draft!
-      @draft.deliver_as_new_message
+      @draft.queue_delivery(:as_new_message)
       redirect_to message_thread_path(ticket_id: @ticket.id, ticket_type: @ticket.class, id: @draft.email.outlook_conversation_id)
     else
       render :edit

--- a/app/jobs/deliver_email_job.rb
+++ b/app/jobs/deliver_email_job.rb
@@ -1,0 +1,13 @@
+class DeliverEmailJob < ApplicationJob
+  queue_as :emailing # FIXME: Set this queue up?
+
+  def perform(id, send_type)
+    draft = Email::Draft.find(id)
+
+    if send_type == :as_new_message
+      draft.deliver_as_new_message
+    elsif send_type == :as_reply
+      draft.delivery_as_reply
+    end
+  end
+end

--- a/app/models/email/draft.rb
+++ b/app/models/email/draft.rb
@@ -50,6 +50,10 @@ class Email::Draft
     email.cache_message(microsoft_graph.create_and_send_new_reply(mailbox:, draft: self), folder: "SentItems")
   end
 
+  def queue_delivery(send_type)
+    DeliverEmailJob.perform_later(email.id, send_type)
+  end
+
   def save_draft!
     if email.present?
       email.update!(

--- a/spec/factories/emails.rb
+++ b/spec/factories/emails.rb
@@ -25,5 +25,9 @@ FactoryBot.define do
     trait :sent_items do
       folder { :sent_items }
     end
+
+    trait :draft do
+      is_draft { true }
+    end
   end
 end

--- a/spec/jobs/deliver_email_job_spec.rb
+++ b/spec/jobs/deliver_email_job_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe DeliverEmailJob, type: :job do
+  include ActiveJob::TestHelper
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    allow(Email::Draft).to receive(:find).and_return(draft)
+    described_class.perform_later(email_id, send_type)
+    perform_enqueued_jobs
+  end
+
+  let(:draft) { double(:draft, deliver_as_new_message: nil, delivery_as_reply: nil) }
+  let(:email_id) { 42 }
+  let(:send_type) { :as_new_message }
+
+  describe ".perform_later" do
+    it "enqueues a job asynchronously on the emailing queue" do
+      expect { described_class.perform_later }.to have_enqueued_job.on_queue("emailing")
+    end
+
+    it "finds the correct email" do
+      expect(Email::Draft).to have_received(:find).with(email_id)
+    end
+
+    context "when called with :as_new_message" do
+      it "delivers the draft as a new message" do
+        expect(draft).to have_received(:deliver_as_new_message)
+      end
+    end
+
+    context "when called with :as_reply" do
+      let(:send_type) { :as_reply }
+
+      it "delivers the draft as a reply" do
+        expect(draft).to have_received(:delivery_as_reply)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Emails are sent via the Microsoft Graph API, which is unreliable and may fail due to timeouts or errors; currently, failures are silent. To improve reliability, this moves email sending to a background job with retries

## Changes in this PR

- Add new method `Email::Draft#queue_delivery`
- 7 controllers now call this instead of `Email::Draft.deliver_as_(new_message/reply)`

