### PR TITLE
SC-131 Activity log created for deleted framework every night

### DIFF
--- a/app/services/support/sync_frameworks.rb
+++ b/app/services/support/sync_frameworks.rb
@@ -124,7 +124,7 @@ module Support
     end
 
     def update_archive_status(prepared_frameworks)
-      cms_frameworks = ::Frameworks::Framework.where(source: 2)
+      cms_frameworks = ::Frameworks::Framework.where(source: 2, faf_archived_at: nil)
 
       cms_frameworks.each do |cms_framework|
         exists = prepared_frameworks.any? do |faf_framework|

--- a/spec/services/support/sync_frameworks_spec.rb
+++ b/spec/services/support/sync_frameworks_spec.rb
@@ -86,6 +86,29 @@ describe Support::SyncFrameworks do
           end
         end
       end
+
+      context "when there ia a archived framework" do
+        let(:provider_detail) { create(:frameworks_provider, short_name: "ABC") }
+        let!(:existing_framework1) do
+          create(
+            :frameworks_framework,
+            name: "Framework 3",
+            provider_id: provider_detail.id,
+            faf_slug_ref: "ref-1",
+            faf_category: "Energy",
+            provider_end_date: Date.parse("2026-08-31"),
+            url: testurl1,
+            description: "Desc",
+            source: 2,
+            status: "dfe_approved",
+            faf_archived_at: Date.parse("2024-12-31"),
+          )
+        end
+
+        it "makes no changes to existing frameworks" do
+          expect { service.call }.to(not_change { existing_framework1.reload.faf_archived_at })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
1. app/services/support/sync_frameworks.rb -  updated condition to archive framework
2. spec/services/support/sync_frameworks_spec.rb - Added test case to check framework archive changes


<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
