### PR TITLE
Make evaluator upload docs task clickable but not editable when evalu…

### DIFF
--- a/app/controllers/evaluation/upload_completed_documents_controller.rb
+++ b/app/controllers/evaluation/upload_completed_documents_controller.rb
@@ -4,7 +4,6 @@ module Evaluation
     before_action :check_user_is_evaluator
     before_action { @back_url = evaluation_task_path(@current_case) }
     before_action :uploaded_files
-    before_action :evaluation_approved_by_dfe?
     def show
       @document_uploader = @current_case.document_uploader
     end
@@ -128,12 +127,6 @@ module Evaluation
       )
 
       @current_case.notify_agent_of_evaluation_submitted(email)
-    end
-
-    def evaluation_approved_by_dfe?
-      return unless current_evaluator.evaluation_approved?
-
-      redirect_to evaluation_task_path(@current_case)
     end
 
     def log_completed_documents_deleted(file_name)

--- a/app/views/evaluation/tasks/show.html.erb
+++ b/app/views/evaluation/tasks/show.html.erb
@@ -23,11 +23,7 @@
 
   task_list.with_item(title: I18n.t("evaluation.task_list.item.download_documents"), href: evaluation_download_document_path(@current_case), status: download_status)
 
-  if current_evaluator&.evaluation_approved?
-    task_list.with_item(title: I18n.t("evaluation.task_list.item.upload_evaluation_scoring_document")) do | item | 
-      item.with_status(text: govuk_tag(text: I18n.t("support.case.label.tasklist.status.complete"), colour: "green"))
-    end
-  elsif current_evaluator.has_downloaded_documents?
+  if current_evaluator.has_downloaded_documents?
     task_list.with_item(title: I18n.t("evaluation.task_list.item.upload_evaluation_scoring_document"), href: evaluation_upload_completed_document_path(@current_case), status: upload_status)
   else
     task_list.with_item(title: I18n.t("evaluation.task_list.item.upload_evaluation_scoring_document")) do | item | 
@@ -36,7 +32,7 @@
   end
 
   if current_evaluator&.evaluation_approved?
-    evaluation_complete = govuk_tag(text: I18n.t("support.case.label.tasklist.status.in_progress"), colour: "green")
+    evaluation_complete = govuk_tag(text: I18n.t("support.case.label.tasklist.status.complete"), colour: "green")
     task_list.with_item(title: I18n.t("evaluation.task_list.item.evaluation_approved_by_dfe"), href: evaluation_evaluation_approved_path(@current_case), status: evaluation_complete)
   elsif current_evaluator.has_downloaded_documents? && current_evaluator.has_uploaded_documents? && !current_evaluator&.evaluation_approved?
     evaluation_in_progress = govuk_tag(text: I18n.t("support.case.label.tasklist.status.in_progress"), colour: "yellow")

--- a/app/views/evaluation/upload_completed_documents/_form.html.erb
+++ b/app/views/evaluation/upload_completed_documents/_form.html.erb
@@ -1,14 +1,19 @@
 <%= form_with model: @document_uploader,  scope: :document_uploader, url: evaluation_upload_completed_documents_path,
-          html: { "data-controller" => "case-files" } do |form| %>
+          html: current_evaluator&.evaluation_approved? ? {} : { "data-controller" => "case-files" } do |form| %>
 
     <h2 class="govuk-heading-m"><%= I18n.t("support.cases.upload_documents.choose_file_title") %></h2>
 
     <%= form.govuk_error_summary %>
 
-    <span class="govuk-button govuk-button--secondary" role="button"
-      data-case-files-target="btnDisplayFileDialog">
-      <%= I18n.t("support.cases.upload_documents.button.choose_file") %>
-    </span>
+    <% if current_evaluator&.evaluation_approved? %>
+      <span class="govuk-button govuk-button--secondary" role="button"
+        data-case-files-target="btnDisplayFileDialog" disabled>
+    <% else %>
+      <span class="govuk-button govuk-button--secondary" role="button"
+        data-case-files-target="btnDisplayFileDialog">
+    <% end %>        
+        <%= I18n.t("support.cases.upload_documents.button.choose_file") %>
+      </span>
 
     <%= render "uploaded_documents" %>
 
@@ -17,11 +22,11 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--s"><%= I18n.t("evaluation.upload_evaluation.file_upload_confirmation") %></legend>
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= form.radio_button :has_uploaded_documents, true, checked: current_evaluator.present? && current_evaluator.has_uploaded_documents == true, class: "govuk-radios__input" %>
+            <%= form.radio_button :has_uploaded_documents, true, checked: current_evaluator.present? && current_evaluator.has_uploaded_documents == true, disabled: current_evaluator&.evaluation_approved?, class: "govuk-radios__input" %>
             <%= form.label :has_uploaded_documents, "Yes, I have uploaded all the completed documents", value: true, class: "govuk-label govuk-radios__label" %>
           </div>
           <div class="govuk-radios__item">
-            <%= form.radio_button :has_uploaded_documents, false, checked: current_evaluator.present? && current_evaluator.has_uploaded_documents == false, class: "govuk-radios__input" %>
+            <%= form.radio_button :has_uploaded_documents, false, checked: current_evaluator.present? && current_evaluator.has_uploaded_documents == false, disabled: current_evaluator&.evaluation_approved?, class: "govuk-radios__input" %>
             <%= form.label :has_uploaded_documents, "No", value: false, class: "govuk-label govuk-radios__label" %>
           </div>
         </div>
@@ -29,7 +34,7 @@
     </div>
 
     <div class="govuk-button-group flex-align-center">
-      <%= form.submit I18n.t("generic.button.continue"), class: "govuk-button", role: "button", "data-action" => "case-files#submit", data: { disable_with: "Uploading..." } %>
+      <%= form.submit I18n.t("generic.button.continue"), class: "govuk-button", role: "button", "data-action" => "case-files#submit", data: { disable_with: "Uploading..." }, disabled: current_evaluator&.evaluation_approved? %>
       <%= link_to I18n.t("generic.button.cancel"), @back_url, class: "govuk-link govuk-link--no-visited-state" %>
     </div>
 

--- a/spec/features/evaluation/task_list_spec.rb
+++ b/spec/features/evaluation/task_list_spec.rb
@@ -100,7 +100,7 @@ describe "Evaluator can see task list", :js do
 
     visit evaluation_task_path(support_case)
 
-    expect(page).not_to have_link("Upload evaluation scoring document")
+    expect(page).to have_link("Upload evaluation scoring document")
   end
 
   specify "Verify the evaluation scoring document task status" do

--- a/spec/features/evaluation/upload_completed_documents_spec.rb
+++ b/spec/features/evaluation/upload_completed_documents_spec.rb
@@ -196,4 +196,19 @@ RSpec.feature "Evaluator can can upload completed documents", :js, :with_csrf_pr
 
     expect(find(evaluator_task_status, wait: 10)).to have_text("To do")
   end
+
+  specify "when proc ops have approved the evaluation" do
+    upload_documents
+
+    support_evaluator.update!(evaluation_approved: true)
+
+    visit evaluation_upload_completed_document_path(support_case)
+
+    span_button = find('span[role="button"][data-case-files-target="btnDisplayFileDialog"]')
+
+    expect(span_button[:disabled]).to be_truthy
+    expect(page).to have_field("Yes, I have uploaded all the completed documents", disabled: true)
+    expect(page).to have_field("No", disabled: true)
+    expect(page).to have_button("Continue", disabled: true)
+  end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
Allow the upload docs task to be clickable from the tasklist, and allow it to be edited when the evaluation has **not** been approved by Proc Ops.

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
