### PR TITLE
Add usability survey for FABS

### DIFF
--- a/app/controllers/usability_surveys_controller.rb
+++ b/app/controllers/usability_surveys_controller.rb
@@ -21,7 +21,7 @@ class UsabilitySurveysController < ApplicationController
     end
   end
 
-  private
+private
 
   def usability_survey_params
     params.fetch(:usability_survey, {}).permit(:service, :usage_reason_other, :service_helpful, :service_not_helpful_reason, :improvements, usage_reasons: [])

--- a/app/controllers/usability_surveys_controller.rb
+++ b/app/controllers/usability_surveys_controller.rb
@@ -11,8 +11,9 @@ class UsabilitySurveysController < ApplicationController
       format.html do
         @usability_survey = UsabilitySurveyResponse.new(usability_survey_params)
         @usability_survey.service ||= usability_survey_params[:service]
+        @decoded_url = decode_return_url
         if @usability_survey.save
-          redirect_to decode_return_url || root_path
+          redirect_to @decoded_url || root_path, allow_other_host: true
         else
           render :new
         end

--- a/app/controllers/usability_surveys_controller.rb
+++ b/app/controllers/usability_surveys_controller.rb
@@ -1,0 +1,34 @@
+class UsabilitySurveysController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def new
+    @usability_survey = UsabilitySurveyResponse.new(service: params[:service])
+    @decoded_url = decode_return_url
+  end
+
+  def create
+    respond_to do |format|
+      format.html do
+        @usability_survey = UsabilitySurveyResponse.new(usability_survey_params)
+        @usability_survey.service ||= usability_survey_params[:service]
+        if @usability_survey.save
+          redirect_to decode_return_url || root_path
+        else
+          render :new
+        end
+      end
+    end
+  end
+
+  private
+
+  def usability_survey_params
+    params.fetch(:usability_survey, {}).permit(:service, :usage_reason_other, :service_helpful, :service_not_helpful_reason, :improvements, usage_reasons: [])
+  end
+
+  def decode_return_url
+    return nil unless params[:return_url]
+
+    UrlVerifier.verify_url(params[:return_url])
+  end
+end

--- a/app/controllers/usability_surveys_controller.rb
+++ b/app/controllers/usability_surveys_controller.rb
@@ -1,5 +1,6 @@
 class UsabilitySurveysController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :check_usability_surveys_feature
 
   def new
     @usability_survey = UsabilitySurveyResponse.new(service: params[:service])
@@ -31,5 +32,9 @@ private
     return nil unless params[:return_url]
 
     UrlVerifier.verify_url(params[:return_url])
+  end
+
+  def check_usability_surveys_feature
+    redirect_to root_path unless Flipper.enabled?(:usability_surveys)
   end
 end

--- a/app/helpers/usability_surveys_helper.rb
+++ b/app/helpers/usability_surveys_helper.rb
@@ -1,0 +1,10 @@
+module UsabilitySurveysHelper
+  def usability_survey_usage_reason_options
+    CheckboxOption.from(
+      I18nOption.from(
+        "usability_survey.usage_reasons.options.%%key%%",
+        %w[browsing finding_a_framework guidance request_for_help other],
+      ),
+    )
+  end
+end

--- a/app/models/usability_survey_response.rb
+++ b/app/models/usability_survey_response.rb
@@ -1,6 +1,4 @@
 class UsabilitySurveyResponse < ApplicationRecord
-  USAGE_REASONS = %w[browsing finding_a_framework guidance request_for_help other].freeze
-
   enum :service, { find_a_buying_solution: 0 }, prefix: true
 
   validates :service_helpful, inclusion: { in: [true, false], message: "Select if the service helped you" }, on: :service_helpful

--- a/app/models/usability_survey_response.rb
+++ b/app/models/usability_survey_response.rb
@@ -1,0 +1,23 @@
+class UsabilitySurveyResponse < ApplicationRecord
+  USAGE_REASONS = %w[browsing finding_a_framework guidance request_for_help other].freeze
+
+  enum :service, { find_a_buying_solution: 0 }, prefix: true
+
+  validates :service_helpful, inclusion: { in: [true, false], message: "Select if the service helped you" }, on: :service_helpful
+  validates :service_not_helpful_reason, presence: { message: "Tell us why the service was not helpful" }, if: -> { service_helpful == false }
+  validates :usage_reason_other, presence: { message: "Tell us what you used the service for" }, if: -> { usage_reasons&.include?("other") }
+  validates :service, presence: { message: "Select which service you used" }
+  validate :at_least_one_field_present
+
+  before_validation :sanitize_fields
+
+  def at_least_one_field_present
+    if [usage_reasons, improvements].all?(&:blank?) && service_helpful.nil?
+      errors.add(:base, "At least one field must be filled in")
+    end
+  end
+
+  def sanitize_fields
+    self.usage_reasons = Array(usage_reasons).reject(&:blank?)
+  end
+end

--- a/app/services/url_verifier.rb
+++ b/app/services/url_verifier.rb
@@ -1,0 +1,11 @@
+class UrlVerifier
+  def self.verifier
+    @verifier ||= ActiveSupport::MessageVerifier.new(ENV["FAF_WEBHOOK_SECRET"])
+  end
+
+  def self.verify_url(signed_url)
+    verifier.verify(signed_url)
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    nil
+  end
+end

--- a/app/services/url_verifier.rb
+++ b/app/services/url_verifier.rb
@@ -8,4 +8,8 @@ class UrlVerifier
   rescue ActiveSupport::MessageVerifier::InvalidSignature
     nil
   end
+
+  def self.generate(url)
+    verifier.generate(url)
+  end
 end

--- a/app/views/usability_surveys/new.html.erb
+++ b/app/views/usability_surveys/new.html.erb
@@ -28,6 +28,8 @@
     label: { text: "How could we improve this service?" }
   %>
 
-  <%= form.submit "Send feedback", class: "govuk-button" %>
-  <%= link_to "Skip survey", @decoded_url || root_path, class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-3" %>
+  <div class="govuk-button-group">
+    <%= form.submit "Send feedback", class: "govuk-button" %>
+    <%= link_to "Skip survey", @decoded_url || root_path, class: "govuk-link govuk-link--no-visited-state" %>
+  </div>
 <% end %>

--- a/app/views/usability_surveys/new.html.erb
+++ b/app/views/usability_surveys/new.html.erb
@@ -1,0 +1,33 @@
+<h2 class="govuk-heading-m">Before you go</h2>
+<p class="govuk-body">Please could you let us know how easy it was to use this service. Your feedback helps us make our service better.</p>
+
+<%= form_with model: @usability_survey, scope: :usability_survey, url: usability_surveys_path do |form| %>
+  <%= form.govuk_error_summary %>
+  <%= form.hidden_field :service, value: @usability_survey.service %>
+  <%= hidden_field_tag :return_url, @decoded_url %>
+
+  <%= form.govuk_check_boxes_fieldset :usage_reasons, legend: { text: "What did you use the service for today?", size: "s" } do %>
+    <% UsabilitySurveyResponse::USAGE_REASONS.each do |reason| %>
+      <%= form.govuk_check_box :usage_reasons, reason, label: { text: reason == "other" ? "Other" : reason.humanize } do %>
+        <% if reason == "other" %>
+          <%= form.govuk_text_area :usage_reason_other, label: { text: "Label - text area" }, form_group: { class: "govuk-!-margin-left-6" } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= form.govuk_radio_buttons_fieldset :service_helpful, legend: { text: "Did this service help you get what you were looking for?", size: "s" } do %>
+    <%= form.govuk_radio_button :service_helpful, true, label: { text: "Yes" } %>
+    <%= form.govuk_radio_button :service_helpful, false, label: { text: "No" } do %>
+      <%= form.govuk_text_area :service_not_helpful_reason, label: { text: "Why not?" } %>
+    <% end %>
+  <% end %>
+
+  <%= form.govuk_text_area :improvements,
+    rows: 5,
+    label: { text: "How could we improve this service?" }
+  %>
+
+  <%= form.submit "Send feedback", class: "govuk-button" %>
+  <%= link_to "Skip survey", @decoded_url || root_path, class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-3" %>
+<% end %>

--- a/app/views/usability_surveys/new.html.erb
+++ b/app/views/usability_surveys/new.html.erb
@@ -1,35 +1,37 @@
-<h2 class="govuk-heading-m">Before you go</h2>
-<p class="govuk-body">Please could you let us know how easy it was to use this service. Your feedback helps us make our service better.</p>
+<h2 class="govuk-heading-m"><%= I18n.t("usability_survey.heading") %></h2>
+<p class="govuk-body"><%= I18n.t("usability_survey.body") %></p>
 
 <%= form_with model: @usability_survey, scope: :usability_survey, url: usability_surveys_path do |form| %>
   <%= form.govuk_error_summary %>
   <%= form.hidden_field :service, value: @usability_survey.service %>
   <%= hidden_field_tag :return_url, params[:return_url] %>
 
-  <%= form.govuk_check_boxes_fieldset :usage_reasons, legend: { text: "What did you use the service for today?", size: "s" } do %>
-    <% UsabilitySurveyResponse::USAGE_REASONS.each do |reason| %>
-      <%= form.govuk_check_box :usage_reasons, reason, label: { text: reason == "other" ? "Other" : reason.humanize } do %>
-        <% if reason == "other" %>
-          <%= form.govuk_text_area :usage_reason_other, label: { text: "Label - text area" }, form_group: { class: "govuk-!-margin-left-6" } %>
+  <%= form.govuk_check_boxes_fieldset :usage_reasons, legend: { text: I18n.t("usability_survey.usage_reasons.question"), size: "s" } do %>
+    <% usability_survey_usage_reason_options.each do |option| %>
+      <% if option.id == "other" %>
+        <%= form.govuk_check_box :usage_reasons, option.id, label: { text: option.title } do %>
+          <%= form.govuk_text_area :usage_reason_other, label: { text: I18n.t("usability_survey.usage_reasons.usage_reason_other") }, form_group: { class: "govuk-!-margin-left-6" } %>
         <% end %>
+      <% else %>
+        <%= form.govuk_check_box :usage_reasons, option.id, label: { text: option.title } %>
       <% end %>
     <% end %>
   <% end %>
 
-  <%= form.govuk_radio_buttons_fieldset :service_helpful, legend: { text: "Did this service help you get what you were looking for?", size: "s" } do %>
+  <%= form.govuk_radio_buttons_fieldset :service_helpful, legend: { text: I18n.t("usability_survey.service_helpful"), size: "s" } do %>
     <%= form.govuk_radio_button :service_helpful, true, label: { text: "Yes" } %>
     <%= form.govuk_radio_button :service_helpful, false, label: { text: "No" } do %>
-      <%= form.govuk_text_area :service_not_helpful_reason, label: { text: "Why not?" } %>
+      <%= form.govuk_text_area :service_not_helpful_reason, label: { text: I18n.t("usability_survey.service_not_helpful_reason") } %>
     <% end %>
   <% end %>
 
   <%= form.govuk_text_area :improvements,
     rows: 5,
-    label: { text: "How could we improve this service?" }
+    label: { text: I18n.t("usability_survey.improvements") }
   %>
 
   <div class="govuk-button-group">
-    <%= form.submit "Send feedback", class: "govuk-button" %>
-    <%= link_to "Skip survey", @decoded_url || root_path, class: "govuk-link govuk-link--no-visited-state" %>
+    <%= form.submit I18n.t("usability_survey.send"), class: "govuk-button" %>
+    <%= link_to I18n.t("usability_survey.skip"), @decoded_url || root_path, class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 <% end %>

--- a/app/views/usability_surveys/new.html.erb
+++ b/app/views/usability_surveys/new.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @usability_survey, scope: :usability_survey, url: usability_surveys_path do |form| %>
   <%= form.govuk_error_summary %>
   <%= form.hidden_field :service, value: @usability_survey.service %>
-  <%= hidden_field_tag :return_url, @decoded_url %>
+  <%= hidden_field_tag :return_url, params[:return_url] %>
 
   <%= form.govuk_check_boxes_fieldset :usage_reasons, legend: { text: "What did you use the service for today?", size: "s" } do %>
     <% UsabilitySurveyResponse::USAGE_REASONS.each do |reason| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2274,3 +2274,20 @@ en:
   time:
     formats:
       compact: "%d %b %y"
+  usability_survey:
+    body: Please could you let us know how easy it was to use this service. Your feedback helps us make our service better.
+    heading: Before you go
+    improvements: How could we improve this service?
+    send: Send feedback
+    service_helpful: Did this service help you get what you were looking for?
+    service_not_helpful_reason: Please tell us why not
+    skip: Skip survey
+    usage_reasons:
+      options:
+        browsing: Browsing
+        finding_a_framework: Finding a framework
+        guidance: Guidance
+        request_for_help: Request for help
+        other: Other
+      question: What did you use the service for today?
+      usage_reason_other: Please tell how else this service has helped you

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -479,6 +479,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :usability_surveys, only: %i[new create]
+
   if Rails.env.development?
     require "sidekiq/web"
     mount Sidekiq::Web, at: "/sidekiq"

--- a/db/migrate/20250404120000_create_usability_survey_responses.rb
+++ b/db/migrate/20250404120000_create_usability_survey_responses.rb
@@ -1,0 +1,13 @@
+class CreateUsabilitySurveyResponses < ActiveRecord::Migration[7.2]
+  def change
+    create_table :usability_survey_responses, id: :uuid do |t|
+      t.string :usage_reasons, array: true, default: []
+      t.text :usage_reason_other
+      t.boolean :service_helpful
+      t.text :service_not_helpful_reason
+      t.text :improvements
+      t.integer :service
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_03_085542) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_04_120000) do
   create_sequence "evaluation_refs"
   create_sequence "framework_refs"
 
@@ -1067,6 +1067,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_03_085542) do
     t.index ["section_id"], name: "index_tasks_on_section_id"
     t.index ["skipped_ids"], name: "index_tasks_on_skipped_ids", using: :gin
     t.index ["statement_ids"], name: "index_tasks_on_statement_ids"
+  end
+
+  create_table "usability_survey_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "usage_reasons", default: [], array: true
+    t.text "usage_reason_other"
+    t.boolean "service_helpful"
+    t.text "service_not_helpful_reason"
+    t.text "improvements"
+    t.integer "service"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "user_feedback", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/features/usability_survey/usability_survey_spec.rb
+++ b/spec/features/usability_survey/usability_survey_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.feature "Completing the Usability Survey" do
+  let(:signed_url) { UrlVerifier.verifier.generate("https://example.com") }
+
+  before do
+    # Mock URL verification to return the decoded URL for the signed URL
+    allow(UrlVerifier).to receive(:verify_url) do |url|
+      url == signed_url ? "https://example.com" : nil
+    end
+  end
+
+  describe "new page" do
+    before do
+      visit new_usability_survey_path(return_url: signed_url, service: "find_a_buying_solution")
+    end
+
+    it "shows the survey form" do
+      expect(page).to have_text "Before you go"
+      expect(page).to have_text "Please could you let us know how easy it was to use this service"
+    end
+
+    it "has a skip survey link" do
+      expect(page).to have_link "Skip survey", href: "https://example.com"
+    end
+
+    context "when selecting 'other' usage reason" do
+      it "shows the other reason text area" do
+        check "Other"
+        expect(page).to have_field "Label - text area"
+      end
+    end
+
+    context "when selecting service not helpful" do
+      it "shows the reason text area" do
+        choose "No"
+        expect(page).to have_field "Why not?"
+      end
+    end
+
+    context "when submitting without filling required fields" do
+      it "shows validation errors" do
+        click_button "Send feedback"
+        expect(page).to have_text "At least one field must be filled in"
+      end
+    end
+
+    context "when submitting with valid data" do
+      it "creates the survey and redirects" do
+        check "Browsing"
+        choose "Yes"
+        fill_in "How could we improve this service?", with: "Make it better"
+        click_button "Send feedback"
+
+        expect(UsabilitySurveyResponse.last.usage_reasons).to include("browsing")
+        expect(UsabilitySurveyResponse.last.service_helpful).to be true
+        expect(UsabilitySurveyResponse.last.improvements).to eq("Make it better")
+        expect(UsabilitySurveyResponse.last.service).to eq("find_a_buying_solution")
+        expect(page).to have_current_path("https://example.com")
+      end
+    end
+  end
+
+  describe "with invalid return_url" do
+    before do
+      visit new_usability_survey_path(return_url: "invalid_url", service: "find_a_buying_solution")
+    end
+
+    it "redirects to root after submission" do
+      check "Browsing"
+      choose "Yes"
+      fill_in "How could we improve this service?", with: "Make it better"
+      click_button "Send feedback"
+
+      expect(UsabilitySurveyResponse.last.usage_reasons).to include("browsing")
+      expect(UsabilitySurveyResponse.last.service_helpful).to be true
+      expect(UsabilitySurveyResponse.last.improvements).to eq("Make it better")
+      expect(UsabilitySurveyResponse.last.service).to eq("find_a_buying_solution")
+      expect(page).to have_current_path("/")
+    end
+
+    it "has a skip survey link to root" do
+      expect(page).to have_link "Skip survey", href: "/"
+    end
+  end
+end

--- a/spec/features/usability_survey/usability_survey_spec.rb
+++ b/spec/features/usability_survey/usability_survey_spec.rb
@@ -16,8 +16,8 @@ RSpec.feature "Completing the Usability Survey" do
     end
 
     it "shows the survey form" do
-      expect(page).to have_text "Before you go"
-      expect(page).to have_text "Please could you let us know how easy it was to use this service"
+      expect(page).to have_text I18n.t("usability_survey.heading")
+      expect(page).to have_text I18n.t("usability_survey.body")
     end
 
     it "has a skip survey link" do
@@ -26,31 +26,31 @@ RSpec.feature "Completing the Usability Survey" do
 
     context "when selecting 'other' usage reason" do
       it "shows the other reason text area" do
-        check "Other"
-        expect(page).to have_field "Label - text area"
+        check I18n.t("usability_survey.usage_reasons.options.other")
+        expect(page).to have_field I18n.t("usability_survey.usage_reasons.usage_reason_other")
       end
     end
 
     context "when selecting service not helpful" do
       it "shows the reason text area" do
-        choose "No"
-        expect(page).to have_field "Why not?"
+        choose I18n.t("generic.no", default: "No")
+        expect(page).to have_field I18n.t("usability_survey.service_not_helpful_reason")
       end
     end
 
     context "when submitting without filling required fields" do
       it "shows validation errors" do
-        click_button "Send feedback"
+        click_button I18n.t("usability_survey.send")
         expect(page).to have_text "At least one field must be filled in"
       end
     end
 
     context "when submitting with valid data" do
       it "creates the survey and redirects" do
-        check "Browsing"
-        choose "Yes"
-        fill_in "How could we improve this service?", with: "Make it better"
-        click_button "Send feedback"
+        check I18n.t("usability_survey.usage_reasons.options.browsing")
+        choose I18n.t("generic.yes", default: "Yes")
+        fill_in I18n.t("usability_survey.improvements"), with: "Make it better"
+        click_button I18n.t("usability_survey.send")
 
         expect(UsabilitySurveyResponse.last.usage_reasons).to include("browsing")
         expect(UsabilitySurveyResponse.last.service_helpful).to be true
@@ -67,10 +67,10 @@ RSpec.feature "Completing the Usability Survey" do
     end
 
     it "redirects to root after submission" do
-      check "Browsing"
-      choose "Yes"
-      fill_in "How could we improve this service?", with: "Make it better"
-      click_button "Send feedback"
+      check I18n.t("usability_survey.usage_reasons.options.browsing")
+      choose I18n.t("generic.yes", default: "Yes")
+      fill_in I18n.t("usability_survey.improvements"), with: "Make it better"
+      click_button I18n.t("usability_survey.send")
 
       expect(UsabilitySurveyResponse.last.usage_reasons).to include("browsing")
       expect(UsabilitySurveyResponse.last.service_helpful).to be true

--- a/spec/features/usability_survey/usability_survey_spec.rb
+++ b/spec/features/usability_survey/usability_survey_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature "Completing the Usability Survey" do
   let(:signed_url) { UrlVerifier.verifier.generate("https://example.com") }
 
   before do
-    # Mock URL verification to return the decoded URL for the signed URL
     allow(UrlVerifier).to receive(:verify_url) do |url|
       url == signed_url ? "https://example.com" : nil
     end

--- a/spec/features/usability_survey/usability_survey_spec.rb
+++ b/spec/features/usability_survey/usability_survey_spec.rb
@@ -1,11 +1,17 @@
 require "rails_helper"
 
 RSpec.feature "Completing the Usability Survey" do
-  let(:signed_url) { UrlVerifier.verifier.generate("https://example.com") }
+  let(:example_url) { "https://example.com" }
+  let(:test_improvement) { "Make it better" }
+  let(:signed_url) { UrlVerifier.verifier.generate(example_url) }
+
+  def submit_form
+    click_button I18n.t("usability_survey.send")
+  end
 
   before do
     allow(UrlVerifier).to receive(:verify_url) do |url|
-      url == signed_url ? "https://example.com" : nil
+      url == signed_url ? example_url : nil
     end
   end
 
@@ -20,7 +26,7 @@ RSpec.feature "Completing the Usability Survey" do
     end
 
     it "has a skip survey link" do
-      expect(page).to have_link "Skip survey", href: "https://example.com"
+      expect(page).to have_link "Skip survey", href: example_url
     end
 
     context "when selecting 'other' usage reason" do
@@ -39,7 +45,7 @@ RSpec.feature "Completing the Usability Survey" do
 
     context "when submitting without filling required fields" do
       it "shows validation errors" do
-        click_button I18n.t("usability_survey.send")
+        submit_form
         expect(page).to have_text "At least one field must be filled in"
       end
     end
@@ -48,14 +54,14 @@ RSpec.feature "Completing the Usability Survey" do
       it "creates the survey and redirects" do
         check I18n.t("usability_survey.usage_reasons.options.browsing")
         choose I18n.t("generic.yes", default: "Yes")
-        fill_in I18n.t("usability_survey.improvements"), with: "Make it better"
-        click_button I18n.t("usability_survey.send")
+        fill_in I18n.t("usability_survey.improvements"), with: test_improvement
+        submit_form
 
         expect(UsabilitySurveyResponse.last.usage_reasons).to include("browsing")
         expect(UsabilitySurveyResponse.last.service_helpful).to be true
-        expect(UsabilitySurveyResponse.last.improvements).to eq("Make it better")
+        expect(UsabilitySurveyResponse.last.improvements).to eq(test_improvement)
         expect(UsabilitySurveyResponse.last.service).to eq("find_a_buying_solution")
-        expect(page).to have_current_path("https://example.com")
+        expect(page).to have_current_path(example_url)
       end
     end
   end
@@ -68,12 +74,12 @@ RSpec.feature "Completing the Usability Survey" do
     it "redirects to root after submission" do
       check I18n.t("usability_survey.usage_reasons.options.browsing")
       choose I18n.t("generic.yes", default: "Yes")
-      fill_in I18n.t("usability_survey.improvements"), with: "Make it better"
-      click_button I18n.t("usability_survey.send")
+      fill_in I18n.t("usability_survey.improvements"), with: test_improvement
+      submit_form
 
       expect(UsabilitySurveyResponse.last.usage_reasons).to include("browsing")
       expect(UsabilitySurveyResponse.last.service_helpful).to be true
-      expect(UsabilitySurveyResponse.last.improvements).to eq("Make it better")
+      expect(UsabilitySurveyResponse.last.improvements).to eq(test_improvement)
       expect(UsabilitySurveyResponse.last.service).to eq("find_a_buying_solution")
       expect(page).to have_current_path("/")
     end

--- a/spec/models/usability_survey_response_spec.rb
+++ b/spec/models/usability_survey_response_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+describe UsabilitySurveyResponse do
+  subject(:survey_response) { described_class.new }
+
+  describe "Validations" do
+    it "is not valid without service" do
+      survey_response.usage_reasons = %w[browsing]
+      survey_response.service_helpful = true
+      expect(survey_response).not_to be_valid
+      expect(survey_response.errors[:service]).to include("Select which service you used")
+    end
+
+    it "requires usage_reason_other if 'other' is checked" do
+      survey_response.usage_reasons = %w[other]
+      survey_response.service_helpful = true
+      survey_response.service = "find_a_buying_solution"
+      expect(survey_response).not_to be_valid
+      expect(survey_response.errors[:usage_reason_other]).to include("Tell us what you used the service for")
+    end
+
+    it "is valid with all required fields" do
+      survey_response.usage_reasons = %w[browsing]
+      survey_response.service_helpful = false
+      survey_response.service_not_helpful_reason = "It was confusing"
+      survey_response.service = "find_a_buying_solution"
+      expect(survey_response).to be_valid
+    end
+
+    it "is invalid with an invalid service value" do
+      expect {
+        survey_response.service = "invalid_service"
+      }.to raise_error(ArgumentError)
+    end
+
+    it "accepts all valid usage reasons" do
+      UsabilitySurveyResponse::USAGE_REASONS.each do |reason|
+        survey_response.usage_reasons = [reason]
+        survey_response.service_helpful = true
+        survey_response.service = "find_a_buying_solution"
+        if reason == "other"
+          survey_response.usage_reason_other = "Other reason"
+        end
+        expect(survey_response).to be_valid
+      end
+    end
+
+    it "is valid if at least one non-service field is present (usage_reasons)" do
+      survey_response.service = "find_a_buying_solution"
+      survey_response.usage_reasons = %w[browsing]
+      expect(survey_response).to be_valid
+    end
+
+    it "is valid if at least one non-service field is present (service_helpful)" do
+      survey_response.service = "find_a_buying_solution"
+      survey_response.service_helpful = true
+      expect(survey_response).to be_valid
+    end
+
+    it "is not valid if all fields except service are blank" do
+      survey_response.service = "find_a_buying_solution"
+      expect(survey_response).not_to be_valid
+      expect(survey_response.errors[:base]).to include("At least one field must be filled in")
+    end
+
+    it "is valid if service_helpful is false and service_not_helpful_reason is present" do
+      survey_response.service = "find_a_buying_solution"
+      survey_response.service_helpful = false
+      survey_response.service_not_helpful_reason = "It was confusing"
+      survey_response.usage_reasons = %w[browsing]
+      expect(survey_response).to be_valid
+    end
+
+    it "sanitizes usage_reasons to remove blanks" do
+      survey_response.service = "find_a_buying_solution"
+      survey_response.usage_reasons = ["", "browsing", ""]
+      survey_response.service_helpful = true
+      survey_response.valid?
+      expect(survey_response.usage_reasons).to eq(%w[browsing])
+    end
+
+    it "requires service_not_helpful_reason when service_helpful is false" do
+      survey_response.usage_reasons = %w[browsing]
+      survey_response.service_helpful = false
+      survey_response.service = "find_a_buying_solution"
+      expect(survey_response).not_to be_valid
+      expect(survey_response.errors[:service_not_helpful_reason]).to include("Tell us why the service was not helpful")
+    end
+  end
+end

--- a/spec/models/usability_survey_response_spec.rb
+++ b/spec/models/usability_survey_response_spec.rb
@@ -34,11 +34,11 @@ describe UsabilitySurveyResponse do
     end
 
     it "accepts all valid usage reasons" do
-      UsabilitySurveyResponse::USAGE_REASONS.each do |reason|
-        survey_response.usage_reasons = [reason]
+      I18n.t("usability_survey.usage_reasons.options").each_key do |reason|
+        survey_response.usage_reasons = [reason.to_s]
         survey_response.service_helpful = true
         survey_response.service = "find_a_buying_solution"
-        if reason == "other"
+        if reason.to_s == "other"
           survey_response.usage_reason_other = "Other reason"
         end
         expect(survey_response).to be_valid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,6 +80,7 @@ RSpec.configure do |config|
     Bullet.enable = false
     Flipper.enable(:customer_satisfaction_survey)
     Flipper.enable(:sc_tasklist_case)
+    Flipper.enable(:usability_surveys)
   end
 
   config.after do

--- a/spec/requests/usability_survey/usability_survey_flow_spec.rb
+++ b/spec/requests/usability_survey/usability_survey_flow_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+describe "Filling out a usability survey" do
+  let(:params) do
+    {
+      usability_survey: {
+        usage_reasons: %w[browsing other],
+        usage_reason_other: "Some other reason",
+        service_helpful: "false",
+        service_not_helpful_reason: "It was confusing",
+        improvements: "do better",
+        service: "find_a_buying_solution",
+      },
+    }
+  end
+
+  let(:signed_url) { UrlVerifier.verifier.generate("/somewhere") }
+
+  it "creates the survey response and redirects to root" do
+    expect { post usability_surveys_path, params: }.to change(UsabilitySurveyResponse, :count).by(1)
+    expect(response).to redirect_to(root_path)
+
+    survey = UsabilitySurveyResponse.last
+    expect(survey.usage_reasons).to include("browsing", "other")
+    expect(survey.usage_reason_other).to eq("Some other reason")
+    expect(survey.service_helpful).to eq(false)
+    expect(survey.service_not_helpful_reason).to eq("It was confusing")
+    expect(survey.improvements).to eq("do better")
+    expect(survey.service).to eq("find_a_buying_solution")
+  end
+
+  it "creates the survey response and redirects to return_url if provided and verified" do
+    expect {
+      post usability_surveys_path, params: params.merge(return_url: signed_url)
+    }.to change(UsabilitySurveyResponse, :count).by(1)
+    expect(response).to redirect_to("/somewhere")
+  end
+
+  it "redirects to root if return_url is not verified" do
+    allow(UrlVerifier).to receive(:verify_url).with(signed_url).and_return(nil)
+    expect {
+      post usability_surveys_path, params: params.merge(return_url: signed_url)
+    }.to change(UsabilitySurveyResponse, :count).by(1)
+    expect(response).to redirect_to(root_path)
+  end
+
+  it "shows errors if required fields are missing" do
+    post usability_surveys_path, params: { usability_survey: {} }
+    expect(response.body).to include("At least one field must be filled in")
+  end
+
+  it "shows errors if service is missing" do
+    post usability_surveys_path, params: { usability_survey: { usage_reasons: %w[browsing], service_helpful: true } }
+    expect(response.body).to include("Select which service you used")
+  end
+
+  it "shows errors if usage_reason_other is missing when 'other' is selected" do
+    post usability_surveys_path, params: { usability_survey: { usage_reasons: %w[other], service: "find_a_buying_solution", service_helpful: true } }
+    expect(response.body).to include("Tell us what you used the service for")
+  end
+
+  it "allows improvements to be blank" do
+    expect {
+      post usability_surveys_path, params: { usability_survey: { usage_reasons: %w[browsing], service: "find_a_buying_solution", service_helpful: true } }
+    }.to change(UsabilitySurveyResponse, :count).by(1)
+    expect(response).to redirect_to(root_path)
+    expect(UsabilitySurveyResponse.last.improvements).to be_nil
+  end
+
+  it "removes blank values from usage_reasons on submit" do
+    post usability_surveys_path, params: { usability_survey: { usage_reasons: ["", "browsing", ""], service: "find_a_buying_solution", service_helpful: true } }
+    expect(UsabilitySurveyResponse.last.usage_reasons).to eq(%w[browsing])
+  end
+
+  it "shows errors if service_not_helpful_reason is missing when service_helpful is false" do
+    post usability_surveys_path, params: { usability_survey: { usage_reasons: %w[browsing], service: "find_a_buying_solution", service_helpful: false } }
+    expect(response.body).to include("Tell us why the service was not helpful")
+  end
+end


### PR DESCRIPTION
This PR adds a new Usability Survey which will be used in the [FABS app](https://github.com/DFE-Digital/find-a-buying-solution/).

## Changes in this PR

- New table, model, controller and form for collecting Usability Survey Responses
- Updated translation file
- URL Verifier to allow safe redirects back to urls provided by FABS 
- Unit, request and feature specs

## Screenshot

<img width="808" alt="Screenshot 2025-05-06 at 4 38 44 pm" src="https://github.com/user-attachments/assets/b310f0eb-750d-4610-9c3f-242667761e4f" />


