### PR TITLE
Disable MSAL cache to fix build

### DIFF
--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -1,5 +1,8 @@
 name: "CI/CD - Full Pipeline"
 
+env:
+  AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
The build was failing:

    AttributeError: Can't get attribute 'NormalizedResponse' on <module 'msal.throttled_http_client' from '/usr/local/lib/python3.10/site-packages/msal/throttled_http_client.py'>

This fixes it by disabling the MSAL HTTP cache. See https://github.com/Azure/azure-cli/issues/31419