### PR TITLE
ES-431 Add next key date to cec view

### DIFF
--- a/app/helpers/support/sort_helper.rb
+++ b/app/helpers/support/sort_helper.rb
@@ -32,6 +32,7 @@ module Support
         [I18n.t("support.case.label.organisation"), "organisation_name"],
         [I18n.t("support.case.label.status"), "state"],
         [I18n.t("support.case.label.updated"), "last_updated"],
+        [I18n.t("support.case.label.key_action_date"), "next_key_date"],
       ]
     end
 

--- a/app/views/cec/onboarding_cases/case_list/case_panel/_top_right_pane.html.erb
+++ b/app/views/cec/onboarding_cases/case_list/case_panel/_top_right_pane.html.erb
@@ -41,4 +41,22 @@
       <span title="<%= kase.last_updated_at %>"><%= relative_date_format(kase.last_updated_at) %></span>
     </dd>
   </div>
+  <% if kase.next_key_date.present? %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= I18n.t("support.case.label.next_key_date.label") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= kase.next_key_date_formatted %>
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= I18n.t("support.case.label.next_key_date.description2") %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= kase.next_key_date_description_formatted %>
+      </dd>
+    </div>
+  <% end %>
 </dl>

--- a/app/views/support/cases/show/_case_details.html.erb
+++ b/app/views/support/cases/show/_case_details.html.erb
@@ -118,18 +118,16 @@
         </div>
       <% end %>  
 
-      <% unless @current_case.energy_onboarding_case? %>  
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= I18n.t("support.case.label.next_key_date.full_label") %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= current_case.next_key_date_formatted %>
-            <%= current_case.next_key_date_description_formatted %>
-          </dd>
-          <dd class="govuk-summary-list__actions"></dd>
-        </div>
-      <% end %>  
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= I18n.t("support.case.label.next_key_date.full_label") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= current_case.next_key_date_formatted %>
+          <%= current_case.next_key_date_description_formatted %>
+        </dd>
+        <dd class="govuk-summary-list__actions"></dd>
+      </div>
     </dl>
 
     <% unless @current_case.energy_onboarding_case? %>

--- a/spec/features/cec/case_summary_spec.rb
+++ b/spec/features/cec/case_summary_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Case summary details" do
   context "when the case is an energy for schools case" do
     let(:dfe_energy_category) { create(:support_category, title: "DfE Energy for Schools service") }
     let(:energy_stage) { create(:support_procurement_stage, key: "onboarding_form", title: "Onboarding form", stage: "6") }
-    let(:support_case) { create(:support_case, category: dfe_energy_category, support_level: "L7", source: :energy_onboarding, procurement_stage: energy_stage) }
+    let(:support_case) { create(:support_case, category: dfe_energy_category, support_level: "L7", source: :energy_onboarding, procurement_stage: energy_stage, next_key_date: "2025-06-05") }
 
     it "shows fields with details" do
       within("div#case-details") do
@@ -21,6 +21,8 @@ RSpec.feature "Case summary details" do
         expect(all("dd.govuk-summary-list__value")[2]).to have_text "Stage 6 - Onboarding form"
         expect(all("dt.govuk-summary-list__key")[3]).to have_text "Source"
         expect(all("dd.govuk-summary-list__value")[3]).to have_text "Energy Onboarding"
+        expect(all("dt.govuk-summary-list__key")[4]).to have_text "Next key date and description"
+        expect(all("dd.govuk-summary-list__value")[4]).to have_text "05/06/2025"
       end
     end
   end

--- a/spec/features/cec/case_tabs_spec.rb
+++ b/spec/features/cec/case_tabs_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature "Case summary", :js do
         expect(all(".govuk-summary-list__row")[1]).to have_text "Case level"
         expect(all(".govuk-summary-list__row")[2]).to have_text "Procurement stage"
         expect(all(".govuk-summary-list__row")[3]).to have_text "Source"
+        expect(all(".govuk-summary-list__row")[4]).to have_text "Next key date and description"
       end
     end
   end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Adds next key date (that is already in the procops view) to the case details tab, case list summary, and as a sort option to the cec portal
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
![Screenshot 2025-05-23 at 09 35 46](https://github.com/user-attachments/assets/ab6a55c6-8a04-4b8d-a68f-1cc0f817a74b)
![Screenshot 2025-05-23 at 09 35 55](https://github.com/user-attachments/assets/489d4880-d439-4f1f-8154-e7aa4a9c33b6)

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
