### PR TITLE
Disable MSAL cache in all workflows

### DIFF
--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -1,8 +1,5 @@
 name: "CI/CD - Full Pipeline"
 
-env:
-  AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
-
 on:
   pull_request:
   push:
@@ -10,6 +7,9 @@ on:
       - main
       - development
       - production
+
+env:
+  AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
 
 jobs:
   build_test:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '31 12 * * 5'
 
+env:
+  AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/support-knapsack-generate-json.yml
+++ b/.github/workflows/support-knapsack-generate-json.yml
@@ -6,6 +6,9 @@ on:
     # At 01:00 on day-of-month 1. https://crontab.guru/#0_1_1_*_*
     - cron: '0 1 1 * *'
 
+env:
+  AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
+
 jobs:
   generate_json:
     runs-on: ubuntu-latest

--- a/.github/workflows/support-update-ssl-cert-validation-implementation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation-implementation.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
+  AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
 
 jobs:
   check_need_for_validation_update:

--- a/.github/workflows/support-update-ssl-cert-validation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation.yml
@@ -6,6 +6,9 @@ on:
     # At 09:00 on Monday. https://crontab.guru/#0_9_*_*_MON
     - cron: '0 9 * * MON'
 
+env:
+  AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
+
 jobs:
   check_need_to_validate_and_potentially_update:
     strategy:


### PR DESCRIPTION
Deployment was fixed in 95b4c90d but other workflows were also broken. This disables the MSAL cache everywhere else to get the SSL certificate rotation workflow working again.