### PR TITLE
ES-335 - fix redirection of form started email link

### DIFF
--- a/app/controllers/energy/tasks_controller.rb
+++ b/app/controllers/energy/tasks_controller.rb
@@ -31,5 +31,14 @@ module Energy
 
       incomplete_tasks.none?
     end
+
+    def authenticate_user!
+      return unless current_user.guest?
+
+      session.delete(:energy_case_tasks_path)
+      session[:energy_case_tasks_path] = energy_case_tasks_path(case_id: params[:case_id]) if params[:case_id].present?
+
+      redirect_to energy_onboarding_path
+    end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -85,7 +85,9 @@ private
   def entry_path(user)
     if session[:energy_onboarding] == true
       session.delete(:energy_onboarding)
-      energy_school_selection_path
+      energy_case_tasks_path = session[:energy_case_tasks_path]
+      session.delete(:energy_case_tasks_path)
+      energy_case_tasks_path.presence || energy_school_selection_path
     elsif user.internal?
       # proc ops / internal team members go to case management
       cms_entrypoint_path

--- a/app/services/energy/emails/school_onboarding_variable_parser.rb
+++ b/app/services/energy/emails/school_onboarding_variable_parser.rb
@@ -13,7 +13,7 @@ module Energy
         "case_creator_full_name" => "#{@current_case.first_name} #{@current_case.last_name}".strip,
         "case_reference_number" => @current_case.ref,
         "organisation_name" => @current_case.organisation_name || @current_case.email,
-        "unique_case_specific_link" => link_to("link", @unique_link, target: "_blank", rel: "noopener noreferrer"),
+        "unique_case_specific_link" => link_to("Energy for Schools", @unique_link, target: "_blank", rel: "noopener noreferrer"),
       }
     end
 

--- a/spec/controllers/energy/tasks_controller_spec.rb
+++ b/spec/controllers/energy/tasks_controller_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Energy::TasksController, type: :controller do
+  describe "#authenticate_user!" do
+    let(:support_organisation) { create(:support_organisation, urn: 100_253) }
+    let(:user) { create(:user, :many_supported_schools_and_groups) }
+    let(:support_case) { create(:support_case, organisation: support_organisation, email: user.email) }
+    let(:onboarding_case) { create(:onboarding_case, support_case:) }
+    let(:case_organisation) { create(:energy_onboarding_case_organisation, onboarding_case:, onboardable: support_organisation) }
+
+    context "with guest user" do
+      before do
+        case_organisation
+      end
+
+      it "redirects to energy_onboarding_path" do
+        get(:show, params: { case_id: onboarding_case.id })
+
+        expect(response).to redirect_to(energy_onboarding_path)
+        expect(session[:energy_case_tasks_path]).to eq(energy_case_tasks_path(case_id: onboarding_case.id))
+      end
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -88,7 +88,6 @@ describe SessionsController do
       end
 
       it "redirects to my_procurements_verify_unique_link_path" do
-        # binding.pry
         expect(response).to redirect_to(my_procurements_task_path(support_case))
       end
     end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -88,7 +88,25 @@ describe SessionsController do
       end
 
       it "redirects to my_procurements_verify_unique_link_path" do
+        # binding.pry
         expect(response).to redirect_to(my_procurements_task_path(support_case))
+      end
+    end
+
+    context "when user logging in from energy form started link" do
+      let(:support_case) { create(:support_case) }
+      let(:onboarding_case) { create(:onboarding_case, support_case:) }
+      let(:energy_task_list_path) { energy_case_tasks_path(case_id: onboarding_case.id) }
+
+      let(:session) do
+        {
+          energy_case_tasks_path: energy_task_list_path,
+          energy_onboarding: true,
+        }
+      end
+
+      it "redirects to task list" do
+        expect(response).to redirect_to(energy_task_list_path)
       end
     end
   end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
https://dfedigital.atlassian.net.mcas.ms/browse/ES-335

As part of the energy form started email, when the user click on the link, 
- For the signed in users: It should redirect to task list if the user has selected switching energy type, if switching energy type is not selected then the user will be redirected to switch energy screen. 
- For the non sign-in users: It should redirected to energy sign in page and then goes to task list

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
