### PR TITLE
 ES-390 | PDF generator, VAT certificates - EDF

### DIFF
--- a/app/services/energy/documents/vat_declaration_form_edf.rb
+++ b/app/services/energy/documents/vat_declaration_form_edf.rb
@@ -1,16 +1,154 @@
+# frozen_string_literal: true
+
 module Energy
   module Documents
     class VatDeclarationFormEdf
-      def initialize(onboarding_case:)
-        @onboarding_case = onboarding_case
+      include Energy::Documents::PdfFormsHelper
+      TEMPLATE_FILE = "VAT Declaration Form EDF.pdf"
+
+      def initialize(onboarding_case)
+        @support_case = onboarding_case.support_case
+        @organisation = @support_case.organisation
+        @onboarding_case_organisation = onboarding_case.onboarding_case_organisations.first
       end
 
-      def generate
-        # Logic to generate the "VAT Declaration Form EDF" document
-        # This could involve rendering a template with the onboarding_case data
-        # and returning a PDF or similar document format.
-        # For now, we will return a placeholder string.
-        "VAT Declaration Form EDF document for #{@onboarding_case.id}"
+      def call
+        raise "Missing template file" unless File.exist?(input_pdf_template_file)
+
+        pdftk.fill_form(input_pdf_template_file, output_pdf_file, form_field_values)
+        output_pdf_file
+      end
+
+      def input_pdf_template_file
+        @input_pdf_template_file ||= INPUT_PDF_TEMPLATE_PATH.join(TEMPLATE_FILE)
+      end
+
+      def output_pdf_file
+        @output_pdf_file ||= OUTPUT_PDF_PATH.join("EDF Vat Declaration_#{@support_case.ref}_#{Date.current}.pdf")
+      end
+
+    private
+
+      def form_field_values
+        customer_details.merge(vat_registration_number)
+                        .merge(electricity_mpan_numbers)
+                        .merge(other_fields)
+      end
+
+      def customer_details
+        {
+          "BUSINESS NAME" => @organisation.name,
+          "ADDRESS 1" => address_line1,
+          "ADDRESS 2" => address_line2,
+          "ADDRESS 3" => city,
+          "ADDRESS 4" => address_line3,
+          "ADDRESS 5 POSTCODE" => postcode,
+          "PERCENT VAT" => vat_lower_percentage[0],
+          "PERCENT VAT 1" => vat_lower_percentage[1],
+          "PERCENT VAT 2" => vat_lower_percentage[2],
+          "ELECTRCITY" => "Yes",
+        }
+      end
+
+      def vat_registration_number
+        vat_registration_no.to_s.chars.each_with_index.to_h do |digit, index|
+          vat_field_name = index.zero? ? "VAT-REG-NUM" : "VAT-REG-NUM #{index}"
+          [vat_field_name, digit]
+        end
+      end
+
+      def electricity_mpan_numbers
+        electricity_meters.join.to_s.chars.each_with_index.to_h do |digit, index|
+          ["MPAN#{index + 1}", digit]
+        end
+      end
+
+      def other_fields
+        {
+          "CHARITY" => "Yes",
+          "Signature Field 2" => "",
+          "FULL NAME" => vat_person_or_vat_alt_person,
+          "Text Field 35" => submitted_date[0],
+          "Text Field 36" => submitted_date[1],
+          "Text Field 37" => submitted_date[2],
+          "Text Field 38" => submitted_date[3],
+          "Text Field 39" => submitted_date[4],
+          "Text Field 40" => submitted_date[5],
+          "TELEPHONE" => telephone,
+          "CERT 1" => "Yes",
+          "CERT 2" => "Yes",
+          "CERT 3" => "Yes",
+          "Text Field 42" => contract_end_date[0],
+          "Text Field 43" => contract_end_date[1],
+          "Text Field 44" => contract_end_date[2],
+          "Text Field 45" => contract_end_date[3],
+          "Text Field 46" => contract_end_date[4],
+          "Text Field 47" => contract_end_date[5],
+        }
+      end
+
+      def electricity_meters
+        @onboarding_case_organisation.electricity_meters.map(&:mpan) || []
+      end
+
+      def vat_person_or_vat_alt_person
+        if @onboarding_case_organisation.vat_person_correct_details
+          "#{@onboarding_case_organisation.vat_person_first_name} #{@onboarding_case_organisation.vat_person_last_name}"
+        else
+          "#{@onboarding_case_organisation.vat_alt_person_first_name} #{@onboarding_case_organisation.vat_alt_person_last_name}"
+        end
+      end
+
+      def telephone
+        if @onboarding_case_organisation.vat_person_correct_details
+          @onboarding_case_organisation.vat_person_phone
+        else
+          @onboarding_case_organisation.vat_alt_person_phone
+        end
+      end
+
+      def vat_lower_percentage
+        @onboarding_case_organisation.vat_lower_rate_percentage.to_s
+      end
+
+      def contract_end_date
+        @contract_end_date ||= (@onboarding_case_organisation.electric_current_contract_end_date + 1.day).strftime("%d%m%y")
+      end
+
+      def submitted_date
+        @submitted_date ||= Time.current.strftime("%d%m%y")
+      end
+
+      def vat_registration_no
+        @vat_registration_no ||= @onboarding_case_organisation.vat_lower_rate_reg_no
+      end
+
+      def address
+        @address ||= if @onboarding_case_organisation.vat_person_correct_details
+                       @onboarding_case_organisation.vat_person_address || {}
+                     else
+                       @onboarding_case_organisation.vat_alt_person_address || {}
+                     end.with_indifferent_access
+      end
+
+      def address_line1
+        address[:street]
+      end
+
+      def address_line2
+        address[:locality]
+      end
+
+      def address_line3
+        address[:county]
+      end
+
+      def city
+        address[:town]
+      end
+
+      def postcode
+        address[:postcode]
       end
     end
   end

--- a/spec/services/energy/documents/vat_declaration_form_edf_spec.rb
+++ b/spec/services/energy/documents/vat_declaration_form_edf_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe Energy::Documents::VatDeclarationFormEdf, type: :model do
+  subject(:service) { described_class.new(onboarding_case) }
+
+  let(:support_organisation) { create(:support_organisation, name: "Hillside School") }
+  let(:user) { create(:user, :many_supported_schools_and_groups) }
+  let(:support_case) { create(:support_case, organisation: support_organisation) }
+  let(:onboarding_case) { create(:onboarding_case, support_case:) }
+  let(:onboarding_case_organisation) { create(:energy_onboarding_case_organisation, onboarding_case:, onboardable: support_organisation, **input_values) }
+  let(:energy_electricity_meter) { create(:energy_electricity_meter, :with_valid_data, onboarding_case_organisation:) }
+
+  let(:fields) { service.pdftk.get_fields(service.output_pdf_file) }
+  let(:values) { fields.map(&:value).compact }
+
+  describe "#call" do
+    context "with vat person details" do
+      let(:input_values) do
+        {
+          vat_rate: 5,
+          electric_current_contract_end_date: Date.new(2025, 12, 12),
+          vat_lower_rate_reg_no: "123456789",
+          vat_person_correct_details: true,
+          vat_person_first_name: "John",
+          vat_person_last_name: "Doe",
+          vat_person_phone: "01234567890",
+          vat_person_address: {
+            street: "456 Secondary St",
+            locality: "Suite 5",
+            town: "Another City",
+            postcode: "WD18 0FV",
+          },
+        }
+      end
+
+      before do
+        energy_electricity_meter
+        service.call
+      end
+
+      it "creates new pdf file" do
+        expect(File.exist?(service.output_pdf_file)).to be true
+      end
+
+      it "matches the input values with the output pdf" do
+        expect(values).to include(support_organisation.name)
+        expect(fields.find { |f| f.name == "ELECTRCITY" }.value).to eq "Yes"
+        expect(fields.find { |f| f.name == "CHARITY" }.value).to eq "Yes"
+        full_name = fields.find { |f| f.name == "FULL NAME" }.value
+        expect(full_name).to eq("#{input_values[:vat_person_first_name]} #{input_values[:vat_person_last_name]}")
+        expect(fields.find { |f| f.name == "TELEPHONE" }.value).to eq input_values[:vat_person_phone]
+        expect(fields.find { |f| f.name == "ADDRESS 5 POSTCODE" }.value).to eq(input_values[:vat_person_address][:postcode])
+      end
+
+      it "has electricity mpan numbers populated" do
+        mpans = onboarding_case_organisation.electricity_meters.map(&:mpan)
+        pdf_mapns = (1..13).map { |i| fields.find { |f| f.name == "MPAN#{i}" }.value }.join
+        expect(mpans).to include(pdf_mapns)
+      end
+
+      it "matches VAT registration no" do
+        vat_number = (0..8).map { |i|
+          name = i.zero? ? "VAT-REG-NUM" : "VAT-REG-NUM #{i}"
+          fields.find { |f| f.name == name }&.value
+        }.join
+        expect(vat_number).to eq(input_values[:vat_lower_rate_reg_no])
+      end
+
+      it "effective date populated with +1 day to contract end date" do
+        day_part_1 = fields.find { |f| f.name == "Text Field 42" }.value
+        day_part_2 = fields.find { |f| f.name == "Text Field 43" }.value
+
+        effective_date_day = (input_values[:electric_current_contract_end_date] + 1).day.to_s
+        expect("#{day_part_1}#{day_part_2}").to eq effective_date_day
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Ticket: [ES-391](https://dfedigital.atlassian.net/browse/ES-391)

- PDG generation
- Auto-Populate EDF Electricity VAT Declaration PDF for Single Schools

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
