### PR TITLE
ES-481 - Add text to show user the feedback link opens in a new tab

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,16 @@ module ApplicationHelper
   end
 
   def banner_message
-    I18n.t("banner.beta.message", feedback_link: link_to(I18n.t("banner.beta.feedback_link"), banner_feedback_link, class: "govuk-link", target: "_blank", rel: :noopener))
+    I18n.t(
+      "banner.beta.message",
+      feedback_link: link_to(
+        "#{I18n.t('banner.beta.feedback_link')}<span class=\"govuk-visually-hidden\"> opens in new tab</span>".html_safe,
+        banner_feedback_link,
+        class: "govuk-link",
+        target: "_blank",
+        rel: :noopener,
+      ),
+    )
   end
 
   def dsi_url(**args)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,7 +70,7 @@ en:
   banner:
     beta:
       feedback_link: feedback
-      message: This is a new service – your %{feedback_link} will help us to improve it.
+      message: This is a new service – your %{feedback_link} will help us to improve it
       tag: Beta
     design: "%{env} Environment"
     session:

--- a/spec/features/specify/landing/environment_banner_spec.rb
+++ b/spec/features/specify/landing/environment_banner_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "To alert users to the current stage of development" do
     # banner.beta.tag
     expect(find("strong.govuk-phase-banner__content__tag")).to have_content "Beta"
     # banner.beta.message
-    expect(find("span.govuk-phase-banner__text")).to have_text "This is a new service – your feedback will help us to improve it."
-    expect(find("span.govuk-phase-banner__text")).to have_link "feedback", href: new_customer_satisfaction_survey_path(source: "banner_link", service: "create_a_spec"), class: "govuk-link"
+    within("span.govuk-phase-banner__text") do
+      expect(page).to have_text "This is a new service – your feedback opens in new tab will help us to improve it"
+      expect(page).to have_css(".govuk-visually-hidden", text: "opens in new tab")
+      expect(page).to have_link "feedback", href: new_customer_satisfaction_survey_path(source: "banner_link", service: "create_a_spec"), class: "govuk-link"
+    end
   end
 end

--- a/spec/features/specify/steps/checkboxes_spec.rb
+++ b/spec/features/specify/steps/checkboxes_spec.rb
@@ -36,9 +36,9 @@ RSpec.feature "Checkbox Question" do
       # It should not create a label when text for one isn't provided
       expect(page).not_to have_content "No_further_information"
 
-      within "span.govuk-visually-hidden" do
-        # Default the hidden label to something understandable for screen readers
-        expect(page).to have_content "Optional further information"
+      # Default the hidden label to something understandable for screen readers
+      within ".govuk-fieldset" do
+        expect(page).to have_css(".govuk-visually-hidden", text: "Optional further information")
       end
 
       fill_in "answer[no_further_information]", with: "A second piece of further information"

--- a/spec/features/specify/steps/radios_spec.rb
+++ b/spec/features/specify/steps/radios_spec.rb
@@ -12,7 +12,9 @@ RSpec.feature "Radio Question" do
       expect(page).not_to have_text "No further information"
 
       # Default the hidden label to something understandable for screen readers
-      expect(find("span.govuk-visually-hidden")).to have_text "Optional further information"
+      within ".govuk-fieldset" do
+        expect(find("span.govuk-visually-hidden")).to have_text "Optional further information"
+      end
 
       fill_in "answer[catering_further_information]", with: "The school needs the kitchen cleaned once a day"
 

--- a/spec/helpers/specify/application_helper_spec.rb
+++ b/spec/helpers/specify/application_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#banner_message" do
     it "returns the beta message by default" do
       # banner.beta.message
-      expect(helper.banner_message).to eq "This is a new service – your <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener\" href=\"#{CGI.escapeHTML(new_customer_satisfaction_survey_path(source: 'banner_link', service: 'create_a_spec'))}\">feedback</a> will help us to improve it."
+      expect(helper.banner_message).to eq "This is a new service – your <a class=\"govuk-link\" target=\"_blank\" rel=\"noopener\" href=\"#{CGI.escapeHTML(new_customer_satisfaction_survey_path(source: 'banner_link', service: 'create_a_spec'))}\">feedback<span class=\"govuk-visually-hidden\"> opens in new tab</span></a> will help us to improve it"
     end
   end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Add text to show user the feedback link opens in a new tab but the span is visually hidden within the link so that it is only picked up by assistive technology
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
