### PR TITLE
ES-508 - Temporarily Remove "Move emails to existing case" Action from CEC Cases

### DIFF
--- a/app/views/support/cases/show/_case_actions.html.erb
+++ b/app/views/support/cases/show/_case_actions.html.erb
@@ -4,9 +4,11 @@
     <li>
       <%= link_to I18n.t("support.case.label.add_note"), new_support_case_interaction_path(@current_case, option: :note), class: "govuk-link" unless @current_case.closed? %>
     </li>
+    <% unless @current_case.energy_onboarding_case? %>
     <li>
       <%= link_to I18n.t("support.case.label.move_email"), support_case_move_emails_path(@current_case), class: "govuk-link govuk-link--no-visited-state" unless @current_case.closed?%>
     </li>
+    <% end %>
     <% if @current_case.opened? %>
       <li>
         <%= link_to I18n.t("support.case.label.change_owner"), portal_new_case_assignments_path(@current_case), class: "govuk-link" %>

--- a/spec/features/cec/case_tabs_spec.rb
+++ b/spec/features/cec/case_tabs_spec.rb
@@ -35,6 +35,10 @@ RSpec.feature "Case summary", :js do
     expect(page).not_to have_css(".govuk-tabs__list-item", text: "Request")
   end
 
+  it "does not have the link Move emails to existing case" do
+    expect(page).not_to have_text "Move emails to existing case"
+  end
+
   describe "School details tab" do
     before { visit "/cec/onboarding_cases/#{support_case.id}#school-details" }
 


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

[e6d62d7](https://github.com/DFE-Digital/buy-for-your-school/commit/e6d62d7017c34dbfe723f05c7efcfbbf56bb412f) - Removed 'Move emails to existing case' link for energy onboarding cases

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
