### PR TITLE
ES-529 Create CEC Email Template Filter with Subgroup and Stage Defaults

### DIFF
--- a/app/controllers/concerns/cec_email_template_filters.rb
+++ b/app/controllers/concerns/cec_email_template_filters.rb
@@ -1,0 +1,27 @@
+module CecEmailTemplateFilters
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :cec_template_group
+  end
+
+private
+
+  def filter_params
+    filters = params.fetch(:email_template_filters, {}).permit(:group_id, :remove_group, :remove_subgroup, :remove_stage, subgroup_ids: [], stages: [])
+
+    if (current_agent&.roles & %w[cec cec_admin]).any? && params[:email_template_filters].blank?
+      filters[:group_id] = @cec_group&.id
+      filters[:subgroup_ids] = [@dfe_subgroup&.id]
+    end
+
+    filters
+  end
+
+  def cec_template_group
+    @cec_group = Support::EmailTemplateGroup.find_by(title: "CEC")
+    if @cec_group.present?
+      @dfe_subgroup = Support::EmailTemplateGroup.find_by(title: "DfE Energy for Schools service", parent_id: @cec_group.id)
+    end
+  end
+end

--- a/app/controllers/support/cases/email_templates_controller.rb
+++ b/app/controllers/support/cases/email_templates_controller.rb
@@ -2,6 +2,7 @@ module Support
   module Cases
     class EmailTemplatesController < Cases::ApplicationController
       require "will_paginate/array"
+      include CecEmailTemplateFilters
 
       before_action :back_url, only: %i[index]
 
@@ -17,10 +18,6 @@ module Support
         params.require(:email_template_form).permit(*%i[
           group_id subgroup_id stage title description subject body
         ]).merge(id: params[:id], agent: current_agent)
-      end
-
-      def filter_params
-        params.fetch(:email_template_filters, {}).permit(:group_id, :remove_group, :remove_subgroup, :remove_stage, subgroup_ids: [], stages: [])
       end
 
       def back_url

--- a/app/controllers/support/cases/message_threads_controller.rb
+++ b/app/controllers/support/cases/message_threads_controller.rb
@@ -4,6 +4,7 @@ module Support
       before_action :redirect_to_messages_tab, unless: :turbo_frame_request?, only: %i[show templated_messages logged_contacts]
       before_action :current_thread, only: %i[show]
       before_action :back_url, only: %i[index show edit submit templated_messages logged_contacts]
+      before_action :cec_template_group, only: %i[index show edit]
 
       helper_method :back_to_url_b64
 
@@ -106,6 +107,13 @@ module Support
 
       def back_url
         @back_url ||= url_from(back_link_param) || is_user_cec_agent? ? cec_cases_path : support_cases_path
+      end
+
+      def cec_template_group
+        @cec_group = Support::EmailTemplateGroup.find_by(title: "CEC")
+        if @cec_group.present?
+          @dfe_subgroup = Support::EmailTemplateGroup.find_by(title: "DfE Energy for Schools service", parent_id: @cec_group.id)
+        end
       end
 
       def default_subject = "Case #{current_case.ref} – DfE Get help buying for schools: your request for advice and guidance"

--- a/app/controllers/support/management/email_templates_controller.rb
+++ b/app/controllers/support/management/email_templates_controller.rb
@@ -69,7 +69,7 @@ module Support
       def filter_params
         filters = params.fetch(:email_template_filters, {}).permit(:group_id, :remove_group, :remove_subgroup, :remove_stage, subgroup_ids: [], stages: [])
 
-        if (current_agent&.roles & %w[cec cec_admin]).any?
+        if (current_agent&.roles & %w[cec cec_admin]).any? && params[:email_template_filters].blank?
           filters[:group_id] = @cec_group&.id
           filters[:subgroup_ids] = [@dfe_subgroup&.id]
         end

--- a/app/controllers/support/management/email_templates_controller.rb
+++ b/app/controllers/support/management/email_templates_controller.rb
@@ -3,6 +3,7 @@ module Support
     class EmailTemplatesController < BaseController
       before_action :cec_template_group
       require "will_paginate/array"
+      include CecEmailTemplateFilters
 
       def index
         parser = Email::TemplateParser.new
@@ -64,24 +65,6 @@ module Support
         params.require(:email_template_form).permit(
           :group_id, :subgroup_id, :stage, :title, :description, :subject, :body, :blob_attachments, file_attachments: []
         ).merge(id: params[:id], agent: current_agent)
-      end
-
-      def filter_params
-        filters = params.fetch(:email_template_filters, {}).permit(:group_id, :remove_group, :remove_subgroup, :remove_stage, subgroup_ids: [], stages: [])
-
-        if (current_agent&.roles & %w[cec cec_admin]).any? && params[:email_template_filters].blank?
-          filters[:group_id] = @cec_group&.id
-          filters[:subgroup_ids] = [@dfe_subgroup&.id]
-        end
-
-        filters
-      end
-
-      def cec_template_group
-        @cec_group = Support::EmailTemplateGroup.find_by(title: "CEC")
-        if @cec_group.present?
-          @dfe_subgroup = Support::EmailTemplateGroup.find_by(title: "DfE Energy for Schools service", parent_id: @cec_group.id)
-        end
       end
 
       helper_method def portal_management_path

--- a/app/forms/support/management/email_template_filter_form.rb
+++ b/app/forms/support/management/email_template_filter_form.rb
@@ -19,6 +19,7 @@ module Support
         @group = Support::EmailTemplateGroup.find(@group_id) if @group_id.present?
         @subgroup_ids = [Support::Emails::Templates::Filter.all_none_values[:all]] if subgroup_ids.blank?
         @stages = [Support::Emails::Templates::Filter.all_none_values[:all]] if stages.blank?
+        @selected_id = group_id
       end
 
       def group_options
@@ -40,7 +41,7 @@ module Support
           OpenStruct.new(id: Support::Emails::Templates::Filter.all_none_values[:all], title: I18n.t("support.management.email_templates.index.template_manager.filters.all_stages"), exclusive: true),
           OpenStruct.new(id: Support::Emails::Templates::Filter.all_none_values[:none], title: I18n.t("support.management.email_templates.index.template_manager.filters.no_stage"), exclusive: false),
         ]
-        other_options + Support::EmailTemplate.stages.map { |stage| OpenStruct.new(id: stage.to_s, title: "#{I18n.t('support.management.email_templates.common.stage')} #{stage}", exclusive: false) }
+        other_options + Support::EmailTemplate.stages(@group_id).map { |stage| OpenStruct.new(id: stage.to_s, title: I18n.t(stage, scope: "support.management.email_templates.stages").to_s, exclusive: false) }
       end
 
       def has_subgroups?

--- a/app/forms/support/management/email_template_form.rb
+++ b/app/forms/support/management/email_template_form.rb
@@ -79,7 +79,8 @@ module Support
       end
 
       def stage_options
-        Support::EmailTemplate.stages.map { |stage| ["#{I18n.t('support.management.email_templates.common.stage')} #{stage}", stage] }
+        stages = @group&.title == "CEC" ? Support::EmailTemplate.cec_stages : Support::EmailTemplate.stages
+        stages.map { |stage| [I18n.t(stage, scope: "support.management.email_templates.stages").to_s, stage] }
       end
 
       def email_template

--- a/app/javascript/controllers/email_templates_edit_controller.js
+++ b/app/javascript/controllers/email_templates_edit_controller.js
@@ -7,11 +7,17 @@ export default class extends Controller {
     "subgroupWrapper",
     "subgroupSelect",
     "variableWarning",
+    "stageSelect"
   ];
   static values = { subgroupUrl: String };
 
   populateSubgroups(e) {
     const groupId = e.target.value;
+
+    const groupText = e.target.options[e.target.selectedIndex].text;
+    const stageOptions = this.stageToOptions(groupText, "Select stage");
+    this.stageSelectTarget.replaceChildren(...stageOptions);
+    
     if (!groupId) {
       this.clearSubgroups();
       return;
@@ -58,5 +64,40 @@ export default class extends Controller {
   displayVariablesWarning(e) {
     const body = tinymce.activeEditor.getContent();
     display(this.variableWarningTarget, body.indexOf("{{caseworker_full_name}}") > -1);
+  }
+
+  stageToOptions(groupText, selectText) {
+    const defaultStages = [
+      { id: 0, title: "Stage 0" },
+      { id: 1, title: "Stage 1" },
+      { id: 2, title: "Stage 2" },
+      { id: 3, title: "Stage 3" },
+      { id: 4, title: "Stage 4" }
+    ]
+
+    const cecStages = [
+      { id: 5, title: "Enquiry" },
+      { id: 6, title: "Onboarding form" },
+      { id: 7, title: "Form review" },
+      { id: 8, title: "With supplier" },
+      { id: 9, title: "Objection" },
+      { id: 10, title: "Awaiting contract start" },
+      { id: 11, title: "Interim rate customer" },
+      { id: 12, title: "V30 Rate Customer" }
+    ]
+
+    const stageOptions = groupText == 'CEC' ? cecStages : defaultStages
+    const options = stageOptions.map(stage => {
+      const option = document.createElement("option");
+      option.setAttribute("value", stage.id);
+      option.textContent = stage.title;
+      return option;
+    });
+    const selectOption = document.createElement("option");
+    selectOption.textContent = selectText;
+    selectOption.setAttribute("value", "");
+    options.unshift(selectOption);
+
+    return options;
   }
 }

--- a/app/javascript/controllers/email_templates_edit_controller.test.js
+++ b/app/javascript/controllers/email_templates_edit_controller.test.js
@@ -26,7 +26,6 @@ describe("EmailTemplatesEditController", () => {
 
   describe("subgroupSource", () => {
     const groupId = "123";
-    const groupText = "Group 1"
 
     it("concatenates the groupId to the subgroupUrl", () => {
       expect(subject.subgroupSource(groupId)).toEqual("https://test-url.com/123");
@@ -97,7 +96,7 @@ describe("EmailTemplatesEditController", () => {
       let subgroupSourceSpy;
       let groupsToOptionsSpy;
       const options = [createOption("", "Select group"), createOption("1", "Group 1"), createOption("2", "Group 2")];
-      const csrf_token = "token";      
+      const csrf_token = "token";
 
       beforeAll(() => {
         const meta = document.createElement("meta");
@@ -181,7 +180,7 @@ describe("EmailTemplatesEditController", () => {
       beforeEach(() => {
         textContent = "hi {{caseworker_full_name}}";
         displaySpy = jest.spyOn(utilities, "display").mockImplementation(() => {});
-        
+
         subject.displayVariablesWarning(null);
       });
 
@@ -194,7 +193,7 @@ describe("EmailTemplatesEditController", () => {
       beforeEach(() => {
         textContent = "this is test content";
         displaySpy = jest.spyOn(utilities, "display").mockImplementation(() => {});
-        
+
         subject.displayVariablesWarning(null);
       });
 

--- a/app/javascript/controllers/email_templates_edit_controller.test.js
+++ b/app/javascript/controllers/email_templates_edit_controller.test.js
@@ -17,6 +17,7 @@ describe("EmailTemplatesEditController", () => {
     subject.subgroupSelectTarget = document.createElement("select");
     subject.subgroupWrapperTarget = document.createElement("div");
     subject.variableWarningTarget = document.createElement("div");
+    subject.stageSelectTarget = document.createElement("select");
   });
 
   afterAll(() => {
@@ -25,6 +26,7 @@ describe("EmailTemplatesEditController", () => {
 
   describe("subgroupSource", () => {
     const groupId = "123";
+    const groupText = "Group 1"
 
     it("concatenates the groupId to the subgroupUrl", () => {
       expect(subject.subgroupSource(groupId)).toEqual("https://test-url.com/123");
@@ -71,7 +73,16 @@ describe("EmailTemplatesEditController", () => {
       let clearSubgroupsSpy;
 
       beforeEach(() => {
-        event = { target: { value: "" } };
+        event =  {
+          target: {
+            value: "",
+            options: [
+              { text: "Group 1" },
+              { text: "Group 2" },
+            ],
+            selectedIndex: 0,
+          },
+        };
         clearSubgroupsSpy = jest.spyOn(subject, "clearSubgroups").mockImplementation(() => {});
       });
 
@@ -96,7 +107,16 @@ describe("EmailTemplatesEditController", () => {
       })
 
       beforeEach(() => {
-        event = { target: { value: "1" } };
+        event = {
+          target: {
+            value: "1",
+            options: [
+              { text: "Group 1" },
+              { text: "Group 2" },
+            ],
+            selectedIndex: 1,
+          },
+        };
         subgroupSourceSpy = jest.spyOn(subject, "subgroupSource").mockImplementation(() => "https://test-url.com/123");
         groupsToOptionsSpy = jest.spyOn(subject, "groupsToOptions").mockImplementation(() => options);
 

--- a/app/models/support/email_template.rb
+++ b/app/models/support/email_template.rb
@@ -3,6 +3,7 @@ module Support
     include Support::Concerns::ScopeActive
 
     STAGE_VALUES = [0, 1, 2, 3, 4].freeze
+    CEC_STAGE_VALUES = [5, 6, 7, 8, 9, 10, 11, 12].freeze
 
     belongs_to :group, class_name: "Support::EmailTemplateGroup", foreign_key: "template_group_id"
     belongs_to :created_by, class_name: "Support::Agent"
@@ -10,7 +11,7 @@ module Support
     has_many :emails, class_name: "Support::Email", foreign_key: "template_id"
     has_many :attachments, class_name: "Support::EmailTemplateAttachment", foreign_key: "template_id", dependent: :destroy
 
-    validates :stage, inclusion: { in: STAGE_VALUES }, allow_nil: true
+    validates :stage, inclusion: { in: STAGE_VALUES + CEC_STAGE_VALUES }, allow_nil: true
 
     default_scope { order(:title) }
 
@@ -18,7 +19,20 @@ module Support
     scope :by_stages, ->(stages, include_null: false) { include_null ? where(stage: stages).or(where(stage: nil)) : where(stage: stages) }
     scope :without_stage, -> { where(stage: nil) }
 
-    def self.stages = STAGE_VALUES
+    def self.stages(group_id = nil)
+      is_cec_group?(group_id) ? CEC_STAGE_VALUES : STAGE_VALUES
+    end
+
+    def self.cec_stages
+      CEC_STAGE_VALUES
+    end
+
+    def self.is_cec_group?(group_id)
+      return false unless group_id && group_id.present?
+
+      group = Support::EmailTemplateGroup.find(group_id)
+      group.title == "CEC"
+    end
 
     def archive!(agent = nil)
       updates = {

--- a/app/views/support/cases/message_threads/_create_new_message_thread.erb
+++ b/app/views/support/cases/message_threads/_create_new_message_thread.erb
@@ -6,8 +6,12 @@
   </summary>
   <div class="govuk-details__text">
     <div class="govuk-button-group flex-align-center">
+      <% if (current_agent&.roles & %w[cec cec_admin]).any? %>
+      <%= link_to I18n.t("support.case.label.message_threads.create_with_template"), support_case_email_templates_path(back_to: Base64.encode64(@back_url), email_template_filters: { group_id: @cec_group&.id, subgroup_ids: [@dfe_subgroup&.id]} ), class: "govuk-button govuk-button--secondary", role: "button" %>
+      <% else %>
       <%= link_to I18n.t("support.case.label.message_threads.create_with_template"), support_case_email_templates_path(back_to: Base64.encode64(@back_url)), class: "govuk-button govuk-button--secondary", role: "button" %>
-      <%= button_to I18n.t("support.case.label.message_threads.create_using_signatory_template"), support_case_message_threads_path(back_to: Base64.encode64(@back_url)), class: "govuk-button govuk-button--secondary" %>
+      <% end %>
+      <%= button_to I18n.t("support.case.label.message_threads.create_using_signatory_template"), support_case_message_threads_path(back_to: Base64.encode64(@back_url) ), class: "govuk-button govuk-button--secondary" %>
     </div>
   </div>
 </details>

--- a/app/views/support/management/email_templates/form/_form.html.erb
+++ b/app/views/support/management/email_templates/form/_form.html.erb
@@ -30,7 +30,8 @@
           <%= form.govuk_select :stage,
               options_for_select(form.object.stage_options, form.object.stage),
               options: { include_blank: I18n.t("support.management.email_templates.new.select_stage") },
-              label: { text: I18n.t("support.management.email_templates.new.stage"), size: "m" } %>
+              label: { text: I18n.t("support.management.email_templates.new.stage"), size: "m" },
+              "data-email-templates-edit-target" => "stageSelect" %>
 
           <%= form.govuk_text_field :title,
               label: { text: I18n.t("support.management.email_templates.new.title"), size: "m" } %>

--- a/app/views/support/management/email_templates/template_manager/_filters.html.erb
+++ b/app/views/support/management/email_templates/template_manager/_filters.html.erb
@@ -1,5 +1,6 @@
 <div class="template-manager__filters-panel">
   <h2 class="govuk-heading-m"><%= I18n.t("support.management.email_templates.index.template_manager.filters.header") %></h2>
+  <%=  @cec_user%>
 
   <%= form_with model: @filter_form, scope: :email_template_filters, id: :email_template_filters, method: :get, url: filter_url, html: { "data-controller" => "email-template-filters" } do |form| %>
     <%= form.govuk_select :group_id,

--- a/app/views/support/management/email_templates/template_manager/templates/_template_tags.html.erb
+++ b/app/views/support/management/email_templates/template_manager/templates/_template_tags.html.erb
@@ -10,7 +10,7 @@
     <% if template.stage.present? %>
       <li>
         <strong class="govuk-tag govuk-tag--grey">
-          <%= template.stage %>
+          <%= I18n.t(template.stage.gsub("Stage ", "").strip, scope: 'support.management.email_templates.stages') %>
         </strong>
       </li>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2582,6 +2582,20 @@ en:
           stage: Stage
           unsafe_attachments: One or more attachments contain a virus
           variable_warning: "'{{caseworker_full_name}}' will be replaced by the name of the caseworker sending the email."
+        stages:
+          0: Stage 0
+          1: Stage 1
+          2: Stage 2
+          3: Stage 3
+          4: Stage 4
+          5: Enquiry
+          6: Onboarding form
+          7: Form review
+          8: With supplier
+          9: Objection
+          10: Awaiting contract start
+          11: Interim rate customer
+          12: V30 Rate Customer
         create:
           notice: Your template has been saved
         destroy:

--- a/config/support/email_template_groups.yml
+++ b/config/support/email_template_groups.yml
@@ -29,3 +29,7 @@ groups:
 
   - title: Approvals
     sub_groups: []
+
+  - title: CEC
+    sub_groups:
+      - title: DfE Energy for Schools service

--- a/spec/features/cec/emails/cec_agent_can_send_new_emails_spec.rb
+++ b/spec/features/cec/emails/cec_agent_can_send_new_emails_spec.rb
@@ -1,0 +1,39 @@
+describe "Agent can send new emails", :js do
+  include_context "with a cec agent"
+
+  let(:support_case) { create(:support_case, email: "contact@email.com") }
+
+  before do
+    visit cec_onboarding_case_path(support_case)
+    click_on "Messages"
+  end
+
+  it "shows the new thread expandable details button" do
+    within(all("details.govuk-details")[0]) do
+      expect(find("span.govuk-details__summary-text")).to have_text "Create a new message thread"
+    end
+  end
+
+  describe "check CEC filter applies", :js, :with_csrf_protection do
+    before do
+      cec_group = create(:support_email_template_group, title: "CEC")
+      create(:support_email_template_group, title: "DfE Energy for Schools service", parent: cec_group)
+      template = create(:support_email_template, title: "CEC template", subject: "about cec", body: "cec body", group: cec_group)
+      create(:support_email_template_attachment, template:)
+
+      first("span", text: "Create a new message thread").click
+    end
+
+    context "with a cec template" do
+      before do
+        within(all("details.govuk-details")[0]) do
+          click_on "Create with an email template"
+        end
+      end
+
+      it "pre-selected group" do
+        expect(page).to have_select("Select group", selected: "CEC")
+      end
+    end
+  end
+end

--- a/spec/features/support/management/email_templates/admin_can_create_templates_spec.rb
+++ b/spec/features/support/management/email_templates/admin_can_create_templates_spec.rb
@@ -6,6 +6,9 @@ describe "Admin can create email templates", :js, :with_csrf_protection do
   before do
     energy = create(:support_email_template_group, title: "Energy")
     create(:support_email_template_group, title: "Solar", parent: energy)
+
+    cec = create(:support_email_template_group, title: "CEC")
+    create(:support_email_template_group, title: "DfE Energy for Schools service", parent: cec)
   end
 
   describe "Admin viewing email templates selects to create a new template" do
@@ -33,6 +36,19 @@ describe "Admin can create email templates", :js, :with_csrf_protection do
       expect(page).to have_content("Stage 3")
       expect(page).to have_content("New template subject")
       expect(page).to have_content("Procurement Specialist")
+    end
+  end
+
+  describe "Admin can view CEC template group" do
+    before do
+      visit support_management_email_templates_path
+      click_on "Create new template"
+      select "CEC", from: "Template group"
+    end
+
+    it "view DfE Energy for Schools service" do
+      subgroup_field = find("#email-template-form-subgroup-id-field")
+      expect(subgroup_field).to have_selector("option", text: "DfE Energy for Schools service")
     end
   end
 end

--- a/spec/models/support/email_template_spec.rb
+++ b/spec/models/support/email_template_spec.rb
@@ -6,7 +6,7 @@ describe Support::EmailTemplate, type: :model do
   it { is_expected.to belong_to(:updated_by).class_name("Support::Agent").optional }
   it { is_expected.to have_many(:emails).class_name("Support::Email").with_foreign_key("template_id") }
   it { is_expected.to have_many(:attachments).class_name("Support::EmailTemplateAttachment").with_foreign_key("template_id") }
-  it { is_expected.to validate_inclusion_of(:stage).in_array([0, 1, 2, 3, 4]).allow_nil }
+  it { is_expected.to validate_inclusion_of(:stage).in_array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]).allow_nil }
 
   describe "default ordering" do
     before do

--- a/spec/services/support/emails/templates/seed_groups_spec.rb
+++ b/spec/services/support/emails/templates/seed_groups_spec.rb
@@ -8,8 +8,8 @@ describe Support::Emails::Templates::SeedGroups do
 
   it "populates the tables" do
     expect { service.call }
-      .to change(groups, :count).from(0).to(6)
-      .and change(sub_groups, :count).from(0).to(13)
+      .to change(groups, :count).from(0).to(7)
+      .and change(sub_groups, :count).from(0).to(14)
   end
 
   context "when a group has sub-groups" do


### PR DESCRIPTION
…lity

<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

[1a97ac0](https://github.com/DFE-Digital/buy-for-your-school/commit/1a97ac09d42280ef05a04ed7de5c2e0db762bbc2) - Updated CEC Email Template Filter files to include Subgroup functionality

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
