### PR TITLE
ES-502 - Restrict "Reject Case" Function to Admin Roles

### DIFF
--- a/app/views/support/cases/show/_case_actions.html.erb
+++ b/app/views/support/cases/show/_case_actions.html.erb
@@ -22,9 +22,11 @@
        <li>
         <%= link_to I18n.t("support.case.label.resolve"), portal_new_case_resolution_path(@current_case), class: "govuk-link" %>
       </li>
+      <% if !@current_case.energy_onboarding_case? || (current_agent&.roles & %w[procops_admin cec_admin]).any? %>
       <li>
         <%= link_to I18n.t("support.case_closures.action"), portal_case_closures_path(@current_case), class: "govuk-link" %>
       </li>
+      <% end %>
     <% else %>
       <li>
         <%= link_to I18n.t("support.case.label.assign_to_agent"), portal_new_case_assignments_path(@current_case), class: "govuk-link" unless @current_case.closed?%>

--- a/spec/features/cec/case_closure_link_spec.rb
+++ b/spec/features/cec/case_closure_link_spec.rb
@@ -1,0 +1,21 @@
+RSpec.feature "Case closure", :js do
+  include_context "with a cec agent"
+
+  let(:dfe_energy_category) { create(:support_category, title: "DfE Energy for Schools service") }
+  let(:energy_stage) { create(:support_procurement_stage, key: "onboarding_form", title: "Onboarding form", stage: "6") }
+  let(:support_case) { create(:support_case, category: dfe_energy_category, state: :opened, agent: nil, procurement_stage: energy_stage) }
+  let(:link) { "/cec/onboarding_cases/#{support_case.id}" }
+
+  describe "Check Reject case link" do
+    it "page should not have Reject case link" do
+      visit link
+      expect(page).not_to have_link("Reject case")
+    end
+
+    it "page should have Reject case link" do
+      agent.update!(roles: %w[cec cec_admin])
+      visit link
+      expect(page).to have_link("Reject case")
+    end
+  end
+end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

[ecf5df6](https://github.com/DFE-Digital/buy-for-your-school/commit/ecf5df6eb6f5dbe151851ce1a37df505130dd7dc)  - Displayed the "Reject Case" link based on agent roles 

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
