### PR TITLE
ES-639 Fix error when procurement type is query and changing to level 6

### DIFF
--- a/app/controllers/support/cases/summaries_controller.rb
+++ b/app/controllers/support/cases/summaries_controller.rb
@@ -20,8 +20,8 @@ module Support
 
         @case_summary.save!
 
-        # set status to ‘On hold’ when case level is L6 and procurement stage is Enquiry
-        if @case_summary.support_case.support_level == "L6" && @case_summary.procurement_stage.title == "Enquiry"
+        # set status to ‘On hold’ when case level is L6
+        if @case_summary.support_case.support_level == "L6"
           change_case_state(to: :on_hold)
         end
         # putting a redirect path in based on roles for now - this may change if a new form for CEC is created

--- a/spec/features/support/agent_can_change_case_summary_spec.rb
+++ b/spec/features/support/agent_can_change_case_summary_spec.rb
@@ -29,6 +29,7 @@ describe "Agent can change case summary", :js do
       fill_in "Description of next key date", with: "Key event"
       click_button "Continue"
       click_button "Save"
+      sleep 0.1
     end
 
     it "persists the changes" do
@@ -104,6 +105,7 @@ describe "Agent can change case summary", :js do
       fill_in "Description of next key date", with: "Key event"
       click_button "Continue"
       click_button "Save"
+      sleep 0.1
     end
 
     it "persists the changes" do


### PR DESCRIPTION
When a case has a request type of ‘query' rather than 'procurement', it doesn't have a procurement stage title so returns an internal server error. This code removes the condition of looking for the procurement title enquiry. It also adds a small sleep to the test which is flaky to fix that.

<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Removes condition for changing to on hold
- Adds small sleep to fix flaky tests

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
