### PR TITLE
ES-238 | Add ability to search cases by MPRN and MPAN

### DIFF
--- a/app/models/support/case/searchable.rb
+++ b/app/models/support/case/searchable.rb
@@ -5,5 +5,11 @@ module Support::Case::Searchable
     has_many :support_case_searches, class_name: "Support::CaseSearch"
 
     scope :by_search_term, ->(terms, exact_match: false) { joins(:support_case_searches).merge(Support::CaseSearch.find_a_case(terms, exact_match:)) }
+
+    scope :by_mpan_or_mprn, lambda { |terms|
+      where(id: joins(energy_onboarding_case: { onboarding_case_organisations: %i[gas_meters electricity_meters] })
+        .where("energy_gas_meters.mprn = :terms OR energy_electricity_meters.mpan = :terms", terms:)
+        .select("support_cases.id"))
+    }
   end
 end

--- a/app/models/support/case/searchable.rb
+++ b/app/models/support/case/searchable.rb
@@ -7,7 +7,7 @@ module Support::Case::Searchable
     scope :by_search_term, ->(terms, exact_match: false) { joins(:support_case_searches).merge(Support::CaseSearch.find_a_case(terms, exact_match:)) }
 
     scope :by_mpan_or_mprn, lambda { |terms|
-      where(id: joins(energy_onboarding_case: { onboarding_case_organisations: %i[gas_meters electricity_meters] })
+      where(id: left_outer_joins(energy_onboarding_case: { onboarding_case_organisations: %i[gas_meters electricity_meters] })
         .where("energy_gas_meters.mprn = :terms OR energy_electricity_meters.mpan = :terms", terms:)
         .select("support_cases.id"))
     }

--- a/app/models/support/concerns/scope_filter_for_search.rb
+++ b/app/models/support/concerns/scope_filter_for_search.rb
@@ -7,7 +7,11 @@ class Support::Concerns::ScopeFilterForSearch
   def filter(records)
     return records unless entered?
 
-    records.send(:by_search_term, value, exact_match:)
+    results = records.send(:by_search_term, value, exact_match:)
+
+    return results if results.present?
+
+    records.send(:by_mpan_or_mprn, value)
   end
 
   def entered?

--- a/spec/models/support/case_spec.rb
+++ b/spec/models/support/case_spec.rb
@@ -83,4 +83,37 @@ RSpec.describe Support::Case, type: :model do
       expect(described_class.high_level.map(&:support_level)).to match_array(%w[L3 L4 L5])
     end
   end
+
+  describe "search by_mpan_or_mprn" do
+    let(:support_case2) { create(:support_case) }
+    let(:onboarding_case) { create(:onboarding_case, support_case:) }
+    let(:onboarding_case_organisation) { create(:energy_onboarding_case_organisation, onboarding_case:, onboardable: support_case.organisation) }
+    let(:gas_meter) { create(:energy_gas_meter, :with_valid_data, onboarding_case_organisation:, mprn:) }
+    let(:electricity_meter) { create(:energy_electricity_meter, :with_valid_data, onboarding_case_organisation:, mpan:) }
+
+    let(:mprn) { "123456789" }
+    let(:mpan) { "0123456789123" }
+
+    before do
+      gas_meter
+      electricity_meter
+    end
+
+    it "finds case by mprn (gas meter)" do
+      results = described_class.by_mpan_or_mprn(mprn)
+      expect(results).to include(support_case)
+      expect(results).not_to include(support_case2)
+    end
+
+    it "finds case by mpan (electricity meter)" do
+      results = described_class.by_mpan_or_mprn(mpan)
+      expect(results).to include(support_case)
+      expect(results).not_to include(support_case2)
+    end
+
+    it "returns empty when term doesn't match" do
+      results = described_class.by_mpan_or_mprn("000000000")
+      expect(results).to be_empty
+    end
+  end
 end

--- a/spec/models/support/case_spec.rb
+++ b/spec/models/support/case_spec.rb
@@ -94,26 +94,52 @@ RSpec.describe Support::Case, type: :model do
     let(:mprn) { "123456789" }
     let(:mpan) { "0123456789123" }
 
-    before do
-      gas_meter
-      electricity_meter
+    context "with gas meter only" do
+      before do
+        gas_meter
+      end
+
+      it "finds case by mprn (gas meter)" do
+        results = described_class.by_mpan_or_mprn(mprn)
+        expect(results).to include(support_case)
+        expect(results).not_to include(support_case2)
+      end
     end
 
-    it "finds case by mprn (gas meter)" do
-      results = described_class.by_mpan_or_mprn(mprn)
-      expect(results).to include(support_case)
-      expect(results).not_to include(support_case2)
+    context "with electricity meter only" do
+      before do
+        electricity_meter
+      end
+
+      it "finds case by mpan (electricity meter)" do
+        results = described_class.by_mpan_or_mprn(mpan)
+        expect(results).to include(support_case)
+        expect(results).not_to include(support_case2)
+      end
     end
 
-    it "finds case by mpan (electricity meter)" do
-      results = described_class.by_mpan_or_mprn(mpan)
-      expect(results).to include(support_case)
-      expect(results).not_to include(support_case2)
-    end
+    context "with both gas and electricity meters" do
+      before do
+        gas_meter
+        electricity_meter
+      end
 
-    it "returns empty when term doesn't match" do
-      results = described_class.by_mpan_or_mprn("000000000")
-      expect(results).to be_empty
+      it "finds case by mprn (gas meter)" do
+        results = described_class.by_mpan_or_mprn(mprn)
+        expect(results).to include(support_case)
+        expect(results).not_to include(support_case2)
+      end
+
+      it "finds case by mpan (electricity meter)" do
+        results = described_class.by_mpan_or_mprn(mpan)
+        expect(results).to include(support_case)
+        expect(results).not_to include(support_case2)
+      end
+
+      it "returns empty when term doesn't match" do
+        results = described_class.by_mpan_or_mprn("000000000")
+        expect(results).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
Ticket: https://dfedigital.atlassian.net/browse/ES-238

This pull request enables users to search for cases using MPRN and MPAN. A new scope has been introduced, as the current case search functionality relies on the support_case_searches SQL view. Consequently, it is not feasible to integrate MPAN/MPRN search directly into the existing Lambda function.
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
