### PR TITLE
ES-568 - Custom DfE Analytics event for engagement time

### DIFF
--- a/app/controllers/dfe_analytics_events_controller.rb
+++ b/app/controllers/dfe_analytics_events_controller.rb
@@ -1,0 +1,35 @@
+class DfeAnalyticsEventsController < ApplicationController
+  EVENT_ALLOWLIST = {
+    page_engagement: %i[engaged_time_ms page_path page_title session_duration_ms timestamp],
+  }.freeze
+
+  def create
+    type = event_params[:type]&.to_sym
+    return bad_request unless EVENT_ALLOWLIST.key?(type)
+
+    data = event_params[:data].to_h.slice(*EVENT_ALLOWLIST[type])
+    send_dfe_analytics_event(type, data)
+
+    head :no_content
+  end
+
+private
+
+  def event_params
+    params.require(:event).permit(:type, data: {})
+  end
+
+  def bad_request
+    head(:bad_request)
+  end
+
+  def send_dfe_analytics_event(type, data)
+    event = DfE::Analytics::Event.new
+      .with_type(type)
+      .with_request_details(request)
+      .with_response_details(response)
+      .with_data(data:)
+
+    DfE::Analytics::SendEvents.do([event])
+  end
+end

--- a/app/javascript/controllers/dfe_analytics_engagement_tracking_controller.js
+++ b/app/javascript/controllers/dfe_analytics_engagement_tracking_controller.js
@@ -1,0 +1,132 @@
+import { Controller } from "@hotwired/stimulus"
+
+const EVENTS = ['mousedown', 'mousemove', 'keypress', 'keydown', 'input', 'scroll', 'touchstart', 'click', 'wheel', 'pointermove']
+const ACTIVITY_WINDOW_MS = 30000
+const SEND_INTERVAL_MS = 60000
+const CHECK_INTERVAL_MS = 10000
+
+export default class extends Controller {
+
+  connect() {
+    this.startTime = Date.now()
+    this.lastActivity = this.startTime
+    this.lastCheckTime = this.startTime
+    this.totalEngagedTime = 0
+    this.lastSentEngagedTime = 0
+    this.isVisible = !document.hidden
+    this.checkInterval = CHECK_INTERVAL_MS
+
+    this.boundHandleActivity = this.handleActivity.bind(this)
+    this.boundHandleVisibilityChange = this.handleVisibilityChange.bind(this)
+    this.boundHandleBeforeUnload = this.handleBeforeUnload.bind(this)
+
+    this.addEventListeners()
+    this.startPeriodicCheck()
+  }
+
+  disconnect() {
+    this.removeEventListeners()
+    this.clearPeriodicCheck()
+    this.sendEngagementData()
+  }
+
+  addEventListeners() {
+    EVENTS.forEach(event => {
+      document.addEventListener(event, this.boundHandleActivity, { passive: true })
+    })
+
+    document.addEventListener('visibilitychange', this.boundHandleVisibilityChange)
+    window.addEventListener('beforeunload', this.boundHandleBeforeUnload)
+  }
+
+  removeEventListeners() {
+    EVENTS.forEach(event => {
+      document.removeEventListener(event, this.boundHandleActivity)
+    })
+
+    document.removeEventListener('visibilitychange', this.boundHandleVisibilityChange)
+    window.removeEventListener('beforeunload', this.boundHandleBeforeUnload)
+  }
+
+  handleActivity() {
+    this.lastActivity = Date.now()
+  }
+
+  handleVisibilityChange() {
+    const now = Date.now()
+
+    if (document.hidden && this.isVisible) {
+      this.updateEngagedTime(now)
+      this.isVisible = false
+    } else if (!document.hidden && !this.isVisible) {
+      this.lastActivity = now
+      this.isVisible = true
+    }
+  }
+
+  handleBeforeUnload() {
+    this.sendEngagementData()
+  }
+
+  startPeriodicCheck() {
+    this.intervalId = setInterval(() => {
+      this.checkEngagement()
+    }, this.checkInterval)
+  }
+
+  clearPeriodicCheck() {
+    clearInterval(this.intervalId)
+  }
+
+  checkEngagement() {
+    const now = Date.now()
+    this.updateEngagedTime(now)
+
+    if (
+      this.totalEngagedTime > 0 &&
+      this.totalEngagedTime - this.lastSentEngagedTime >= SEND_INTERVAL_MS
+    ) {
+      this.sendEngagementData()
+      this.lastSentEngagedTime = this.totalEngagedTime
+    }
+  }
+
+  updateEngagedTime(now) {
+    if (this.isVisible && this.isRecentlyActive(now)) {
+      const timeSinceLastCheck = now - (this.lastCheckTime || this.startTime)
+      this.totalEngagedTime += Math.min(timeSinceLastCheck, this.checkInterval)
+    }
+    this.lastCheckTime = now
+  }
+
+  isRecentlyActive(now) {
+    return (now - this.lastActivity) < ACTIVITY_WINDOW_MS
+  }
+
+  async sendEngagementData() {
+    if (this.totalEngagedTime === 0) return
+
+    const engagementData = {
+      engaged_time_ms: this.totalEngagedTime,
+      page_path: window.location.pathname,
+      page_title: document.title,
+      session_duration_ms: Date.now() - this.startTime,
+      timestamp: new Date().toISOString()
+    }
+
+    await fetch('/dfe_analytics_events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({
+        event: {
+          type: 'page_engagement',
+          data: engagementData
+        }
+      }),
+      keepalive: true
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -87,3 +87,6 @@ application.register("download_documents", DownloadDocumentsController)
 
 import DateValidationController from "./date_validation_controller"
 application.register("date_validation", DateValidationController)
+
+import DfeAnalyticsEngagementTrackingController from "./dfe_analytics_engagement_tracking_controller"
+application.register("dfe_analytics_engagement_tracking", DfeAnalyticsEngagementTrackingController);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,7 +50,7 @@
     <%= javascript_include_tag "application" %>
   </head>
 
-  <body class="govuk-template__body">
+  <body class="govuk-template__body" data-controller="dfe_analytics_engagement_tracking">
 
     <%= javascript_tag nonce: true do -%>
       document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,0 +1,2 @@
+shared:
+  - page_engagement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@
 Rails.application.routes.draw do
   root to: "specify/create_a_specification#show"
 
+  # DfE analytics
+  post "/dfe_analytics_events", to: "dfe_analytics_events#create"
+
   # Misc
   get "health_check" => "application#health_check"
   get "maintenance" => "application#maintenance"


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

[c99cd0a](https://github.com/DFE-Digital/buy-for-your-school/commit/c99cd0a58816973bb80f3a6d010c76641339e8d3) - Added files to track dfe analytics engagement time

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
