### PR TITLE
ES-677 - Email Merge functionality to another case is not triggering the notification to the case owner

### DIFF
--- a/app/models/support/case/email_movable.rb
+++ b/app/models/support/case/email_movable.rb
@@ -31,6 +31,7 @@ module Support::Case::EmailMovable
         body: "from ##{ticket.ref}",
         agent_id: Current.actor.id,
       )
+      notify_agent_of_email_merge(agent_id) if agent_id.present?
       update!(action_required: emails.any? { |email| !email.is_read? })
     end
   end

--- a/app/models/support/case/notifiable.rb
+++ b/app/models/support/case/notifiable.rb
@@ -45,4 +45,16 @@ module Support::Case::Notifiable
       created_at: updated_at,
     )
   end
+
+  def notify_agent_of_email_merge(agent_id, assigned_by: Current.agent)
+    return if agent_id == Current.agent.id
+
+    notifications.email_merge.create!(
+      support_case: self,
+      assigned_by:,
+      assigned_to_id: agent_id,
+      subject: self,
+      created_at: updated_at,
+    )
+  end
 end

--- a/app/models/support/notification.rb
+++ b/app/models/support/notification.rb
@@ -11,6 +11,7 @@ module Support
       case_reopened: 2,
       case_closed: 3,
       evaluation_documents_uploaded: 4,
+      email_merge: 5,
     }
 
     scope :unread, -> { where(read: false) }
@@ -42,6 +43,7 @@ module Support
     def case_ref = support_case.ref
     def case_created = support_case.created_at
     def assigned_by_name = assigned_by.full_name
+    def assigned_by_email_address = assigned_by.email
     def received_at = created_at
   end
 end

--- a/app/views/support/notifications/topics/_email_merge.html.erb
+++ b/app/views/support/notifications/topics/_email_merge.html.erb
@@ -1,0 +1,22 @@
+<div class="notification-details">
+  <div class="major">
+    <% if cec_portal? || (support_portal? && (current_agent.roles & %w[cec cec_admin]).any?) %>
+      <span class="action">
+        <%= link_to(cec_notification_read_path(notification, redirect_to: cec_onboarding_case_path(notification.support_case, back_to: Base64.encode64(cec_notifications_path))), method: :post, class: "govuk-link--no-visited-state") do %>
+          Case <%= notification.case_ref %> - Email(s) merged to case
+        <% end %>
+      </span>
+    <% else %>
+      <span class="action">
+        <%= link_to(support_notification_read_path(notification, redirect_to: support_case_path(notification.support_case, back_to: Base64.encode64(support_notifications_path))), method: :post, class: "govuk-link--no-visited-state") do %>
+          Case <%= notification.case_ref %> - Email(s) merged to case
+        <% end %>
+      </span>
+    <% end %>
+    <span class="by">by <%= notification.assigned_by_email_address %></span>
+  </div>
+
+  <div class="minor">
+    <strong>Case created:</strong> <%= notification.case_created.strftime("%d %b %Y at %H:%M") %>
+  </div>
+</div>


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

[523f88d](https://github.com/DFE-Digital/buy-for-your-school/commit/523f88d430b692527b65d7996395ec4c84b2a546) - Added functionality to notify case owner when email merge to the case

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
