### PR TITLE
ES-688: SPIKE: Allow a MAT school to be onboarded by using the MAT school picker screen (option 2)

### DIFF
--- a/app/controllers/energy/authorisation_controller.rb
+++ b/app/controllers/energy/authorisation_controller.rb
@@ -7,10 +7,17 @@ module Energy
 
     def show; end
 
+    #  PATCH /energy/authorisation/:id/:type(/:onboarding_case_id)
     def update
-      return unless params[:type] == "single"
-
-      @onboarding_case_organisation = create_onboarding_case
+      if params[:type] == "single"
+        @onboarding_case_organisation = create_onboarding_case
+      else
+        # MAT - Support::Case and Energy::OnboardingCase have already been created
+        onboarding_case = Energy::OnboardingCase.find(params[:onboarding_case_id])
+        @onboarding_case_organisation = Energy::OnboardingCaseOrganisation.create!(
+          onboarding_case:, onboardable: @support_organisation,
+        )
+      end
 
       draft_and_send_onboarding_email_to_school
       redirect_to energy_case_switch_energy_path(case_id: @onboarding_case_organisation.energy_onboarding_case_id)
@@ -23,7 +30,8 @@ module Energy
     end
 
     def create_onboarding_case
-      Energy::CaseCreatable.create_case(current_user, @support_organisation)
+      _support_case, onboarding_case = Energy::CaseCreatable.create_case(current_user, @support_organisation)
+      onboarding_case.onboarding_case_organisations.first
     end
 
     def check_active_onboarding_case

--- a/app/controllers/energy/mat_school_picker_controller.rb
+++ b/app/controllers/energy/mat_school_picker_controller.rb
@@ -1,0 +1,67 @@
+module Energy
+  class MatSchoolPickerController < ApplicationController
+    skip_before_action :check_if_submitted
+    before_action :form
+    before_action :case_request, only: %i[edit update]
+
+    # GET /energy/which-mat-schools-buying-for/:energy_case_id/:mat_uid
+    def edit
+      energy_case = Energy::OnboardingCase.find(params[:energy_case_id])
+      @case_request = energy_case.support_case
+
+      @back_url = energy_school_selection_path
+      @school_picker = form_params[:school_urns].nil? ? @case_request.school_picker : @case_request.school_picker(school_urns: form_params[:school_urns].compact_blank.excluding("all"))
+      @group = Support::EstablishmentGroup.find_by(uid: params[:mat_uid])
+      @all_schools = @group.organisations_for_multi_school_picker.order(:name)
+      @filters = @all_schools.filtering({ statuses: %w[opened opening closing] })
+      @filtered_schools = @filters.results.map { |s| Support::OrganisationPresenter.new(s) }
+      @all_selectable_schools = @filtered_schools
+    end
+
+    # POST /energy/which-mat-schools-buying-for/:energy_case_id/:mat_uid
+    def update
+      mat_school_urn = params[:framework_support_form][:school_urns].reject(&:empty?).first
+      mat_school = Support::Organisation.find_by(urn: mat_school_urn)
+
+      # Create the Energy org
+      onboarding_case = Energy::OnboardingCase.find(params[:energy_case_id])
+      Energy::OnboardingCaseOrganisation.create!(onboardable: mat_school, onboarding_case:)
+
+      redirect_to school_type_energy_authorisation_path(id: params[:mat_uid],
+                                                        type: "mat",
+                                                        onboarding_case_id: onboarding_case.id)
+    end
+
+  private
+
+    def form
+      @form ||= FrameworkRequests::SchoolPickerForm.new(all_form_params)
+    end
+
+    def case_request
+      @case_request = CaseRequest.find_by(id: params[:id])
+    end
+
+    def form_params
+      params.fetch(:case_request, {}).permit(filters: params.key?(:clear) ? nil : { local_authorities: [], phases: [], statuses: [] }, school_urns: [])
+    end
+
+    def all_form_params
+      params.fetch(:framework_support_form, {}).permit(*%i[
+        dsi
+        school_type
+        org_confirm
+        special_requirements_choice
+        source
+      ], *form_params).merge(id: framework_request_id, user: current_user)
+    end
+
+    def framework_request_id
+      return params[:id] if params[:id]
+      return session[:framework_request_id] if session[:framework_request_id]
+
+      session[:framework_request_id] = FrameworkRequest.create_with_inferred_attributes!(UserPresenter.new(current_user)).id
+      session[:framework_request_id]
+    end
+  end
+end

--- a/app/controllers/energy/school_selections_controller.rb
+++ b/app/controllers/energy/school_selections_controller.rb
@@ -17,9 +17,9 @@ module Energy
         when "urn"
           redirect_to school_type_energy_authorisation_path(id:, type: "single")
         when "uid"
-          # TODO: Update this when MAT service is available
-          # redirect_to school_type_energy_authorisation_path(id: id, type: "mat")
-          redirect_to energy_service_availability_path(id:)
+          # A MAT has been selected. Create the support & energy case
+          _support_case, energy_case = Energy::CaseCreatable.create_case(current_user)
+          redirect_to energy_mat_school_picker_path(mat_uid: id, energy_case_id: energy_case.id)
         else
           redirect_to energy_school_selection_path
         end

--- a/app/views/energy/authorisation/show.html.erb
+++ b/app/views/energy/authorisation/show.html.erb
@@ -24,7 +24,7 @@
 
         <div class="govuk-button-group flex-align-center">
             <%= link_to I18n.t("generic.button.continue"),
-                school_type_energy_authorisation_path(id: params[:id], type: params[:type]),
+                school_type_energy_authorisation_path(id: params[:id], type: params[:type], onboarding_case_id: params[:onboarding_case_id]),
                 method: :patch,
                 class: "govuk-button" %>
         </div>

--- a/app/views/energy/mat_school_picker/edit.html.erb
+++ b/app/views/energy/mat_school_picker/edit.html.erb
@@ -1,0 +1,13 @@
+<% side = show_school_picker_filters?(@all_schools) ? "filters" : nil %>
+
+<%= content_for :title, I18n.t("faf.school_picker.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l"><%= I18n.t("faf.school_picker.caption") %></span>
+    <h1 class="govuk-heading-l"><%= I18n.t("faf.school_picker.title") %></h1>
+    <p class="govuk-body"><%= I18n.t("faf.school_picker.subtitle") %></p>
+  </div>
+</div>
+
+<%= render "framework_requests/form", route: "school_pickers", verb: :post, side:, path: energy_mat_school_picker_path %>

--- a/app/views/framework_requests/_form.html.erb
+++ b/app/views/framework_requests/_form.html.erb
@@ -21,5 +21,5 @@
 </div>
 
 <% if Rails.env.development? %>
-  <%= render "framework_requests/debug" %>
+  <%#= render "framework_requests/debug" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -511,9 +511,13 @@ Rails.application.routes.draw do
   patch "/energy/which-school-buying-for", to: "energy/school_selections#update"
   get "/energy/school-selection-unavailable(/:id)", to: "energy/service_availability#show", as: "energy_service_availability"
 
+  #  MAT school selection
+  get "/energy/which-mat-schools-buying-for/:energy_case_id/:mat_uid", to: "energy/mat_school_picker#edit", as: "energy_mat_school_picker"
+  post "/energy/which-mat-schools-buying-for/:energy_case_id/:mat_uid", to: "energy/mat_school_picker#update"
+
   # Authorisation
-  get "/energy/authorisation/:id/:type", to: "energy/authorisation#show", as: "school_type_energy_authorisation"
-  patch "/energy/authorisation/:id/:type", to: "energy/authorisation#update"
+  get "/energy/authorisation/:id/:type(/:onboarding_case_id)", to: "energy/authorisation#show", as: "school_type_energy_authorisation"
+  patch "/energy/authorisation/:id/:type(/:onboarding_case_id)", to: "energy/authorisation#update"
 
   # rubocop:disable Layout/SpaceInsideArrayPercentLiteral
   # Case level

--- a/spec/features/energy/mat_option2_spec.rb
+++ b/spec/features/energy/mat_option2_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe "MAT flow (option 2)", :js do
+  include_context "with schools and groups"
+
+  before do
+    create(:support_category, title: "DfE Energy for Schools service")
+  end
+
+  specify "Authenticating and seeing the school selection" do
+    Current.user = user
+    user_exists_in_dfe_sign_in(user:)
+    user_is_signed_in(user:)
+
+    # No Support::Case, Energy::OnboardingCase
+    expect(Support::Case.count).to eq(0)
+    expect(Energy::OnboardingCase.count).to eq(0)
+    expect(Energy::OnboardingCaseOrganisation.count).to eq(0)
+
+    visit energy_school_selection_path
+
+    # See the school picker including the MAT
+    expect(page).to have_text("Which school are you buying for?")
+    expect(page).to have_text("Testing Multi Academy Trust")
+    choose "Testing Multi Academy Trust"
+    click_button "Continue"
+
+    # The Support::Case and Energy::OnboardingCase should be created
+    expect(Support::Case.count).to eq(1)
+    expect(Energy::OnboardingCase.count).to eq(1)
+    expect(Energy::OnboardingCaseOrganisation.count).to eq(0)
+
+    #  See the MAT school picker
+    expect(page).to have_text("Which schools in your academy trust")
+    check "Greendale Academy for Bright Sparks" #  FIXME: This sh be choose
+    click_button "Continue"
+
+    # The Energy::OnboardingCaseOrganisation should be created
+    sleep 1
+    expect(Support::Case.count).to eq(1)
+    expect(Energy::OnboardingCase.count).to eq(1)
+    expect(Energy::OnboardingCaseOrganisation.count).to eq(1)
+
+    # The Energy::Org should belong to a MAT BUT still be a school
+    school = Energy::OnboardingCaseOrganisation.first
+    expect(school.onboardable_type).to eq("Support::Organisation")
+    expect(school.onboardable.name).to eq("Greendale Academy for Bright Sparks")
+
+    # See auth page for chosen school
+    expect(page).to have_text("Are you authorised")
+    expect(page).to have_text("Testing Multi Academy Trust")
+    expect(page).to have_text("Greendale Academy for Bright Sparks")
+    click_link "Continue"
+
+    # See energy type selection page
+    expect(page).to have_text("What type of E")
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/ES-688

This PR explores using the existing MAT school selector page at the front of the existing single flow, to enable the user to onboard a school within a MAT
The current state of things and outstanding items:
- Manually, I was able to take a MAT school through to _Check your answers_, which had an error. Sadly this functionality regressed slightly as further exploratory tweaks were made
- The `spec/features/energy/mat_option2_spec.rb` spec currently fails as the _Energy type selection_ page loads with an odd webmock error
- The MAT school picker still has checkboxes allowing multiple schools to be chosen. We only want to allow a single school, so these need to become radio selectors
- The code is rough. Sadly we have to create a `SupportRequest` just to use the MAT school picker. There is further work to unpick the existing code, maybe creating a lighter weight version for energy
- I only got so far. There are undoubtedly more bugs to iron out that were hidden by earlier failures, e.g. the Check your answers page is currently failing, so too, the task list will probably need work as it shares a lot of code with CYA

