### PR TITLE
ES-666 - Disable the ability to make an existing case an 'Energy Onboarding' case

### DIFF
--- a/app/helpers/support/collection_helper.rb
+++ b/app/helpers/support/collection_helper.rb
@@ -28,8 +28,8 @@ module Support
       end
     end
 
-    def procurement_stage_grouped_options(selected_procurement_stage_id: -1, energy_case: false, energy_case_submitted: false)
-      (energy_case && energy_case_submitted ? [6] : Support::ProcurementStage.stages).map do |stage|
+    def procurement_stage_grouped_options(selected_procurement_stage_id: -1, energy_case: false, onboarding_form: false)
+      (energy_case && onboarding_form ? [6] : Support::ProcurementStage.stages.reject { |stage| stage == 6 }).map do |stage|
         ["STAGE #{stage}", Support::ProcurementStage.substages_for_stage(stage).map { |sub_stage| [sub_stage.title, sub_stage.id, { selected: selected_procurement_stage_id == sub_stage.id }] }]
       end
     end

--- a/app/javascript/controllers/case_stage_controller.js
+++ b/app/javascript/controllers/case_stage_controller.js
@@ -19,6 +19,30 @@ export default class extends Controller {
 
   toggleProcurementStageEnabled(e) {
     const supportLevel = e.target.value;
+    const formObject = this.procurementStageWrapperTarget.closest("form");
+    let procurement;
+    let procurementCategory;
+    let nonProcurement;
+    let nonProcurementCategory;
+    let energyCategory;
+    let otherCategory;
+    let procurementText;
+    let procurementLabel;
+    let otherCategoryText;
+    let otherCategoryLabel;
+    if (formObject) {
+      procurement = formObject.querySelector("#case-summary-request-type-true-field");
+      procurementCategory = formObject.querySelector("#case-summary-request-type-true-conditional");
+      nonProcurement = formObject.querySelector("#case-summary-request-type-field");
+      nonProcurementCategory = formObject.querySelector("#case-summary-request-type-conditional");
+      energyCategory = formObject.querySelector("#select_request_details_category_id");
+      otherCategory = formObject.querySelector("#select_request_details_query_id");
+      procurementText = formObject.querySelector("#request_details_other_category_text");
+      procurementLabel = formObject.querySelector('label[for="request_details_other_category_text"]');
+      otherCategoryText = formObject.querySelector("#request_details_other_query_text");
+      otherCategoryLabel = formObject.querySelector('label[for="request_details_other_query_text"]');
+    }
+
     switch (supportLevel) {
       case "L4":
       case "L5":
@@ -29,6 +53,39 @@ export default class extends Controller {
       default:
         enable(this.procurementStageTarget, false);
         this.procurementStageTarget.selectedIndex = 0;
+    }
+
+    // Helper function to update categories
+    const updateCategories = (energyText, otherText) => {
+      const energyOption = Array.from(energyCategory.options).find(option => option.text === energyText);
+      if (energyOption) energyCategory.value = energyOption.value;
+
+      const otherOption = Array.from(otherCategory.options).find(option => option.text === otherText);
+      if (otherOption) otherCategory.value = otherOption.value;
+
+      procurementCategory.classList = "govuk-radios__conditional";
+      nonProcurementCategory.classList = "govuk-radios__conditional govuk-radios__conditional--hidden";
+      procurementText.classList = "govuk-input govuk-!-display-none";
+      procurementLabel.classList = "govuk-label govuk-!-display-none";
+      otherCategoryText.classList = "govuk-input govuk-!-display-none";
+      otherCategoryLabel.classList = "govuk-label govuk-!-display-none";
+    };
+
+    if (procurement) {
+      if (supportLevel === "L6") {
+        nonProcurement.checked = false;
+        procurement.checked = true;
+        procurement.dispatchEvent(new Event("change"));
+        updateCategories("DfE Energy for Schools service", "Please select");
+      } else {
+        const energyCategorySelected = energyCategory.options[energyCategory.selectedIndex].text;
+        if (!(energyCategorySelected === "DfE Energy for Schools service" && procurement.checked)) return false;
+    
+        nonProcurement.checked = false;
+        procurement.checked = true;
+        procurement.dispatchEvent(new Event("change"));
+        updateCategories("Please select", "Please select");
+      }
     }
   }
 

--- a/app/javascript/request/request_details.js
+++ b/app/javascript/request/request_details.js
@@ -32,10 +32,15 @@ function removeValuesOnSelect() {
   } else {
     const otherCategoryText = document.getElementById("request_details_other_category_text");
     const categorySelect = document.getElementById("select_request_details_category_id");
+    const supportLevel6 = document.getElementById("case-summary-support-level-l6-field");
     changeOtherCategoryTextState("hidden")
 
     otherCategoryText.value = '';
     categorySelect.value = '';
+
+    if (supportLevel6.checked) {
+      document.getElementById("case-summary-support-level-l1-field").checked = true;
+    }
   }
 }
 
@@ -98,9 +103,9 @@ function toggleCategoryOtherBoxVisibility() {
 
 function handlingEnergyCategory() {
   const energyCategory = this.options[this.selectedIndex].text == 'DfE Energy for Schools service'
-  const caseLevel1 = document.querySelector("input[name='case_summary[support_level]'][value='L1']");
-  const caseLevel6 = document.querySelector("input[name='case_summary[support_level]'][value='L6']");
-  const procurementStage = document.getElementById("case-summary-procurement-stage-id-field");
+  const caseLevel1 = document.querySelector("#case-summary-support-level-l1-field");
+  const caseLevel6 = document.querySelector("#case-summary-support-level-l6-field");
+  const procurementStage = document.querySelector("#case-summary-procurement-stage-id-field");
 
   if (energyCategory ) {
     const stageSelect = Array.from(procurementStage.options).find(option => option.text === "Enquiry");
@@ -112,9 +117,11 @@ function handlingEnergyCategory() {
     caseLevel6.checked = true
     caseLevel6.dispatchEvent(new Event("change"));
   } else {
-    procurementStage.selectedIndex = 0
-    procurementStage.dispatchEvent(new Event("change"))
-  
+    if (!procurementStage.disabled) {
+      procurementStage.selectedIndex = 0
+      procurementStage.dispatchEvent(new Event("change"))
+    }
+    caseLevel6.checked = false
     caseLevel1.checked = true
     caseLevel1.dispatchEvent(new Event("change"));
   }

--- a/app/views/support/cases/components/_level_and_stage.html.erb
+++ b/app/views/support/cases/components/_level_and_stage.html.erb
@@ -1,4 +1,5 @@
 <% energy_case = @current_case && @current_case.energy_onboarding_case? ? true : false %>
+<% onboarding_form = form.object.support_level == "L7" ? true : false %>
 <% field_disabled = @current_case && @current_case.support_level.in?(%w[L6 L7]) %>
 <% energy_case_submitted =  @current_case && @current_case.energy_onboarding_case? && @current_case.energy_onboarding_case&.submitted_at.present? ? true : false %>
 <div class="case-stage-fields" data-controller="case-stage">
@@ -6,17 +7,20 @@
     <%= form.hidden_field :support_level, value: form.object.support_level %>  
     <div class="govuk-radios">
       <% Support::Case.support_levels.each do |level| %>
-        <%= form.govuk_radio_button :support_level, level.first, disabled: field_disabled, label: { text: I18n.t("support.case.label.support_level.#{level.first}") }, "data-action": "case-stage#toggleProcurementStageEnabled" %>
+        <% energy_form = level.first == "L7" ? true : false %>
+        <% quick_edit_disable = params[:controller].include?("quick_edits") && form.object.support_level.in?(%w[L1 L2 L3 L4 L5]) && level.first == "L6" %>
+        <%= form.govuk_radio_button :support_level, level.first, disabled: field_disabled || energy_form || quick_edit_disable, label: { text: I18n.t("support.case.label.support_level.#{level.first}") }, "data-action": "case-stage#toggleProcurementStageEnabled" %>
       <% end %>
       <%= form.govuk_radio_button :support_level, "", disabled: field_disabled, label: { text: I18n.t("support.case.label.support_level.unspecified") }, "data-action": "case-stage#toggleProcurementStageEnabled" %>
     </div>
   <% end %>
 
+  <%= form.hidden_field :procurement_stage_id, value: form.object.procurement_stage_id %>  
   <%= form.govuk_select :procurement_stage_id,
-                        grouped_options_for_select(procurement_stage_grouped_options(selected_procurement_stage_id: form.object.procurement_stage_id, energy_case:, energy_case_submitted:)),
+                        grouped_options_for_select(procurement_stage_grouped_options(selected_procurement_stage_id: form.object.procurement_stage_id, energy_case:, onboarding_form:)),
                         class: "case-summary__procurement-stages",
                         label: { text: I18n.t("support.case.label.procurement_stage"), size: "m" },
                         "data-case-stage-target": "procurementStage",
                         form_group: { "data-case-stage-target" => "procurementStageWrapper" },
-                        disabled: !form.object.support_level.in?(%w[L4 L5 L6 L7]) || (energy_case && !energy_case_submitted) %>
+                        disabled: !form.object.support_level.in?(%w[L4 L5 L6 L7]) || (energy_case && !energy_case_submitted && form.object.support_level == "L7") %>
 </div>

--- a/spec/features/cec/cec_agent_can_quick_edit_case_spec.rb
+++ b/spec/features/cec/cec_agent_can_quick_edit_case_spec.rb
@@ -5,7 +5,7 @@ describe "Agent can quick edit a case", :js do
 
   let!(:dfe_energy_category) { create(:support_category, title: "DfE Energy for Schools service") }
   let!(:energy_stage) { create(:support_procurement_stage, key: "onboarding_form", title: "Onboarding form", stage: "6") }
-  let!(:support_case) { create(:support_case, ref: "000001", agent:, category: dfe_energy_category, support_level: "L1", source: :energy_onboarding, procurement_stage: energy_stage) }
+  let!(:support_case) { create(:support_case, ref: "000001", agent:, category: dfe_energy_category, support_level: "L6", source: :energy_onboarding, procurement_stage: energy_stage) }
 
   before do
     visit cec_onboarding_cases_path(anchor: "my-cases")
@@ -15,7 +15,6 @@ describe "Agent can quick edit a case", :js do
   context "when changing the note, next key date, and 'with school' flag" do
     before do
       fill_in "Add a note to case 000001", with: "New note"
-      choose "7 - DfE Energy for Schools onboarding case"
       fill_in "Day", with: "10"
       fill_in "Month", with: "08"
       fill_in "Year", with: "2026"
@@ -25,7 +24,7 @@ describe "Agent can quick edit a case", :js do
     end
 
     it "persists the changes" do
-      expect(support_case.reload.support_level).to eq("L7")
+      expect(support_case.reload.support_level).to eq("L6")
       expect(support_case.reload.next_key_date).to eq(Date.parse("2026-08-10"))
       expect(support_case.reload.next_key_date_description).to eq("Key event")
       expect(support_case.reload.with_school).to eq(true)

--- a/spec/features/support/agent_can_change_case_summary_spec.rb
+++ b/spec/features/support/agent_can_change_case_summary_spec.rb
@@ -172,5 +172,15 @@ describe "Agent can change case summary", :js do
 
       expect(page.find("#case-summary-procurement-stage-id-field")["disabled"]).to eq("false")
     end
+
+    it "show only onboarding stages" do
+      onboarding_case.update!(submitted_at: Time.current)
+
+      select_box = page.find("#case-summary-procurement-stage-id-field")
+      option_group_6 = select_box.all("optgroup").find { |group| group[:label] == "STAGE 6" }
+      option_group_1 = select_box.all("optgroup").find { |group| group[:label] == "STAGE 1" }
+      expect(option_group_6).not_to be_nil
+      expect(option_group_1).to be_nil
+    end
   end
 end

--- a/spec/features/support/agent_can_quick_edit_case_spec.rb
+++ b/spec/features/support/agent_can_quick_edit_case_spec.rb
@@ -36,4 +36,10 @@ describe "Agent can quick edit a case", :js do
       expect(support_case.reload.with_school).to eq(true)
     end
   end
+
+  context "when the case level is 1 to 5" do
+    it "Level 6 should be disabled" do
+      expect(page.find("#case-quick-edit-support-level-l6-field")[:disabled]).to eq("true")
+    end
+  end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
[a371046](https://github.com/DFE-Digital/buy-for-your-school/commit/a3710469ca94e4333a99952e3e3d4d20936359a3) - Merge branch 'ES-596' into ES-666

[eba54c8](https://github.com/DFE-Digital/buy-for-your-school/pull/2293/commits/eba54c860eca01554d58f4be1e368b4d41563dd2) - Updated the files to show only onboarding stages for Level 7 cases. Level 6 should have the category 'DfE Energy for Schools service'.

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
