### PR TITLE
ES-782 - Remove energy deadline sentences from the start page

### DIFF
--- a/app/views/energy/onboarding/start.html.erb
+++ b/app/views/energy/onboarding/start.html.erb
@@ -9,7 +9,6 @@
     <%= render ParagraphComponent.new(text: I18n.t("energy.join.benefits.text")) %>
     <%= govuk_list I18n.t("energy.join.benefits.list"), type: :bullet %>
     <%= render ParagraphComponent.new(text: I18n.t("energy.join.mat_info", form_url: @register_your_interest_form_url)) %>
-    <%= render ParagraphComponent.new(text: I18n.t("energy.join.deadline").html_safe) %>
 
     <%= govuk_start_button(text: I18n.t("generic.button.start"), href: energy_before_you_start_path) %>
     <%= govuk_list [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,7 +312,6 @@ en:
       mat_info:
       - The Energy for Schools online service is currently only available for individual state-funded schools, like local authority-maintained schools and single academy trusts.
       - Multi-academy trusts (MATs) can join the contract by filling in the <a class="govuk-link" href="%{form_url}">Register your interest form</a> and completing the process offline.
-      deadline: "<span class=\"govuk-!-font-weight-bold\">Apply by 5pm, 11 September 2025</span> to join the next available V30 contract in April 2026. You’ll be placed on an interim rate if your current contract expires before 31 March 2026."
       more_info: Get more information
     guidance:
       contents: Contents


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Remove the energy deadline sentences from the start page
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
<img width="1067" height="912" alt="Screenshot 2025-09-11 at 09 36 33" src="https://github.com/user-attachments/assets/c2107afe-9acd-4ada-98c8-eea6cc0408d4" />

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
