### PR TITLE
Fix search toggle Stimulus controller

### DIFF
--- a/app/javascript/controllers/search_toggle_controller.js
+++ b/app/javascript/controllers/search_toggle_controller.js
@@ -2,18 +2,16 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   static targets = ['openButton', 'closeButton', 'backgroundColor']
-  static classes = ['hidden']
 
   connect () {
-    // Get the hidden class from data attribute (defaults to 'is-not-visible')
-    // data-search-toggle-hidden-class becomes searchToggleHiddenClass in dataset
-    this.hiddenClassName = this.element.dataset.searchToggleHiddenClass || 'is-not-visible'
-    this.backgroundClassName = this.element.dataset.searchToggleBackgroundClass || 'search-header-background'
-    
+    this.hiddenClassName = this.element.dataset.searchToggleHiddenClass
+    this.backgroundClassName = this.element.dataset.searchToggleBackgroundClass
+    this.visibleClassName = this.element.dataset.searchToggleVisibleClass
+
     // Get the search box element
     this.searchBox = document.getElementById('wrap-search')
     this.searchArea = document.querySelector('.search-area')
-    
+
     // Ensure initial state
     if (this.openButtonTarget) {
       this.openButtonTarget.classList.remove(this.hiddenClassName)
@@ -23,6 +21,7 @@ export default class extends Controller {
     }
     if (this.searchBox) {
       this.searchBox.classList.add(this.hiddenClassName)
+      this.searchBox.classList.remove(this.visibleClassName)
     }
   }
 
@@ -35,6 +34,7 @@ export default class extends Controller {
     }
     if (this.searchBox) {
       this.searchBox.classList.remove(this.hiddenClassName)
+      this.searchBox.classList.add(this.visibleClassName)
     }
     if (this.searchArea) {
       this.searchArea.classList.add(this.backgroundClassName)
@@ -53,6 +53,7 @@ export default class extends Controller {
     }
     if (this.searchBox) {
       this.searchBox.classList.add(this.hiddenClassName)
+      this.searchBox.classList.remove(this.visibleClassName)
     }
     if (this.searchArea) {
       this.searchArea.classList.remove(this.backgroundClassName)

--- a/app/services/solution_indexer.rb
+++ b/app/services/solution_indexer.rb
@@ -1,0 +1,74 @@
+require "opensearch/transport"
+
+class SolutionIndexer
+  attr_reader :id, :client
+
+  INDEX = "solution-data".freeze
+
+  def initialize(id:)
+    @client = SearchClient.instance
+    @id = id
+  end
+
+  def index_document
+    return false if entry.nil?
+
+    response = client.index(index: INDEX, id:, body:)
+
+    return true if index_created?(response["result"])
+
+    false
+  end
+
+  def delete_document
+    response = client.delete(index: INDEX, id:)
+    return true if index_deleted?(response["result"])
+
+    false
+  rescue OpenSearch::Transport::Transport::Errors::NotFound
+    true
+  end
+
+  def find_document
+    client.get(
+      index: "solution-data",
+      id:,
+    )
+  rescue OpenSearch::Transport::Transport::Errors::NotFound
+    nil
+  end
+
+private
+
+  def index_created?(result)
+    %w[created updated].include?(result)
+  end
+
+  def index_deleted?(result)
+    result == "deleted"
+  end
+
+  def entry
+    @entry ||= Solution.find_by_id!(id)
+  end
+
+  def body
+    {
+      id: entry.id,
+      title: entry.title,
+      description: entry.description,
+      summary: entry.summary,
+      slug: entry.slug,
+      provider_reference: entry.provider_reference,
+      primary_category:,
+    }
+  end
+
+  def primary_category
+    {
+      id: entry.primary_category.id,
+      title: entry.primary_category.title,
+      slug: entry.primary_category.slug,
+    }
+  end
+end

--- a/app/services/solution_searcher.rb
+++ b/app/services/solution_searcher.rb
@@ -1,0 +1,33 @@
+require "opensearch/transport"
+
+class SolutionSearcher
+  attr_reader :query, :client
+
+  INDEX = "solution-data".freeze
+
+  def initialize(query:)
+    @client = SearchClient.instance
+    @query = query
+  end
+
+  def search
+    results = client.search(index: INDEX, body: search_body)["hits"]["hits"]
+    return [] if results.empty?
+
+    results.map { |result| Solution.rehydrate_from_search(result["_source"]) }
+      .select(&:presentable?)
+  end
+
+private
+
+  def search_body
+    @search_body ||= {
+      query: {
+        multi_match: {
+          query:,
+          fields: %w[title description summary slug provider_reference],
+        },
+      },
+    }
+  end
+end

--- a/app/views/shared/_dfe_search_button.html.erb
+++ b/app/views/shared/_dfe_search_button.html.erb
@@ -1,5 +1,5 @@
 <div class="dfe-header__search_narrow" data-controller="search-toggle"
-data-search-toggle-hidden-class="is-not-visible" data-search-toggle-background-class="search-header-background">
+data-search-toggle-hidden-class="is-not-visible" data-search-toggle-visible-class="js-show" data-search-toggle-background-class="search-header-background">
   <div  data-search-toggle-target="backgroundColor" id="content-header">
     <button  class="search_open" id="toggle-search" aria-controls="search" aria-label="Open search"
             data-action="search-toggle#toggleOpen" data-search-toggle-target="openButton">

--- a/spec/services/solution_indexer_spec.rb
+++ b/spec/services/solution_indexer_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe SolutionIndexer do
+  subject(:indexer) { described_class.new(id:) }
+
+  let(:solution_index) { "solution-data" }
+  let(:id) { "solution-123" }
+
+  let(:es_client_mock) { instance_double(::OpenSearch::Client) }
+  let(:primary_category) do
+    instance_double(
+      Category,
+      id: "mock_id",
+      title: "mock title",
+      slug: " mock slug",
+    )
+  end
+
+  let(:primary_category_hash) do
+    {
+      id: "mock_id",
+      title: "mock title",
+      slug: " mock slug",
+    }
+  end
+
+  let(:solution_entry) do
+    instance_double(
+      Solution,
+      id: "solution-123",
+      title: "Test Solution",
+      description: "A description.",
+      summary: "A summary.",
+      slug: "test-solution",
+      provider_reference: "ref-123",
+      primary_category:,
+    )
+  end
+
+  before do
+    allow(SearchClient).to receive(:instance).and_return(es_client_mock)
+    allow(Solution).to receive(:find_by_id!).with(id).and_return(solution_entry)
+  end
+
+  describe "#index_document" do
+    context "when the entry is found and indexing is successful" do
+      it "calls the search client's index method" do
+        allow(es_client_mock).to receive(:index).with(
+          index: solution_index,
+          id:,
+          body: {
+            id: solution_entry.id,
+            title: solution_entry.title,
+            description: solution_entry.description,
+            summary: solution_entry.summary,
+            slug: solution_entry.slug,
+            provider_reference: solution_entry.provider_reference,
+            primary_category: primary_category_hash,
+          },
+        ).and_return("result" => "created")
+        expect(indexer.index_document).to be true
+      end
+    end
+
+    context "when the entry is not found" do
+      before do
+        allow(Solution).to receive(:find_by_id!).with(id).and_return(nil)
+      end
+
+      it "does not call the search client's index method" do
+        expect(es_client_mock).not_to receive(:index)
+        expect(indexer.index_document).to be false
+      end
+    end
+
+    context "when search indexing fails" do
+      it "returns false when the client returns an unexpected result" do
+        allow(es_client_mock).to receive(:index).and_return("result" => "failed")
+        expect(indexer.index_document).to be false
+      end
+    end
+  end
+
+  describe "#delete_document" do
+    context "when the document is successfully deleted" do
+      it "calls the search client's delete method and returns true" do
+        allow(es_client_mock).to receive(:delete).with(
+          index: solution_index,
+          id:,
+        ).and_return("result" => "deleted")
+        expect(indexer.delete_document).to be true
+      end
+    end
+
+    context "when the document is not found" do
+      it "rescues the NotFound error and returns true" do
+        allow(es_client_mock).to receive(:delete).and_raise(OpenSearch::Transport::Transport::Errors::NotFound)
+        expect(indexer.delete_document).to be true
+      end
+    end
+
+    context "when search deletion fails" do
+      it "returns false for an unexpected result" do
+        allow(es_client_mock).to receive(:delete).and_return("result" => "unexpected")
+        expect(indexer.delete_document).to be false
+      end
+    end
+  end
+
+  describe "#find_document" do
+    let(:found_doc) { { "found" => true, "_id" => id, "_source" => { title: "Test Doc" } } }
+
+    context "when the document is found" do
+      it "calls the search client's get method and returns the document" do
+        allow(es_client_mock).to receive(:get).with(
+          index: solution_index,
+          id:,
+        ).and_return(found_doc)
+        expect(indexer.find_document).to eq(found_doc)
+      end
+    end
+
+    context "when the document is not found" do
+      it "rescues the NotFound error and returns nil" do
+        allow(es_client_mock).to receive(:get).and_raise(OpenSearch::Transport::Transport::Errors::NotFound)
+        expect(indexer.find_document).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/solution_searcher_spec.rb
+++ b/spec/services/solution_searcher_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe SolutionSearcher do
+  subject(:searcher) { described_class.new(query:) }
+
+  let(:query) { "laptops" }
+  let(:client) { instance_double(SearchClient) }
+
+  before do
+    allow(SearchClient).to receive(:instance).and_return(client)
+  end
+
+  describe "#search" do
+    let(:search_response) do
+      {
+        "hits" => {
+          "hits" => hits,
+        },
+      }
+    end
+    let(:hits) { [] }
+
+    before do
+      allow(client).to receive(:search).and_return(search_response)
+    end
+
+    context "when OpenSearch returns no hits" do
+      let(:hits) { [] }
+
+      it "returns an empty array" do
+        expect(searcher.search).to eq([])
+      end
+    end
+
+    context "when OpenSearch returns hits" do
+      let(:hits) do
+        [
+          { "_source" => { "id" => "presentable-solution" } },
+          { "_source" => { "id" => "draft-solution" } },
+        ]
+      end
+      let(:presentable_solution) { instance_double(Solution, presentable?: true) }
+      let(:draft_solution) { instance_double(Solution, presentable?: false) }
+
+      before do
+        allow(Solution).to receive(:rehydrate_from_search)
+          .with({ "id" => "presentable-solution" })
+          .and_return(presentable_solution)
+        allow(Solution).to receive(:rehydrate_from_search)
+          .with({ "id" => "draft-solution" })
+          .and_return(draft_solution)
+      end
+
+      it "rehydrates each hit and returns presentable solutions" do
+        expect(searcher.search).to eq([presentable_solution])
+      end
+    end
+
+    it "searches the solution index with a multi-match query" do
+      allow(client).to receive(:search).and_return(search_response)
+
+      expect(searcher.search).to eq([])
+      expect(client).to have_received(:search).with(
+        index: "solution-data",
+        body: {
+          query: {
+            multi_match: {
+              query: "laptops",
+              fields: %w[title description summary slug provider_reference],
+            },
+          },
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fix search toggle Stimulus controller - this needs to add the "js-show" class for the search panel to be compatible with the existing GHBS styles. Cleaned up controller a bit.

Also added missing service classes from FABS to implement the OpenSearch variant of the Solution search functionality. This was missing test coverage for SolutionSearcher so added specs for this too.