### PR TITLE
Determine redirect host for DfE Authentication automatically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,6 @@ CONTENTFUL_WEBHOOK_API_KEY=
 # DfE Sign-in
 DSI_ENV=test
 DFE_SIGN_IN_IDENTIFIER=buyforyourschool
-DFE_SIGN_IN_REDIRECT_URL=https://localhost:3000/auth/dfe/callback
 DFE_SIGN_IN_SECRET=one-two-three-four
 DFE_SIGN_IN_API_SECRET=one-two-three-four
 DFE_SIGN_IN_ENABLED=false

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -5,12 +5,18 @@ OmniAuth.config.logger = Rails.logger
 dfe_sign_in_issuer_uri = Dsi::Uri.new(subdomain: "oidc").call
 dfe_sign_in_identifier = ENV.fetch("DFE_SIGN_IN_IDENTIFIER", "example")
 dfe_sign_in_secret = ENV.fetch("DFE_SIGN_IN_SECRET", "example")
-dfe_sign_in_redirect_uri = ENV.fetch("DFE_SIGN_IN_REDIRECT_URL", "example")
 
 dfe_sign_in_issuer_url = "#{dfe_sign_in_issuer_uri}:#{dfe_sign_in_issuer_uri.port}" if dfe_sign_in_issuer_uri.port
 
+set_dfe_sign_in_redirect_uri = lambda do |env|
+  request = Rack::Request.new(env)
+  strategy = env["omniauth.strategy"]
+  strategy.options.client_options.redirect_uri = "#{request.base_url}/auth/dfe/callback"
+end
+
 options = {
   name: :dfe,
+  setup: set_dfe_sign_in_redirect_uri,
   discovery: true,
   response_type: :code,
   issuer: dfe_sign_in_issuer_url,
@@ -22,7 +28,6 @@ options = {
     host: dfe_sign_in_issuer_uri.host,
     identifier: dfe_sign_in_identifier,
     secret: dfe_sign_in_secret,
-    redirect_uri: dfe_sign_in_redirect_uri,
   },
 }
 


### PR DESCRIPTION
Determine redirect host for DfE Authentication automatically from the incoming requests host header.

This approach allows support of two different domain names during the forthcoming domain swap - and means we no longer need to explicitly set `DFE_SIGN_IN_REDIRECT_URL` env var. It's also safe to use this approach since we explicitly define allowed hostnames in `config.hosts` and permitted redirect paths in DfE Authentication service.

Note that I've removed `DFE_SIGN_IN_REDIRECT_URL` from the example envs, and once merged and deployed, that can be removed from the Azure environments and CI.