### PR TITLE
Very quick fix to show gov uk copyright image in the footer

### DIFF
--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -34,7 +34,9 @@
         </div>
       </div>
       <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/" target="_blank" rel="noopener noreferrer"><%= t(".crown_copyright") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
+        <a class="govuk-footer__link __govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/" target="_blank" rel="noopener noreferrer">
+          <%= image_tag("govuk-frontend/govuk-crest.svg", alt: "Crown Logo") %><br>
+          <%= t(".crown_copyright") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
       </div>
     </div>
   </div>

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -35,7 +35,7 @@
       </div>
       <div class="govuk-footer__meta-item">
         <a class="govuk-footer__link __govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/" target="_blank" rel="noopener noreferrer">
-          <%= image_tag("govuk-frontend/govuk-crest.svg", alt: "Crown Logo") %><br>
+          <%= image_tag("govuk-frontend/govuk-crest.svg") %><br>
           <%= t(".crown_copyright") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
       </div>
     </div>


### PR DESCRIPTION
Very quick fix to show gov uk copyright image in the footer for FABS pages.

This has no styling so isn't correctly positioned but is a temporary fix to render the copyright image, even if slightly misaligned. This will be cleaned up as part of the larger PR to refactor all of the legacy FABS styling and improve the asset configuration, but that work needs extensive QA so won't meet the timeline for the next planned production release.

Deployed to dev and confirmed image is now rendering, although slightly misaligned as expected.

<img width="241" height="181" alt="Screenshot 2026-04-22 at 12 52 42" src="https://github.com/user-attachments/assets/c93b1c3f-0c49-41f5-9724-938c2647c1c7" />
