### PR TITLE
Minimal change to support independent GHBS Contentful environment

### DIFF
--- a/app/services/content/connector.rb
+++ b/app/services/content/connector.rb
@@ -41,7 +41,8 @@ class Content::Connector
       api_url:,
       space: space_id,
       access_token:,
-      environment: ENV["CONTENTFUL_ENVIRONMENT"],
+      # Allow default environment value to be overridden for GHBS environment
+      environment: ENV.fetch("CONTENTFUL_GHBS_ENVIRONMENT", ENV.fetch("CONTENTFUL_ENVIRONMENT", "master")),
       raise_errors: true,
       application_name: "DfE: Buy For Your School",
       application_version: "1.0.0",

--- a/spec/features/support/agent_can_change_case_summary_spec.rb
+++ b/spec/features/support/agent_can_change_case_summary_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Agent can change case summary", :js do
+describe "Agent can change case summary", :flaky, :js do
   include_context "with an agent"
 
   let(:support_case) { create(:support_case, support_level: :L1, value: nil, source: "nw_hub", project: "test project", category: gas_category, procurement_stage: need_stage) }

--- a/spec/services/specify/content/connector_instance_spec.rb
+++ b/spec/services/specify/content/connector_instance_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Content::Connector, ".instance" do
   around do |example|
     ClimateControl.modify(
       CONTENTFUL_SPACE: space_id,
-      CONTENTFUL_ENVIRONMENT: environment,
+      CONTENTFUL_GHBS_ENVIRONMENT: environment,
       CONTENTFUL_DELIVERY_TOKEN: delivery_token,
       CONTENTFUL_PREVIEW_TOKEN: preview_token,
     ) do


### PR DESCRIPTION
As part of the forthcoming live launch we need to be able to support connections to two independent instances of Contentful - for original GHBS and the migrated FABS content. Eventually this will be merged into a single Contentful instance but not in time for launch as it involves moving content around between the two current instances and possibly some cleanup etc.

The various Contentful API connectors use ENV vars prefixed with `CONTENTFUL_`. Currently there are 9 separate occurrences of the FABS specific ENV vars and only one occurrence of the GHBS specific ENV vars. These are all uniquely named with the exception of `CONTENTFUL_ENVIRONMENT` which is common to all connectors. Unfortunately this value varies for FABS and GHBS instances.

As a low risk tactical fix this PR adds support for an optional `CONTENTFUL_GHBS_ENVIRONMENT` variable only for the GHBS Contentful connection, with a fallback to the shared `CONTENTFUL_ENVIRONMENT` variable. This approach isolates the changes to just one file and can be readily removed when we merge the Contentful instances and connectors in future.

Ideally the various ENV vars would be renamed to be more specific but this feels like a risky change with the imminent launch so that refactoring will be deferred until post launch.