### PR TITLE
 CORE-257, CORE-258 | Extend SSL certificate renewal workflow to supp…

### DIFF
--- a/.github/workflows/support-update-ssl-cert-validation-implementation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation-implementation.yml
@@ -41,7 +41,7 @@ jobs:
               customDomainName="devghbscustom-domain0"
               zoneName="dev.get-help-buying-for-schools.service.gov.uk"
             else
-              customDomainName="devghbscustom-domain1"
+              customDomainName="dev-get-help-buying-for-schools-education-gov-uk-ab1b"
               zoneName="dev.get-help-buying-for-schools.education.gov.uk"
             fi
 
@@ -53,7 +53,7 @@ jobs:
               zoneName="staging.get-help-buying-for-schools.service.gov.uk"
             else
               customDomainName="stagghbscustom-domain1"
-              zoneName="staging.get-help-buying-for-schools.education.gov.uk"
+              zoneName="staging.get-help-buying-for-schools-education-gov-uk-ab1b"
             fi
 
           elif [[ "${{ inputs.chosen_environment }}" == "az-production" ]]; then
@@ -63,7 +63,7 @@ jobs:
               customDomainName="prodghbscustom-domain0"
               zoneName="www.get-help-buying-for-schools.service.gov.uk"
             else
-              customDomainName="prodghbscustom-domain1"
+              customDomainName="get-help-buying-for-schools-education-gov-uk-ab1b"
               zoneName="www.get-help-buying-for-schools.education.gov.uk"
             fi
           fi

--- a/.github/workflows/support-update-ssl-cert-validation-implementation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation-implementation.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Setup variables
         id: vars
+        env:
+          # Supports "service" and "education" values for *.service.gov.uk and *.education.gov.uk domains
+          DOMAIN_FAMILY: ${{ inputs.domain_family }}
         run: |
           # To avoid adding multiple variables into the environment when the names
           # are based on convention and therefor can be built programmatically
@@ -37,7 +40,7 @@ jobs:
           if [[ "${{ inputs.chosen_environment }}" == "az-dev" ]]; then
             profileName="devghbscdn"
 
-            if [[ "${{ inputs.domain_family }}" == "service" ]]; then
+            if [[ "$DOMAIN_FAMILY" == "service" ]]; then
               customDomainName="devghbscustom-domain0"
               zoneName="dev.get-help-buying-for-schools.service.gov.uk"
             else
@@ -48,21 +51,22 @@ jobs:
           elif [[ "${{ inputs.chosen_environment }}" == "az-staging" ]]; then
             profileName="stagghbscdn"
 
-            if [[ "${{ inputs.domain_family }}" == "service" ]]; then
+            if [[ "$DOMAIN_FAMILY" == "service" ]]; then
               customDomainName="stagghbscustom-domain0"
               zoneName="staging.get-help-buying-for-schools.service.gov.uk"
             else
-              customDomainName="stagghbscustom-domain1"
-              zoneName="staging.get-help-buying-for-schools-education-gov-uk-ab1b"
+              customDomainName="staging-get-help-buying-for-schools-education-gov-uk-c932"
+              zoneName="staging.get-help-buying-for-schools.education.gov.uk"
             fi
 
           elif [[ "${{ inputs.chosen_environment }}" == "az-production" ]]; then
             profileName="prodghbscdn"
 
-            if [[ "${{ inputs.domain_family }}" == "service" ]]; then
+            if [[ "$DOMAIN_FAMILY" == "service" ]]; then
               customDomainName="prodghbscustom-domain0"
               zoneName="www.get-help-buying-for-schools.service.gov.uk"
             else
+              # prod customDomainName is not yet done. We need to update this 2026-04-29
               customDomainName="get-help-buying-for-schools-education-gov-uk-ab1b"
               zoneName="www.get-help-buying-for-schools.education.gov.uk"
             fi

--- a/.github/workflows/support-update-ssl-cert-validation-implementation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation-implementation.yml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
 
+      domain_family:
+        required: true
+        type: string
+
 env:
   RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
   AZURE_CORE_USE_MSAL_HTTP_CACHE: "false"
@@ -15,7 +19,7 @@ jobs:
   check_need_for_validation_update:
     runs-on: ubuntu-latest
 
-    environment: ${{ inputs.chosen_environment == 'az-production' && 'az-production-read-only' ||  inputs.chosen_environment }}
+    environment: ${{ inputs.chosen_environment == 'az-production' && 'az-production-read-only' || inputs.chosen_environment }}
 
     outputs:
       customDomainName: ${{ steps.vars.outputs.customDomainName }}
@@ -31,17 +35,37 @@ jobs:
           # are based on convention and therefor can be built programmatically
 
           if [[ "${{ inputs.chosen_environment }}" == "az-dev" ]]; then
-            customDomainName="devghbscustom-domain0"
             profileName="devghbscdn"
-            zoneName="dev.get-help-buying-for-schools.service.gov.uk"
+
+            if [[ "${{ inputs.domain_family }}" == "service" ]]; then
+              customDomainName="devghbscustom-domain0"
+              zoneName="dev.get-help-buying-for-schools.service.gov.uk"
+            else
+              customDomainName="devghbscustom-domain1"
+              zoneName="dev.get-help-buying-for-schools.education.gov.uk"
+            fi
+
           elif [[ "${{ inputs.chosen_environment }}" == "az-staging" ]]; then
-            customDomainName="stagghbscustom-domain0"
             profileName="stagghbscdn"
-            zoneName="staging.get-help-buying-for-schools.service.gov.uk"
+
+            if [[ "${{ inputs.domain_family }}" == "service" ]]; then
+              customDomainName="stagghbscustom-domain0"
+              zoneName="staging.get-help-buying-for-schools.service.gov.uk"
+            else
+              customDomainName="stagghbscustom-domain1"
+              zoneName="staging.get-help-buying-for-schools.education.gov.uk"
+            fi
+
           elif [[ "${{ inputs.chosen_environment }}" == "az-production" ]]; then
-            customDomainName="prodghbscustom-domain0"
             profileName="prodghbscdn"
-            zoneName="www.get-help-buying-for-schools.service.gov.uk"
+
+            if [[ "${{ inputs.domain_family }}" == "service" ]]; then
+              customDomainName="prodghbscustom-domain0"
+              zoneName="www.get-help-buying-for-schools.service.gov.uk"
+            else
+              customDomainName="prodghbscustom-domain1"
+              zoneName="www.get-help-buying-for-schools.education.gov.uk"
+            fi
           fi
 
           echo customDomainName=$customDomainName >> $GITHUB_OUTPUT
@@ -65,7 +89,12 @@ jobs:
               --custom-domain-name ${{ steps.vars.outputs.customDomainName }} \
               --only-show-errors | jq --raw-output .domainValidationState)
 
-            needsToReEvaluate=$([ -z "$(echo $domainValidationState | grep "PendingRevalidation")" ] && echo "no" || echo "yes")
+            needsToReEvaluate=$(
+              [ -z "$(echo $domainValidationState | grep "PendingRevalidation")" ] \
+              && echo "no" \
+              || echo "yes"
+            )
+
             echo needsToReEvaluate=$needsToReEvaluate >> $GITHUB_OUTPUT
 
   update_validation:

--- a/.github/workflows/support-update-ssl-cert-validation-implementation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation-implementation.yml
@@ -66,8 +66,7 @@ jobs:
               customDomainName="prodghbscustom-domain0"
               zoneName="www.get-help-buying-for-schools.service.gov.uk"
             else
-              # prod customDomainName is not yet done. We need to update this 2026-04-29
-              customDomainName="get-help-buying-for-schools-education-gov-uk-ab1b"
+              customDomainName="www-get-help-buying-for-schools-education-gov-uk-eed8"
               zoneName="www.get-help-buying-for-schools.education.gov.uk"
             fi
           fi

--- a/.github/workflows/support-update-ssl-cert-validation.yml
+++ b/.github/workflows/support-update-ssl-cert-validation.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         environment: [az-dev, az-staging, az-production]
+        domain_family: [service, education]
 
     # we must use a shared workflow in order to have 2 environments for prod (read only and normal)
     # this is so we can check the status of the validation without needing deployment approval.
@@ -23,5 +24,6 @@ jobs:
 
     with:
       chosen_environment: ${{ matrix.environment }}
+      domain_family: ${{ matrix.domain_family }}
 
     secrets: inherit


### PR DESCRIPTION
…ort multiple domains

<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Tickets: 
https://dfedigital.atlassian.net/browse/CORE-257
https://dfedigital.atlassian.net/browse/CORE-258



**Update SSL certificate validation workflow to support multiple domains**

The scheduled GitHub Actions workflow validates SSL certificates before expiry to support automatic renewal. Previously, the workflow only handled a single domain. This change extends the workflow to validate and manage both domains, allowing the existing renewal process to work consistently across multiple domain names.

Test plan:

This workflow cannot be fully validated locally because it depends on Azure-managed certificate validation and GitHub Actions scheduled execution. Changes were reviewed by testing workflow logic locally where possible (including matrix/job flow and script execution). 

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
