### PR TITLE
Removed clear_all_sequences step from DatabaseCleaner

### DIFF
--- a/spec/features/frameworks/register/agent_can_create_framework_spec.rb
+++ b/spec/features/frameworks/register/agent_can_create_framework_spec.rb
@@ -51,8 +51,11 @@ describe "Agent can create frameworks", :js do
     end
     click_on "Create framework"
 
-    expect(page).to have_css(".govuk-caption-l", text: "[F1] Framework")
     expect(page).to have_css(".govuk-heading-l", text: "New Framework 1")
+
+    # Framework reference is assigned from Postgres id so need to fetch that
+    framework = Frameworks::Framework.find_by!(name: "New Framework 1")
+    expect(page).to have_css(".govuk-caption-l", text: "[#{framework.reference}] Framework")
     expect(page).to have_css(".govuk-tag", text: "Not approved")
 
     expect(page).to have_summary("URL", "https://localhost:3000/nf1")

--- a/spec/features/frameworks/register/agent_can_create_framework_spec.rb
+++ b/spec/features/frameworks/register/agent_can_create_framework_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Agent can create frameworks", :flaky, :js do
+describe "Agent can create frameworks", :js do
   include_context "with a framework evaluation agent"
 
   before do

--- a/spec/features/frameworks/register/agent_can_create_framework_spec.rb
+++ b/spec/features/frameworks/register/agent_can_create_framework_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Agent can create frameworks", :js do
+describe "Agent can create frameworks", :flaky, :js do
   include_context "with a framework evaluation agent"
 
   before do

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -21,23 +21,5 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
     FactoryBot.reload
     Faker::UniqueGenerator.clear
-    clear_all_sequences
-  end
-
-  def clear_all_sequences
-    statement = <<-SQL
-      DO $$
-      DECLARE
-        seq RECORD;
-      BEGIN
-        FOR seq IN
-          SELECT sequence_schema, sequence_name
-          FROM information_schema.sequences
-        LOOP
-          EXECUTE format('ALTER SEQUENCE %I.%I RESTART WITH 1', seq.sequence_schema, seq.sequence_name);
-        END LOOP;
-      END $$;
-    SQL
-    ActiveRecord::Base.connection.execute(statement)
   end
 end


### PR DESCRIPTION
This should not be necessary as tests do not assume specific database id's - and if they did this would not be representative of how the code behaves on a real database. This step adds a significant overhead to the test suite, around 30 seconds when running locally. I'm hoping to see a similar speedup on the Github CI Rspec workflow steps.