### PR TITLE
Add feature flag to support deprecation of GHBS Contentful instance

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,8 @@ class PagesController < ApplicationController
 
   include Breadcrumbs
 
+  DEPRECATED_GHBS_CONTENTFUL_PAGES = %w[foo].freeze
+
   def show
     if page.present?
       set_breadcrumbs
@@ -30,11 +32,13 @@ class PagesController < ApplicationController
 private
 
   def page
+    return if deprecated_ghbs_contentful_page?
+
     @page ||= Page.find_by(slug: params[:slug])
   end
 
   def fabs_page
-    @page = FABS::Page.find_by_slug!(params[:slug])
+    @fabs_page ||= FABS::Page.find_by_slug!(params[:slug])
   end
 
   # Apply Contentful breadcrumbs in the format "title, path"
@@ -71,5 +75,9 @@ private
         add_breadcrumb_on_rails n.title, page_path(n.slug)
       end
     end
+  end
+
+  def deprecated_ghbs_contentful_page?
+    Flipper.enabled?(:deprecate_ghbs_contentful) && DEPRECATED_GHBS_CONTENTFUL_PAGES.include?(params[:slug])
   end
 end

--- a/doc/feature-flags.md
+++ b/doc/feature-flags.md
@@ -41,5 +41,6 @@ Click on `add feature` and enter the name you have used for your feature flag. Y
 |sc_tasklist_case|The task list tab for a case at level 4 or 5 will be visible, and the 'case action_required' flag will be updated based on the evaluation document upload status and the evaluation approval status. |ENABLED in development, DISABLED in production|To be enabled when all components of the task list are ready|
 |usability_surveys|Usability survey for FABS|ENABLED|Feature now live, flag to be removed|
 |ghbs_public_frontend|Enable new Get help buying for schools public pages on BFYS (behind feature flag)|DISABLED|Enable in development / staging before go-live|
+|deprecate_ghbs_contentful|Enable deprecation of selected static content pages hosted in GHBS Contentful instance (these will be served from FABS Contentful instance instead)|DISABLED|Enable in development / staging before go-live|
 
 When the feature flag is no longer needed, you can remove it from the code and from the flipper features area in all the environments where it was created. It should also be removed from the current flags table above so we have an up-to-date record of feature flags in the system.

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe PagesController, type: :controller do
+  describe "GET #show" do
+    let(:deprecated_slug) { "deprecated-page" }
+    let(:db_page) { create(:page, slug: deprecated_slug, body: "# DB page", sidebar: nil) }
+    let(:fabs_page) { instance_double(FABS::Page, title: "FABS page", parent: nil) }
+
+    before do
+      stub_const("#{described_class}::DEPRECATED_GHBS_CONTENTFUL_PAGES", [deprecated_slug])
+      allow(Flipper).to receive(:enabled?).and_call_original
+    end
+
+    context "when the deprecation flag is enabled for the slug" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:deprecate_ghbs_contentful).and_return(true)
+        allow(Page).to receive(:find_by)
+        allow(FABS::Page).to receive(:find_by_slug!).with(deprecated_slug).and_return(fabs_page)
+      end
+
+      it "skips the Page model lookup and renders the FABS page" do
+        get :show, params: { slug: deprecated_slug }
+
+        expect(Page).not_to have_received(:find_by)
+        expect(FABS::Page).to have_received(:find_by_slug!).with(deprecated_slug)
+        expect(response).to render_template("fabs/pages/show")
+      end
+    end
+
+    context "when the deprecation flag is disabled" do
+      before do
+        allow(Flipper).to receive(:enabled?).with(:deprecate_ghbs_contentful).and_return(false)
+        allow(FABS::Page).to receive(:find_by_slug!)
+      end
+
+      it "uses the Page model branch" do
+        db_page
+
+        get :show, params: { slug: deprecated_slug }
+
+        expect(FABS::Page).not_to have_received(:find_by_slug!)
+        expect(response).to render_template("pages/show")
+      end
+    end
+  end
+end

--- a/spec/requests/fabs/pages_spec.rb
+++ b/spec/requests/fabs/pages_spec.rb
@@ -106,4 +106,33 @@ RSpec.describe "FABS pages", type: :request do
 
     expect(response).to redirect_to("/404")
   end
+
+  it "serves the FABS page instead of the DB-backed page when the deprecation flag is enabled for the slug" do
+    deprecated_slug = "deprecated-page"
+    db_page = create(:page, slug: deprecated_slug, title: "DB page", body: "DB body", sidebar: nil)
+    deprecated_page_entry = contentful_entry(
+      id: "deprecated-page-id",
+      content_type: "page",
+      fields: {
+        title: "FABS replacement page",
+        description: "Served from FABS",
+        body: "FABS body",
+        slug: deprecated_slug,
+        parent: category_entry,
+        related_content: [],
+      },
+    )
+
+    stub_const("PagesController::DEPRECATED_GHBS_CONTENTFUL_PAGES", [deprecated_slug])
+    allow(Flipper).to receive(:enabled?).and_call_original
+    allow(Flipper).to receive(:enabled?).with(:deprecate_ghbs_contentful).and_return(true)
+    allow(FABS::Page).to receive(:find_by_slug!).with(deprecated_slug).and_return(FABS::Page.new(deprecated_page_entry))
+
+    get page_path(deprecated_slug)
+
+    expect(response).to be_successful
+    expect(response.body).to include("FABS replacement page")
+    expect(response.body).to include("Served from FABS")
+    expect(response.body).not_to include(db_page.title)
+  end
 end


### PR DESCRIPTION
This flag allows individual pages to be retired from GHBS Contentful instance; if the specified slug is present in the `DEPRECATED_GHBS_CONTENTFUL_PAGES` list then it will be served from FABS Contentful instance instead (if it exists there). Once all of the pages are migrated to FABS Contentful this can be removed and the existing Postgres backed `Page` model can be used to add another caching layer for Contentful content.

As this behaviour is controlled by a feature flag we can deprecate pages in dev/staging without affecting production deployments.