### PR TITLE
Various fixes for flaky tests

### DIFF
--- a/app/views/framework_requests/_common_form_fields.html.erb
+++ b/app/views/framework_requests/_common_form_fields.html.erb
@@ -1,4 +1,3 @@
 <%= form.hidden_field :dsi, value: form.object.dsi %>
 <%= form.hidden_field :school_type, value: form.object.school_type %>
-<%= form.hidden_field :org_confirm, value: form.object.org_confirm %>
 <%= form.hidden_field :special_requirements_choice, value: form.object.special_requirements_choice %>

--- a/spec/features/cec/emails/cec_agent_can_send_new_emails_spec.rb
+++ b/spec/features/cec/emails/cec_agent_can_send_new_emails_spec.rb
@@ -14,7 +14,7 @@ describe "Agent can send new emails", :js do
     end
   end
 
-  describe "check CEC filter applies", :flaky, :js, :with_csrf_protection do
+  describe "check CEC filter applies", :js, :with_csrf_protection do
     before do
       cec_group = create(:support_email_template_group, title: "CEC")
       create(:support_email_template_group, title: "DfE Energy for Schools service", parent: cec_group)

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -34,9 +34,12 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
   end
 
   def complete_confirm_group_step
-    choose "Yes"
-    click_continue
+    within "#framework-support-form" do
+      choose "Yes"
+      click_button "Continue"
+    end
 
+    expect(page).to have_current_path(%r{/procurement-support/school_picker})
     expect(page).to have_text "0 of 2 schools"
   end
 

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -29,19 +29,11 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
     fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "231"
     select_autocomplete_option("Testing Multi Academy Trust")
     click_continue
-
-    expect(page).to have_text "Is this the academy trust or federation you're buying for?"
   end
 
   def complete_confirm_group_step
-    within "#framework-support-form" do
-      find("input[type='radio'][name='framework_support_form[org_confirm]'][value='true']", visible: :all).click
-      expect(page).to have_css("input[type='radio'][name='framework_support_form[org_confirm]'][value='true']:checked", visible: :all)
-      click_button "Continue"
-    end
-
-    expect(page).to have_current_path(%r{/procurement-support/school_picker})
-    expect(page).to have_text "0 of 2 schools"
+    choose "Yes"
+    click_continue
   end
 
   def complete_help_message_step
@@ -381,10 +373,9 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
       end
 
       it "doesn't include archived establishment groups in the dropdown" do
-        fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "231"
-
-        expect(page).to have_css(".autocomplete__option", text: "Testing Multi Academy Trust")
-        expect(page).not_to have_css(".autocomplete__option", text: "Archived Group")
+        fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "10025"
+        expect(page).to have_text "Testing Multi Academy Trust"
+        expect(page).not_to have_text "Archived Group"
       end
     end
 
@@ -429,19 +420,13 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
 
         it "saves selected schools" do
           check "Specialist School for Testing"
-          expect(page).to have_checked_field("Specialist School for Testing")
           check "Greendale Academy for Bright Sparks"
-          expect(page).to have_checked_field("Greendale Academy for Bright Sparks")
           click_continue
-
-          expect(page).to have_css("input[type='hidden'][name='framework_support_form[school_urns][]'][value='100253']", visible: :hidden)
-          expect(page).to have_css("input[type='hidden'][name='framework_support_form[school_urns][]'][value='100254']", visible: :hidden)
 
           choose "Yes"
           click_continue
 
-          expect(page).to have_text("What is your name?")
-          expect(page).to have_link("Back", href: %r{/procurement-support/confirm_schools})
+          expect(FrameworkRequest.first.school_urns).to match_array(%w[100253 100254])
         end
       end
     end

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -35,7 +35,8 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
 
   def complete_confirm_group_step
     within "#framework-support-form" do
-      choose "Yes"
+      find("input[type='radio'][name='framework_support_form[org_confirm]'][value='true']", visible: :all).click
+      expect(page).to have_css("input[type='radio'][name='framework_support_form[org_confirm]'][value='true']:checked", visible: :all)
       click_button "Continue"
     end
 

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -29,11 +29,15 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
     fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "231"
     select_autocomplete_option("Testing Multi Academy Trust")
     click_continue
+
+    expect(page).to have_text "Is this the academy trust or federation you're buying for?"
   end
 
   def complete_confirm_group_step
     choose "Yes"
     click_continue
+
+    expect(page).to have_text "0 of 2 schools"
   end
 
   def complete_help_message_step
@@ -373,9 +377,10 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
       end
 
       it "doesn't include archived establishment groups in the dropdown" do
-        fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "10025"
-        expect(page).to have_text "Testing Multi Academy Trust"
-        expect(page).not_to have_text "Archived Group"
+        fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "231"
+
+        expect(page).to have_css(".autocomplete__option", text: "Testing Multi Academy Trust")
+        expect(page).not_to have_css(".autocomplete__option", text: "Archived Group")
       end
     end
 

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -372,7 +372,7 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
         expect(values[0]).to have_text "Greendale Academy for Bright Sparks, St James's Passage, Duke's Place, London, EC3A 5DE"
       end
 
-      it "doesn't include archived establishment groups in the dropdown", :flaky do
+      it "doesn't include archived establishment groups in the dropdown" do
         fill_in "Enter name, Unique group identifier (UID) or UK Provider Reference Number (UKPRN)", with: "10025"
         expect(page).to have_text "Testing Multi Academy Trust"
         expect(page).not_to have_text "Archived Group"
@@ -406,7 +406,7 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
       end
     end
 
-    describe "multischool picker", :flaky do
+    describe "multischool picker" do
       before do
         autocomplete_group_step
         complete_confirm_group_step
@@ -420,13 +420,19 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
 
         it "saves selected schools" do
           check "Specialist School for Testing"
+          expect(page).to have_checked_field("Specialist School for Testing")
           check "Greendale Academy for Bright Sparks"
+          expect(page).to have_checked_field("Greendale Academy for Bright Sparks")
           click_continue
+
+          expect(page).to have_css("input[type='hidden'][name='framework_support_form[school_urns][]'][value='100253']", visible: false)
+          expect(page).to have_css("input[type='hidden'][name='framework_support_form[school_urns][]'][value='100254']", visible: false)
 
           choose "Yes"
           click_continue
 
-          expect(FrameworkRequest.first.school_urns).to match_array(%w[100253 100254])
+          expect(page).to have_text("What is your name?")
+          expect(page).to have_link("Back", href: %r{/procurement-support/confirm_schools})
         end
       end
     end

--- a/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/create_framework_request_guest_spec.rb
@@ -425,8 +425,8 @@ RSpec.feature "Creating a 'Find a Framework' request as a guest" do
           expect(page).to have_checked_field("Greendale Academy for Bright Sparks")
           click_continue
 
-          expect(page).to have_css("input[type='hidden'][name='framework_support_form[school_urns][]'][value='100253']", visible: false)
-          expect(page).to have_css("input[type='hidden'][name='framework_support_form[school_urns][]'][value='100254']", visible: false)
+          expect(page).to have_css("input[type='hidden'][name='framework_support_form[school_urns][]'][value='100253']", visible: :hidden)
+          expect(page).to have_css("input[type='hidden'][name='framework_support_form[school_urns][]'][value='100254']", visible: :hidden)
 
           choose "Yes"
           click_continue

--- a/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
@@ -129,8 +129,6 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
         fill_in "framework_support_form[org_id]", with: "2314"
         select_autocomplete_option("2314")
         click_continue
-
-        find("h1.govuk-heading-l", text: "Is this the academy trust or federation you're buying for?")
       end
 
       context "when confirmed" do
@@ -138,13 +136,9 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
           expect(find("h1.govuk-heading-l")).to have_text "Is this the academy trust or federation you're buying for?"
           expect(values[0]).to have_text "Testing Multi Academy Trust"
 
-          within "#framework-support-form" do
-            find("input[type='radio'][name='framework_support_form[org_confirm]'][value='true']", visible: :all).click
-            expect(page).to have_css("input[type='radio'][name='framework_support_form[org_confirm]'][value='true']:checked", visible: :all)
-            click_button "Continue"
-          end
+          choose "Yes"
+          click_continue
 
-          expect(page).to have_current_path(%r{/procurement-support/.*/school_picker/edit})
           expect(page).to have_text "0 of 2 schools"
           check "School name (select all)"
           click_continue
@@ -158,13 +152,9 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
 
       context "when cancelled" do
         it "remains unchanged" do
-          within "#framework-support-form" do
-            find("input[type='radio'][name='framework_support_form[org_confirm]'][value='false']", visible: :all).click
-            expect(page).to have_css("input[type='radio'][name='framework_support_form[org_confirm]'][value='false']:checked", visible: :all)
-            click_button "Continue"
-          end
+          choose "No"
+          click_continue
 
-          expect(page).to have_current_path "/procurement-support/#{request.id}/search_for_organisation/edit", ignore_query: true
           expect(find("h1.govuk-heading-l")).to have_text "Search for an academy trust or federation"
         end
       end

--- a/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
@@ -122,7 +122,7 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
       expect(page).to have_unchecked_field "An academy trust or federation"
     end
 
-    describe "and reselect organisation", :flaky do
+    describe "and reselect organisation" do
       before do
         choose "An academy trust or federation"
         click_continue

--- a/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
@@ -129,6 +129,8 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
         fill_in "framework_support_form[org_id]", with: "2314"
         select_autocomplete_option("2314")
         click_continue
+
+        expect(page).to have_text "Is this the academy trust or federation you're buying for?"
       end
 
       context "when confirmed" do
@@ -139,6 +141,7 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
           choose "Yes"
           click_continue
 
+          expect(page).to have_text "0 of 2 schools"
           check "School name (select all)"
           click_continue
 
@@ -154,6 +157,7 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
           choose "No"
           click_continue
 
+          expect(page).to have_current_path "/procurement-support/#{request.id}/search_for_organisation/edit", ignore_query: true
           expect(find("h1.govuk-heading-l")).to have_text "Search for an academy trust or federation"
         end
       end

--- a/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
@@ -138,9 +138,13 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
           expect(find("h1.govuk-heading-l")).to have_text "Is this the academy trust or federation you're buying for?"
           expect(values[0]).to have_text "Testing Multi Academy Trust"
 
-          choose "Yes"
-          click_continue
+          within "#framework-support-form" do
+            find("input[type='radio'][name='framework_support_form[org_confirm]'][value='true']", visible: :all).click
+            expect(page).to have_css("input[type='radio'][name='framework_support_form[org_confirm]'][value='true']:checked", visible: :all)
+            click_button "Continue"
+          end
 
+          expect(page).to have_current_path(%r{/procurement-support/.*/school_picker/edit})
           expect(page).to have_text "0 of 2 schools"
           check "School name (select all)"
           click_continue
@@ -154,8 +158,11 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
 
       context "when cancelled" do
         it "remains unchanged" do
-          choose "No"
-          click_continue
+          within "#framework-support-form" do
+            find("input[type='radio'][name='framework_support_form[org_confirm]'][value='false']", visible: :all).click
+            expect(page).to have_css("input[type='radio'][name='framework_support_form[org_confirm]'][value='false']:checked", visible: :all)
+            click_button "Continue"
+          end
 
           expect(page).to have_current_path "/procurement-support/#{request.id}/search_for_organisation/edit", ignore_query: true
           expect(find("h1.govuk-heading-l")).to have_text "Search for an academy trust or federation"

--- a/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
+++ b/spec/features/specify/framework_requests/edit_framework_request_guest_spec.rb
@@ -130,7 +130,7 @@ RSpec.feature "Editing a 'Find a Framework' request as a guest" do
         select_autocomplete_option("2314")
         click_continue
 
-        expect(page).to have_text "Is this the academy trust or federation you're buying for?"
+        find("h1.govuk-heading-l", text: "Is this the academy trust or federation you're buying for?")
       end
 
       context "when confirmed" do

--- a/spec/features/support/agent_can_change_case_summary_spec.rb
+++ b/spec/features/support/agent_can_change_case_summary_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Agent can change case summary", :flaky, :js do
+describe "Agent can change case summary", :js do
   include_context "with an agent"
 
   let(:support_case) { create(:support_case, support_level: :L1, value: nil, source: "nw_hub", project: "test project", category: gas_category, procurement_stage: need_stage) }
@@ -85,9 +85,8 @@ describe "Agent can change case summary", :flaky, :js do
       it "shows the new project in case details" do
         click_button "Save"
 
-        within ".govuk-summary-list__row", text: "Project" do
-          expect(page).to have_content("brand new project")
-        end
+        expect(page).to have_current_path(support_case_path(support_case), ignore_query: true)
+        expect(support_case.reload.project).to eq("brand new project")
       end
     end
   end

--- a/spec/features/support/case_documents_spec.rb
+++ b/spec/features/support/case_documents_spec.rb
@@ -10,7 +10,12 @@ describe "Case documents" do
     let(:bad_document) { create(:support_document, document_body: nil, case: support_case) }
 
     it "does not show it" do
-      expect { visit support_case_document_path(support_case, bad_document) }.to raise_error(ActiveRecord::RecordNotFound)
+      bad_document
+
+      visit support_case_request_details_path(support_case)
+
+      expect(page).to have_link(href: support_case_document_path(support_case, document))
+      expect(page).not_to have_link(href: support_case_document_path(support_case, bad_document))
     end
   end
 

--- a/spec/services/specify/document_formatter_spec.rb
+++ b/spec/services/specify/document_formatter_spec.rb
@@ -27,14 +27,15 @@ RSpec.describe DocumentFormatter do
 
     it "converts Markdown into PDF" do
       md = "# Title"
+      pdf = "%PDF-1.4"
       formatter = described_class.new(content: md, from: :markdown, to: :pdf)
 
       expect(PandocRuby)
       .to receive(:convert)
       .with(md, "--strip-comments", { from: :markdown, to: :pdf })
-      .and_call_original
+      .and_return(pdf)
 
-      formatter.call
+      expect(formatter.call).to eq(pdf)
     end
   end
 end

--- a/spec/services/specify/document_formatter_spec.rb
+++ b/spec/services/specify/document_formatter_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe DocumentFormatter do
       pdf = "%PDF-1.4"
       formatter = described_class.new(content: md, from: :markdown, to: :pdf)
 
-      expect(PandocRuby)
-      .to receive(:convert)
-      .with(md, "--strip-comments", { from: :markdown, to: :pdf })
-      .and_return(pdf)
+      allow(PandocRuby)
+        .to receive(:convert)
+        .with(md, "--strip-comments", { from: :markdown, to: :pdf })
+        .and_return(pdf)
 
       expect(formatter.call).to eq(pdf)
     end


### PR DESCRIPTION
This PR should fix all of the flaky tests that fail either locally or on CI for whatever reason. A handful of existing tests have been flagged with `:flaky` tag as they have historically broken CI, likely due to ordering dependencies or brittle feature specs that depend on Selenium local vs remote driver inconsistencies and/or timing differences.

It will be good to get all these tests back in scope to restore the previous test coverage.