### PR TITLE
Add support for tracking internal links

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,7 @@ class EventsController < Fabs::ApplicationController
   skip_before_action :check_fabs_flag
   EVENT_ALLOWLIST = {
     external_link_clicked: %i[text href],
+    internal_link_clicked: %i[text href],
     page_engagement: %i[engaged_time_ms page_path page_title session_duration_ms timestamp],
   }.freeze
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -100,5 +100,8 @@ application.register("engagement-tracking", EngagementTrackingController);
 import ExternalLinkTrackingController from "./external_link_tracking_controller"
 application.register("external-link-tracking", ExternalLinkTrackingController);
 
+import InternalLinkTrackingController from "./internal_link_tracking_controller"
+application.register("internal-link-tracking", InternalLinkTrackingController);
+
 import SearchToggleController from "./search_toggle_controller"
 application.register("search-toggle", SearchToggleController);

--- a/app/javascript/controllers/internal_link_tracking_controller.js
+++ b/app/javascript/controllers/internal_link_tracking_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  connect () {
+    document.querySelectorAll('a[data-track-internal-link]').forEach(link => {
+      link.addEventListener('click', this.trackClick.bind(this))
+    })
+  }
+
+  async trackClick (event) {
+    const link = event.currentTarget
+    const href = link.href
+    const text = link.textContent.trim()
+
+    await fetch('/events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({
+        event: {
+          type: 'internal_link_clicked',
+          data: {
+            href,
+            text
+          }
+        }
+      })
+    })
+  }
+}

--- a/app/views/shared/_dfe_base.html.erb
+++ b/app/views/shared/_dfe_base.html.erb
@@ -16,7 +16,7 @@
   <%= javascript_include_tag "application", defer: true %>
 </head>
 
-<body class="govuk-template__body" data-controller="external-link-tracking engagement-tracking">
+<body class="govuk-template__body" data-controller="external-link-tracking internal-link-tracking engagement-tracking">
   <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
   <%= yield %>
 </body>

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -8,7 +8,7 @@
         <h2 class="govuk-visually-hidden"><%= t(".feedback") %></h2>
         <ul class="govuk-footer__inline-list govuk-footer__inline-list--inline govuk-!-margin-bottom-6">
           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" target="_blank" rel="noopener noreferrer"><%= t(".procurement_support") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
+            <a class="govuk-footer__link" href="https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" target="_blank" rel="noopener noreferrer" data-track-internal-link><%= t(".procurement_support") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
           </li>
           <li class="govuk-footer__inline-list-item">
             <a class="govuk-footer__link" href="<%=customer_satisfaction_survey_url("footer_link") %>" target="_blank" rel="noopener noreferrer"><%= t(".feedback") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,4 +1,5 @@
 shared:
   - page_engagement
   - external_link_clicked
+  - internal_link_clicked
   - button_click


### PR DESCRIPTION
This adds a new `internal_link_clicked` event that can be opted in on any link by including `track-internal-link` data attribute. This has been included on the procurement support link on home page and can be added to the new RFH button in the same way (in a separate PR).