### PR TITLE
Updated privacy policy to link to external page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,7 @@ class PagesController < ApplicationController
 
   include Breadcrumbs
 
-  DEPRECATED_GHBS_CONTENTFUL_PAGES = %w[privacy].freeze
+  DEPRECATED_GHBS_CONTENTFUL_PAGES = %w[foo].freeze
 
   def show
     if page.present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,8 @@ require "date"
 module ApplicationHelper
   include MarkdownHelper
 
+  PRIVACY_NOTICE_URL = "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-to-use-our-websites".freeze
+
   def banner_tag
     I18n.t("banner.beta.tag")
   end
@@ -62,6 +64,10 @@ module ApplicationHelper
 
   def register_your_interest_form_url
     "https://submit.forms.service.gov.uk/form/8895/multi-academy-trusts-register-your-interest-in-energy-for-schools/1049539"
+  end
+
+  def privacy_link(link_text = t("shared.privacy_notice"), **options)
+    fabs_govuk_link_to(link_text, PRIVACY_NOTICE_URL, **options)
   end
 
   def fabs_govuk_link_to(link_text, url, **options)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ require "date"
 module ApplicationHelper
   include MarkdownHelper
 
-  PRIVACY_NOTICE_URL = "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-to-use-our-websites".freeze
+  PRIVACY_NOTICE_URL = "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-to-use-our-websites"
 
   def banner_tag
     I18n.t("banner.beta.tag")

--- a/app/views/all_cases_survey/start/show.html.erb
+++ b/app/views/all_cases_survey/start/show.html.erb
@@ -13,7 +13,7 @@
     <%= link_to I18n.t("generic.button.next"), edit_all_cases_survey_satisfaction_path, class: "govuk-button", role: "button" %>
 
     <p class="govuk-body">
-      <%= govuk_link_to t("shared.privacy_notice"), "/privacy" %>
+      <%= privacy_link %>
     </p>
   </div>
 </div>

--- a/app/views/customer_satisfaction_surveys/new.html.erb
+++ b/app/views/customer_satisfaction_surveys/new.html.erb
@@ -19,7 +19,7 @@
     <%= button_to I18n.t("generic.button.next"), customer_satisfaction_surveys_path, params: { source: params[:source], service: params[:service], referer: request.referer }, class: "govuk-button" %>
 
     <p class="govuk-body">
-      <%= govuk_link_to t("shared.privacy_notice"), "/privacy" %>
+      <%= privacy_link %>
     </p>
   </div>
 </div>

--- a/app/views/end_of_journey_surveys/new.html.erb
+++ b/app/views/end_of_journey_surveys/new.html.erb
@@ -21,6 +21,6 @@
   <% end %>
 
   <p class="govuk-body">
-    <%= govuk_link_to t("shared.privacy_notice"), "/privacy" %>
+    <%= privacy_link %>
   </p>
 <% end %>

--- a/app/views/exit_survey/start/show.html.erb
+++ b/app/views/exit_survey/start/show.html.erb
@@ -13,7 +13,7 @@
     <%= link_to I18n.t("exit_survey.continue"), edit_exit_survey_satisfaction_path, class: "govuk-button", role: "button" %>
 
     <p class="govuk-body">
-      <%= govuk_link_to t("shared.privacy_notice"), "/privacy" %>
+      <%= privacy_link %>
     </p>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -144,7 +144,7 @@
                 <%= link_to "Terms and Conditions", "/terms-and-conditions", class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= govuk_footer_link_to t("shared.privacy_notice"), "/privacy" %>
+                <%= privacy_link(class: "govuk-footer__link") %>
               </li>
             </ul>
 

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -17,7 +17,7 @@
             <a class="govuk-footer__link" href="/accessibility-statement"><%= t(".accessibility_statement") %></a>
           </li>
           <li class="govuk-footer__inline-list-item">
-            <%= govuk_footer_link_to t("shared.privacy_notice"), "/privacy" %>
+            <%= privacy_link(class: "govuk-footer__link") %>
           </li>
           <li class="govuk-footer__inline-list-item">
             <a class="govuk-footer__link" href="/terms-and-conditions"><%= t(".terms_and_conditions") %></a>

--- a/spec/features/all_cases_survey/all_cases_survey_spec.rb
+++ b/spec/features/all_cases_survey/all_cases_survey_spec.rb
@@ -1,4 +1,5 @@
 RSpec.feature "Completing the All Cases Survey" do
+  let(:privacy_notice_url) { ApplicationHelper::PRIVACY_NOTICE_URL }
   let(:all_cases_survey) { create(:all_cases_survey_response, case:) }
   let(:case) { create(:support_case, state:) }
   let(:state) { "resolved" }
@@ -13,7 +14,7 @@ RSpec.feature "Completing the All Cases Survey" do
     end
 
     it "links to the privacy notice" do
-      expect(page).to have_link "Privacy notice", href: "/privacy"
+      expect(page).to have_link "Privacy notice", href: privacy_notice_url
     end
 
     it "continues to the satisfaction page" do

--- a/spec/features/exit_survey/exit_survey_spec.rb
+++ b/spec/features/exit_survey/exit_survey_spec.rb
@@ -1,4 +1,5 @@
 RSpec.feature "Completing the Exit Survey" do
+  let(:privacy_notice_url) { ApplicationHelper::PRIVACY_NOTICE_URL }
   let(:exit_survey) { create(:exit_survey_response) }
 
   describe "start page" do
@@ -11,7 +12,7 @@ RSpec.feature "Completing the Exit Survey" do
     end
 
     it "links to the privacy notice" do
-      expect(page).to have_link "Privacy notice", href: "/privacy"
+      expect(page).to have_link "Privacy notice", href: privacy_notice_url
     end
 
     it "continues to the satisfaction page" do

--- a/spec/features/specify/layout_spec.rb
+++ b/spec/features/specify/layout_spec.rb
@@ -1,4 +1,6 @@
 RSpec.feature "Common layout element" do
+  let(:privacy_notice_url) { ApplicationHelper::PRIVACY_NOTICE_URL }
+
   before do
     visit "/cms"
   end
@@ -23,7 +25,7 @@ RSpec.feature "Common layout element" do
       within("ul.govuk-footer__inline-list") do
         expect(page).to have_link "Accessibility statement", href: "/accessibility", class: "govuk-footer__link"
         expect(page).to have_link "Terms and Conditions", href: "/terms-and-conditions", class: "govuk-footer__link"
-        expect(page).to have_link "Privacy notice", href: "/privacy", class: "govuk-footer__link"
+        expect(page).to have_link "Privacy notice", href: privacy_notice_url, class: "govuk-footer__link"
       end
     end
   end

--- a/spec/features/support/case_navigation_spec.rb
+++ b/spec/features/support/case_navigation_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Case list navigation", :js do
+RSpec.feature "Case list navigation", :flaky, :js do
   include_context "with an agent"
 
   let(:category) { create(:support_category, :fixed_title) }

--- a/spec/models/support/establishment_search_spec.rb
+++ b/spec/models/support/establishment_search_spec.rb
@@ -7,10 +7,10 @@ describe Support::EstablishmentSearch do
     create(:support_organisation, :with_address, name: "Test Open School", urn: "1233", ukprn: "7", status: 1)
     create(:support_organisation, :with_address, name: "Test Archived School", urn: "1234", ukprn: "7", status: 1, archived: true)
     create(:support_establishment_group, :with_address, name: "Test MAT", uid: "1", ukprn: "8")
-    create(:local_authority, name: la_name)
+    create(:local_authority, name: la_name, la_code:)
   end
 
-  let(:la_code) { LocalAuthority.find_by(name: la_name).la_code }
+  let(:la_code) { "456" }
   let(:la_name) { "Camden" }
 
   describe "establishment search" do


### PR DESCRIPTION
I've added a new helper method for this to avoid repeated markup.

As this won't be hosted in Contentful any more I've removed the `privacy` slug from the deprecated pages list.