### PR TITLE
CORE-404 Improve handling of Contentful url's

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,8 +72,8 @@ module ApplicationHelper
 
   def fabs_govuk_link_to(link_text, url, **options)
     safe_url = safe_url(url)
-    external_attrs = external_link_attributes(url)
-    if is_external_link?(url)
+    external_attrs = external_link_attributes(safe_url)
+    if is_external_link?(safe_url)
       link_text = "#{h(link_text)}<span class=\"govuk-visually-hidden\"> #{h(t('shared.external_link.opens_in_new_tab'))}</span>".html_safe
     end
 
@@ -87,7 +87,7 @@ module ApplicationHelper
       uri = URI.parse(url)
       return false unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
 
-      uri.host != request.host
+      uri.host != request.host && uri.host != application_uri&.host
     rescue URI::InvalidURIError
       false
     end
@@ -101,34 +101,66 @@ module ApplicationHelper
     return "#" unless url.is_a?(String)
 
     uri = URI.parse(url)
+    return application_url_for(url) if relative_path?(uri, url)
+    return application_url_for(relative_url(uri)) if ghbs_host?(uri)
+
     uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS) ? url : "#"
   rescue URI::InvalidURIError => e
     Rollbar.error(e, url:)
     "#"
   end
 
+  def ghbs_host?(uri)
+    (uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)) && uri.host.to_s.include?("get-help-buying-for-schools")
+  end
+
+  def relative_path?(uri, url)
+    uri.relative? && uri.host.blank? && url.starts_with?("/")
+  end
+
+  def application_url_for(path)
+    uri = application_uri
+    return "#" unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+
+    URI.join(uri.to_s, path).to_s
+  end
+
+  def application_uri
+    return if ENV["APPLICATION_URL"].blank?
+
+    URI.parse(ENV.fetch("APPLICATION_URL"))
+  end
+
+  def relative_url(uri)
+    relative_url = uri.path.presence || "/"
+    relative_url += "?#{uri.query}" if uri.query.present?
+    relative_url += "##{uri.fragment}" if uri.fragment.present?
+    relative_url
+  end
+
   def usability_survey_url(url)
-    base_url = "https://www.get-help-buying-for-schools.service.gov.uk/usability_surveys/new"
+    uri = application_uri
+    uri.path = "/usability_surveys/new"
+
     safe_url = safe_url(url)
     return_url = safe_url == "#" ? request.original_url : safe_url
 
-    params = {
+    uri.query = {
       service: "find_a_buying_solution",
       return_url: UrlVerifier.generate(return_url),
-    }
-    "#{base_url}?#{params.to_query}"
+    }.to_query
+    uri.to_s
   end
 
   def customer_satisfaction_survey_url(source)
-    base_url = ENV.fetch("GHBS_SERVER_URL", ENV.fetch("APPLICATION_URL", ""))
-    return "#" if base_url.blank?
+    uri = application_uri
+    uri.path = "/customer_satisfaction_surveys/new"
 
-    uri = URI.join(base_url, "/customer_satisfaction_surveys/new")
     uri.query = {
       service: "find_a_buying_solution",
       source:,
     }.to_query
-    safe_url(uri.to_s)
+    uri.to_s
   end
 
   def fabs_format_date(date_string)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,7 +87,7 @@ module ApplicationHelper
       uri = URI.parse(url)
       return false unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
 
-      uri.host != request.host && uri.host != application_uri&.host
+      uri.host != request.host && uri.host != application_uri.host
     rescue URI::InvalidURIError
       false
     end
@@ -119,15 +119,10 @@ module ApplicationHelper
   end
 
   def application_url_for(path)
-    uri = application_uri
-    return "#" unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-
-    URI.join(uri.to_s, path).to_s
+    URI.join(application_uri.to_s, path).to_s
   end
 
   def application_uri
-    return if ENV["APPLICATION_URL"].blank?
-
     URI.parse(ENV.fetch("APPLICATION_URL"))
   end
 

--- a/spec/features/cec/case_assignment_spec.rb
+++ b/spec/features/cec/case_assignment_spec.rb
@@ -11,9 +11,8 @@ RSpec.feature "Case worker assignment", :js do
       click_button "Assign"
     end
 
-    it "assigns the agent and redirects to the case" do
-      # TODO: Revisit if/when we switch to Playwright
-      skip "Flaky test of mature functionality"
+    # TODO: Revisit if/when we switch to Playwright
+    it "assigns the agent and redirects to the case", skip: "Flaky test of mature functionality" do
       expect(support_case.reload.agent).to eq(agent)
       expect(page).to have_current_path(cec_onboarding_case_path(support_case), ignore_query: true)
     end

--- a/spec/features/engagement/create_case_spec.rb
+++ b/spec/features/engagement/create_case_spec.rb
@@ -77,6 +77,7 @@ RSpec.feature "Create case", :js do
         expect(page).to have_text "2 of 3 schools"
 
         click_on "Create case"
+        expect(page).to have_current_path(engagement_cases_path, ignore_query: true)
         expect(Support::Case.last.organisation).to eq(group)
         expect(Support::Case.last.participating_schools.pluck(:name)).to contain_exactly("School #1", "School #2")
         expect(CaseRequest.last.same_supplier_used).to eq("yes")
@@ -105,6 +106,7 @@ RSpec.feature "Create case", :js do
         expect(page).to have_text "2 of 3 schools"
 
         click_on "Create case"
+        expect(page).to have_current_path(engagement_cases_path, ignore_query: true)
         expect(Support::Case.last.organisation).to eq(local_authority)
         expect(Support::Case.last.participating_schools.pluck(:name)).to contain_exactly("School #1", "School #2")
         expect(CaseRequest.last.same_supplier_used).to eq("yes")

--- a/spec/features/offers_spec.rb
+++ b/spec/features/offers_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Offer Details Page", :vcr, type: :feature do
     it "links to the correct URL for the offer" do
       visit offer_path("energy-for-schools")
       link = find("a.govuk-button[href]", match: :first)
-      expect(link[:href]).to eq("https://www.get-help-buying-for-schools.service.gov.uk/energy/before-you-start")
+      expect(link[:href]).to eq("http://localhost:3000/energy/before-you-start")
     end
   end
 end

--- a/spec/features/support/case_assignment_spec.rb
+++ b/spec/features/support/case_assignment_spec.rb
@@ -11,9 +11,8 @@ RSpec.feature "Case worker assignment", :js do
       click_button "Assign"
     end
 
-    it "assigns the agent and redirects to the case" do
-      # TODO: Revisit if/when we switch to Playwright
-      skip "Flaky test of mature functionality"
+    # TODO: Revisit if/when we switch to Playwright
+    it "assigns the agent and redirects to the case", skip: "Flaky test of mature functionality" do
       expect(support_case.reload.agent).to eq(agent)
       expect(page).to have_current_path(support_case_path(support_case), ignore_query: true)
     end

--- a/spec/features/support/emails/agent_can_forward_emails_spec.rb
+++ b/spec/features/support/emails/agent_can_forward_emails_spec.rb
@@ -58,6 +58,7 @@ describe "Agent can forward an email", :js do
       context "without a valid recipient email address" do
         it "shows validation error when no recipient is added" do
           click_button "Send message"
+          expect(page).to have_css(".govuk-error-summary")
           expect(page).to have_content("At least one recipient must be specified")
         end
 

--- a/spec/features/support/filter_cases_spec.rb
+++ b/spec/features/support/filter_cases_spec.rb
@@ -48,11 +48,16 @@ RSpec.feature "Filter cases", :js do
 
   describe "case filtering and sorting" do
     it "filters by category and sorts by state" do
-      click_link "All cases"
+      visit support_cases_path(
+        anchor: "all-cases",
+        filter_all_cases_form: {
+          category: [mfd_cat.id],
+          sort_by: "state",
+          sort_order: "ascending",
+        },
+      )
+
       within "#all-cases" do
-        check "MFD"
-        select "Status", from: "Sort by"
-        choose("Ascending", allow_label_click: true)
         expect(page).to have_selector(".case-list li", count: 2)
         expect(first(".case-list li")).to have_text "On Hold"
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,9 +1,13 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
+  around do |example|
+    ClimateControl.modify(APPLICATION_URL: "https://get-help-buying-for-schools.education.gov.uk") { example.run }
+  end
+
   describe "#fabs_govuk_link_to" do
-    let(:external_url) { "https://example.com" }
-    let(:internal_url) { "/internal-path" }
+    let(:external_url) { "https://example.com/foo" }
+    let(:internal_url) { "/privacy-policy" }
 
     context "with external URLs" do
       it "adds rel noopener noreferrer attribute" do
@@ -23,6 +27,11 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     context "with internal URLs" do
+      it "uses a fully qualified application URL as the href" do
+        result = helper.fabs_govuk_link_to("Internal", internal_url)
+        expect(result).to include('href="https://get-help-buying-for-schools.education.gov.uk/privacy-policy"')
+      end
+
       it "does not add rel noopener noreferrer attribute" do
         result = helper.fabs_govuk_link_to("Internal", internal_url)
         expect(result).not_to include('rel="noopener noreferrer"')
@@ -39,9 +48,66 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
+    context "with get-help-buying-for-schools URLs" do
+      it "converts staging and service URLs to fully qualified application URLs" do
+        result = helper.fabs_govuk_link_to("Energy", "https://staging.get-help-buying-for-schools.service.gov.uk/energy/before-you-start")
+        expect(result).to include('href="https://get-help-buying-for-schools.education.gov.uk/energy/before-you-start"')
+      end
+
+      it "preserves query strings and fragments when converting to application URLs" do
+        result = helper.fabs_govuk_link_to("Energy", "https://staging.get-help-buying-for-schools.service.gov.uk/energy/before-you-start?source=email#start")
+        expect(result).to include('href="https://get-help-buying-for-schools.education.gov.uk/energy/before-you-start?source=email#start"')
+      end
+
+      it "does not treat converted URLs as external" do
+        result = helper.fabs_govuk_link_to("Energy", "https://staging.get-help-buying-for-schools.service.gov.uk/energy/before-you-start")
+
+        expect(result).not_to include('rel="noopener noreferrer"')
+        expect(result).not_to include('target="_blank"')
+        expect(result).not_to include('<span class="govuk-visually-hidden"> opens in new tab</span>')
+      end
+    end
+
+    context "with non-get-help-buying-for-schools URLs" do
+      it "keeps the external URL as the href" do
+        result = helper.fabs_govuk_link_to("External", "https://example.com/cookie-policy")
+        expect(result).to include('href="https://example.com/cookie-policy"')
+      end
+    end
+
     it "preserves additional options" do
       result = helper.fabs_govuk_link_to("Link", "/path", class: "custom-class")
       expect(result).to include('class="govuk-link custom-class"')
+    end
+  end
+
+  describe "#customer_satisfaction_survey_url" do
+    it "builds a fully qualified survey URL from APPLICATION_URL" do
+      expect(helper.customer_satisfaction_survey_url("footer_link")).to eq(
+        "https://get-help-buying-for-schools.education.gov.uk/customer_satisfaction_surveys/new?service=find_a_buying_solution&source=footer_link",
+      )
+    end
+  end
+
+  describe "#usability_survey_url" do
+    before do
+      allow(UrlVerifier).to receive(:generate).and_return("signed-return-url")
+      allow(helper.request).to receive(:original_url).and_return("https://get-help-buying-for-schools.education.gov.uk/current-page")
+    end
+
+    it "uses a fully qualified application URL for a relative path" do
+      result = helper.usability_survey_url("/custom-page")
+
+      expect(result).to eq(
+        "https://get-help-buying-for-schools.education.gov.uk/usability_surveys/new?return_url=signed-return-url&service=find_a_buying_solution",
+      )
+      expect(UrlVerifier).to have_received(:generate).with("https://get-help-buying-for-schools.education.gov.uk/custom-page")
+    end
+
+    it "falls back to the current request URL for invalid input" do
+      helper.usability_survey_url(nil)
+
+      expect(UrlVerifier).to have_received(:generate).with("https://get-help-buying-for-schools.education.gov.uk/current-page")
     end
   end
 

--- a/spec/requests/fabs/categories_show_spec.rb
+++ b/spec/requests/fabs/categories_show_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "FABS category pages", type: :request do
     expect(response.body).to include("Buy IT and ICT equipment and services")
     expect(response.body).to include("Everything ICT")
     expect(response.body).to include("Related Content")
-    expect(document).to have_link("Plan technology for your school", href: "#")
+    expect(document).to have_link("Plan technology for your school", href: "http://localhost:3000/plan-technology")
     expect(document).to have_link("Home", href: "/")
   end
 

--- a/spec/requests/fabs/offers_spec.rb
+++ b/spec/requests/fabs/offers_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "FABS offers", type: :request do
       expect(response.body).to include("Energy for Schools")
       expect(document).to have_link("Home", href: "/")
       expect(document).to have_link("Offers", href: "/offers")
-      expect(document).to have_link(I18n.t("offers.show.cta", title: "Energy for Schools"), href: "https://www.get-help-buying-for-schools.service.gov.uk/energy/before-you-start")
+      expect(document).to have_link(I18n.t("offers.show.cta", title: "Energy for Schools"), href: "http://localhost:3000/energy/before-you-start")
     end
   end
 end

--- a/spec/requests/fabs/pages_spec.rb
+++ b/spec/requests/fabs/pages_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "FABS pages", type: :request do
     expect(document).to have_link("Home", href: "/")
     expect(document).to have_link("Banking and finance", href: "/categories/banking-finance")
     expect(document).to have_link("Current accounts and savings", href: "/current-account-and-savings")
-    expect(document).to have_link("Framework agreements", href: "#")
+    expect(document).to have_link("Framework agreements", href: "http://localhost:3000/framework-agreements")
   end
 
   it "omits related content when the page has none" do

--- a/spec/requests/fabs/solutions_spec.rb
+++ b/spec/requests/fabs/solutions_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "FABS solutions", type: :request do
       expect(response.body).to include("31 December 2026")
       expect(response.body).to include("RM1234")
       expect(response.body).to include("Related Content")
-      expect(document).to have_link("Framework agreements", href: "#")
+      expect(document).to have_link("Framework agreements", href: "http://localhost:3000/framework-agreements")
       expect(document).to have_link(I18n.t("solutions.show.cta", title: "Audit and financial services"), href: "https://example.com/apply")
     end
 

--- a/spec/support/capybara_driver_helper.rb
+++ b/spec/support/capybara_driver_helper.rb
@@ -46,6 +46,7 @@ Capybara.register_driver :cuprite do |app|
     headless: ENV["GUI"].blank?,
     process_timeout: 20,
     timeout: CUPRITE_TIMEOUT,
+    url_blacklist: [%r{https://rsms\.me/.*}],
     window_size: [1920, 1080],
     **remote_browser_config,
   )

--- a/spec/support/capybara_driver_helper.rb
+++ b/spec/support/capybara_driver_helper.rb
@@ -5,6 +5,7 @@ require "socket"
 require "uri"
 
 JS_DRIVER = :cuprite
+CUPRITE_TIMEOUT = ENV.fetch("CUPRITE_TIMEOUT", ENV["CUPRITE_BROWSER_URL"].present? ? 30 : 10).to_i
 
 def remote_browser_config
   browser_url = ENV["CUPRITE_BROWSER_URL"].presence
@@ -44,7 +45,7 @@ Capybara.register_driver :cuprite do |app|
     browser_options:,
     headless: ENV["GUI"].blank?,
     process_timeout: 20,
-    timeout: 10,
+    timeout: CUPRITE_TIMEOUT,
     window_size: [1920, 1080],
     **remote_browser_config,
   )


### PR DESCRIPTION
Much of the content we ingest from Contentful has links to both internal pages within GHBS and external services. Any external services should open in a new browser tab and internal links should remain within the current tab.

Historically, it has not been possible to use relative links e.g. `/privacy` within Contentful models as these urls are parsed for safety, fail that check and then are returned simply as `#` so don't work when clicked. To mitigate that, fully qualified url's have been populated within Contentful i.e. `https://www.get-help-buying-for-schools.service.gov.uk/privacy`. This is prone to errors, is a bit of a blocker to the forthcoming domain change and also prevents easy migration of Contentful models across environments.

This PR addresses this with a few tweaks. Firstly, any relative urls have the fully qualified hostname prepended using the `APPLICATION_URL` ENV var. That means we can simply use `/privacy` in the Contentful models and everything will render nicely.

For existing Contentful models, any urls that contain the pattern `get-help-buying-for-schools` (irrespective of dev/staging/www subdomain or .education/.service domain) will be returned using the `APPLICATION_URL` domain. This allows Contentful models to be copied across environments and any url's will automatically work for the running server instance. That's particularly helpful for local dev environments as pages will remain on `localhost:3000` rather than constantly jumping to other environments. It also supports the domain change as we can simply update `APPLICATION_URL` to point at `https://get-help-buying-for-schools.education.gov.uk` to immediately fix all internal content links.

I've also refactored a couple of helper functions that generate survey URL's to use the same `APPLICATION_URL` ENV var, removing the previous hardcoded domain and reference to a redundant `GHBS_SERVER_URL` var that is not used anywhere (checked on Azure and it doesn't get populated, so was defaulting to `APPLICATION_URL` anyway).

Also includes a few fixes for flaky specs unrelated to this PR.