### PR TITLE
CORE-556 - Add cookie link to the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -126,6 +126,9 @@
               <li class="govuk-footer__inline-list-item">
                 <%= privacy_link(class: "govuk-footer__link") %>
               </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/cookie_preferences"><%= t(".cookies") %></a>
+              </li>
             </ul>
 
             <svg

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -127,7 +127,7 @@
                 <%= privacy_link(class: "govuk-footer__link") %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/cookie_preferences"><%= t(".cookies") %></a>
+                <a class="govuk-footer__link" href="/cookie_preferences">Cookies</a>
               </li>
             </ul>
 

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -22,6 +22,9 @@
           <li class="govuk-footer__inline-list-item">
             <a class="govuk-footer__link" href="/terms-and-conditions"><%= t(".terms_and_conditions") %></a>
           </li>
+          <li class="govuk-footer__inline-list-item">
+            <a class="govuk-footer__link" href="/cookie_preferences"><%= t(".cookies") %></a>
+          </li>
         </ul>
         <div>
           <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3003,6 +3003,7 @@ en:
       ogl3: Open Government Licence v3.0
       procurement_support: Request help and support for your procurement
       terms_and_conditions: Terms and conditions
+      cookies: Cookies
     dfe_homepage_header:
       view_all_buying_options: Browse a list of all DfE-approved buying options
     dfe_search:

--- a/spec/features/specify/layout_spec.rb
+++ b/spec/features/specify/layout_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "Common layout element" do
         expect(page).to have_link "Accessibility statement", href: "/accessibility-statement", class: "govuk-footer__link"
         expect(page).to have_link "Terms and Conditions", href: "/terms-and-conditions", class: "govuk-footer__link"
         expect(page).to have_link "Privacy notice", href: privacy_notice_url, class: "govuk-footer__link"
+        expect(page).to have_link "Cookies", href: "/cookie_preferences", class: "govuk-footer__link"
       end
     end
   end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Adds the Cookie link to the footer ('fabs' and ghbs) which was goes to the cookie preferences page
- Note that a future ticket will be looking at bringing the footer into one and updating to GDS standards, this is just getting the cookies link in
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
<img width="1103" height="335" alt="Screenshot 2026-05-29 at 11 45 35" src="https://github.com/user-attachments/assets/23266f15-ccfb-48ef-805b-368efdfb60eb" />
<img width="881" height="309" alt="Screenshot 2026-05-29 at 11 46 20" src="https://github.com/user-attachments/assets/d02ee3cf-2605-4b9b-8d7e-c008786e3153" />

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
