### PR TITLE
CORE-420 - Consolidate accessibility statement into one and link from footer

### DIFF
--- a/app/controllers/energy/application_controller.rb
+++ b/app/controllers/energy/application_controller.rb
@@ -1,6 +1,6 @@
 module Energy
   class ApplicationController < ::ApplicationController
-    before_action :check_flag, :set_accessibility_link, :check_if_submitted, :set_routing_flags
+    before_action :check_flag, :check_if_submitted, :set_routing_flags
 
     ALLOWED_CLASSES = [
       "Support::Organisation",
@@ -10,10 +10,6 @@ module Energy
     MAX_METER_COUNT = 5
 
   private
-
-    def set_accessibility_link
-      @energy_accessibility_link = "https://accessibility-statements.education.gov.uk/s/29"
-    end
 
     def check_flag
       render "errors/not_found", status: :not_found unless Flipper.enabled?(:energy)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,7 @@ require "date"
 module ApplicationHelper
   include MarkdownHelper
 
+  ACCESSIBILITY_STATEMENT_URL = "https://accessibility-statements.education.gov.uk/s/29"
   PRIVACY_NOTICE_URL = "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/privacy-information-education-providers-workforce-including-teachers#using-your-data-to-use-our-websites"
 
   def banner_tag
@@ -64,6 +65,10 @@ module ApplicationHelper
 
   def register_your_interest_form_url
     "https://submit.forms.service.gov.uk/form/8895/multi-academy-trusts-register-your-interest-in-energy-for-schools/1049539"
+  end
+
+  def accessibility_link(link_text = t("shared.accessibility_statement"), **options)
+    fabs_govuk_link_to(link_text, ACCESSIBILITY_STATEMENT_URL, **options)
   end
 
   def privacy_link(link_text = t("shared.privacy_notice"), **options)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -118,7 +118,7 @@
 
             <ul class="govuk-footer__inline-list">
               <li class="govuk-footer__inline-list-item">
-                <a href="<%= @energy_accessibility_link || "/accessibility-statement" %>" class="govuk-footer__link">Accessibility statement</a>
+                <%= accessibility_link(class: "govuk-footer__link") %>
               </li>
               <li class="govuk-footer__inline-list-item">
                 <%= link_to "Terms and Conditions", "/terms-and-conditions", class: "govuk-footer__link" %>

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -14,7 +14,7 @@
             <a class="govuk-footer__link" href="<%=customer_satisfaction_survey_url("footer_link") %>" target="_blank" rel="noopener noreferrer"><%= t(".feedback") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
           </li>
           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/accessibility-statement"><%= t(".accessibility_statement") %></a>
+            <%= accessibility_link(class: "govuk-footer__link") %>
           </li>
           <li class="govuk-footer__inline-list-item">
             <%= privacy_link(class: "govuk-footer__link") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2994,8 +2994,8 @@ en:
       about: About this service
       menu: Menu
   shared:
+    accessibility_statement: Accessibility statement
     dfe_footer:
-      accessibility_statement: Accessibility statement
       crown_copyright: "© Crown copyright"
       feedback: Feedback
       licensing_html: All content is available under the %{ogl3}, except where otherwise

--- a/spec/features/specify/layout_spec.rb
+++ b/spec/features/specify/layout_spec.rb
@@ -1,4 +1,5 @@
 RSpec.feature "Common layout element" do
+  let(:accessibility_statement_url) { ApplicationHelper::ACCESSIBILITY_STATEMENT_URL }
   let(:privacy_notice_url) { ApplicationHelper::PRIVACY_NOTICE_URL }
 
   before do
@@ -23,7 +24,7 @@ RSpec.feature "Common layout element" do
   describe "footer" do
     scenario "provides an email address for the service and expected links" do
       within("ul.govuk-footer__inline-list") do
-        expect(page).to have_link "Accessibility statement", href: "/accessibility-statement", class: "govuk-footer__link"
+        expect(page).to have_link "Accessibility statement", href: accessibility_statement_url, class: "govuk-footer__link"
         expect(page).to have_link "Terms and Conditions", href: "/terms-and-conditions", class: "govuk-footer__link"
         expect(page).to have_link "Privacy notice", href: privacy_notice_url, class: "govuk-footer__link"
         expect(page).to have_link "Cookies", href: "/cookie_preferences", class: "govuk-footer__link"


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Changes the accessibility link in the footer to just point at one consolidated external link
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
