### PR TITLE
CORE-571: Combine the footers into one and update to GDS standards

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,11 +67,11 @@ module ApplicationHelper
     "https://submit.forms.service.gov.uk/form/8895/multi-academy-trusts-register-your-interest-in-energy-for-schools/1049539"
   end
 
-  def accessibility_link(link_text = t("shared.accessibility_statement"), **options)
+  def accessibility_link(link_text = t("shared.dfe_footer.accessibility"), **options)
     fabs_govuk_link_to(link_text, ACCESSIBILITY_STATEMENT_URL, **options)
   end
 
-  def privacy_link(link_text = t("shared.privacy_notice"), **options)
+  def privacy_link(link_text = t("shared.dfe_footer.privacy"), **options)
     fabs_govuk_link_to(link_text, PRIVACY_NOTICE_URL, **options)
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,58 +78,7 @@
       </main>
     </div>
 
-    <footer class="govuk-footer">
-      <div class="govuk-width-container <%= container_width_class %>">
-        <%= image_tag("govuk-footer-crown.svg", alt: "Crown Logo", class: "govuk-footer__crown") %>
-        <div class="govuk-footer__meta">
-          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          <h2 class="govuk-visually-hidden">Support links</h2>
-
-            <ul class="govuk-footer__inline-list">
-              <li class="govuk-footer__inline-list-item">
-                <%= accessibility_link(class: "govuk-footer__link") %>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <%= link_to "Terms and Conditions", "/terms-and-conditions", class: "govuk-footer__link" %>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <%= privacy_link(class: "govuk-footer__link") %>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/cookie_preferences">Cookies</a>
-              </li>
-            </ul>
-
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              class="govuk-footer__licence-logo"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 483.2 195.7"
-              height="17"
-              width="41">
-              <path
-                fill="currentColor"
-                d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-            </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a
-                class="govuk-footer__link"
-                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
-          </div>
-          <div class="govuk-footer__meta-item">
-            <a
-              class="govuk-footer__link govuk-footer__copyright-logo"
-              href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
-              © Crown copyright
-            </a>
-          </div>
-        </div>
-      </div>
-    </footer>
+    <%= render "shared/dfe_footer" %>
 
     <%= render partial: "layouts/redirect" %>
   </body>

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -38,18 +38,18 @@
           <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
         </svg>
         <span class="govuk-footer__licence-description">
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+          <%= t(".licensing_html",
+                ogl3: govuk_link_to(t('.ogl3'), 
+                                            "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", 
+                                            class: "govuk-footer__link", 
+                                            rel: "license")) %>
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
-          © Crown copyright
+          <%= t(".crown_copyright") %>
         </a>
       </div>
     </div>

--- a/app/views/shared/_dfe_footer.html.erb
+++ b/app/views/shared/_dfe_footer.html.erb
@@ -5,39 +5,52 @@
     </div>
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <h2 class="govuk-visually-hidden"><%= t(".feedback") %></h2>
-        <ul class="govuk-footer__inline-list govuk-footer__inline-list--inline govuk-!-margin-bottom-6">
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="https://www.get-help-buying-for-schools.service.gov.uk/procurement-support" target="_blank" rel="noopener noreferrer" data-track-internal-link><%= t(".procurement_support") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="<%=customer_satisfaction_survey_url("footer_link") %>" target="_blank" rel="noopener noreferrer"><%= t(".feedback") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <%= accessibility_link(class: "govuk-footer__link") %>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <%= privacy_link(class: "govuk-footer__link") %>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/terms-and-conditions"><%= t(".terms_and_conditions") %></a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/cookie_preferences"><%= t(".cookies") %></a>
-          </li>
+        <h2 class="govuk-visually-hidden"><%= t(".support_links") %></h2>
+        <ul class="govuk-footer__inline-list">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/procurement-support"><%= t(".procurement_help") %></a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= privacy_link(class: "govuk-footer__link") %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/cookie_preferences"><%= t(".cookies") %></a>
+              </li>
+            </div>
+          </div>
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <li class="govuk-footer__inline-list-item">
+                <%= accessibility_link(class: "govuk-footer__link") %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/terms-and-conditions"><%= t(".terms_and_conditions") %></a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="<%=customer_satisfaction_survey_url("footer_link") %>"><%= t(".feedback") %></a>
+              </li>
+            </div>
+          </div>
         </ul>
-        <div>
-          <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
           <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
-          </svg>
-        </div>
-        <div class="govuk-footer__licence-description">
-          <%= t(".licensing_html",
-                ogl3: fabs_govuk_link_to(t('.ogl3'), "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", class: "govuk-footer__link")) %>
-        </div>
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a
+            class="govuk-footer__link"
+            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+            rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
       </div>
       <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/" target="_blank" rel="noopener noreferrer"><%= t(".crown_copyright") %><span class="govuk-visually-hidden"> <%= t("shared.external_link.opens_in_new_tab") %></span></a>
+        <a
+          class="govuk-footer__link govuk-footer__copyright-logo"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
+          © Crown copyright
+        </a>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2994,16 +2994,17 @@ en:
       about: About this service
       menu: Menu
   shared:
-    accessibility_statement: Accessibility statement
     dfe_footer:
+      accessibility: Accessibility
+      cookies: Cookies
       crown_copyright: "© Crown copyright"
       feedback: Feedback
-      licensing_html: All content is available under the %{ogl3}, except where otherwise
-        stated.
+      licensing_html: All content is available under the %{ogl3}, except where otherwise stated.
       ogl3: Open Government Licence v3.0
-      procurement_support: Request help and support for your procurement
+      privacy: Privacy
+      procurement_help: Request procurement help
+      support_links: Support links
       terms_and_conditions: Terms and conditions
-      cookies: Cookies
     dfe_homepage_header:
       view_all_buying_options: Browse a list of all DfE-approved buying options
     dfe_search:
@@ -3015,7 +3016,6 @@ en:
       search_this_website: Search this website
     external_link:
       opens_in_new_tab: opens in new tab
-    privacy_notice: Privacy notice
   solutions:
     index:
       all_buying_options_description: Use a DfE-approved buying option to make sure

--- a/spec/features/all_cases_survey/all_cases_survey_spec.rb
+++ b/spec/features/all_cases_survey/all_cases_survey_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Completing the All Cases Survey" do
     end
 
     it "links to the privacy notice" do
-      expect(page).to have_link "Privacy notice", href: privacy_notice_url
+      expect(page).to have_link "Privacy", href: privacy_notice_url
     end
 
     it "continues to the satisfaction page" do

--- a/spec/features/exit_survey/exit_survey_spec.rb
+++ b/spec/features/exit_survey/exit_survey_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Completing the Exit Survey" do
     end
 
     it "links to the privacy notice" do
-      expect(page).to have_link "Privacy notice", href: privacy_notice_url
+      expect(page).to have_link "Privacy", href: privacy_notice_url
     end
 
     it "continues to the satisfaction page" do

--- a/spec/features/specify/layout_spec.rb
+++ b/spec/features/specify/layout_spec.rb
@@ -2,6 +2,10 @@ RSpec.feature "Common layout element" do
   let(:accessibility_statement_url) { ApplicationHelper::ACCESSIBILITY_STATEMENT_URL }
   let(:privacy_notice_url) { ApplicationHelper::PRIVACY_NOTICE_URL }
 
+  around do |example|
+    ClimateControl.modify(APPLICATION_URL: "https://get-help-buying-for-schools.education.gov.uk") { example.run }
+  end
+
   before do
     visit "/cms"
   end
@@ -24,10 +28,12 @@ RSpec.feature "Common layout element" do
   describe "footer" do
     scenario "provides an email address for the service and expected links" do
       within("ul.govuk-footer__inline-list") do
-        expect(page).to have_link "Accessibility statement", href: accessibility_statement_url, class: "govuk-footer__link"
-        expect(page).to have_link "Terms and Conditions", href: "/terms-and-conditions", class: "govuk-footer__link"
-        expect(page).to have_link "Privacy notice", href: privacy_notice_url, class: "govuk-footer__link"
+        expect(page).to have_link "Request procurement help", href: "/procurement-support", class: "govuk-footer__link"
+        expect(page).to have_link "Privacy", href: privacy_notice_url, class: "govuk-footer__link"
         expect(page).to have_link "Cookies", href: "/cookie_preferences", class: "govuk-footer__link"
+        expect(page).to have_link "Accessibility", href: accessibility_statement_url, class: "govuk-footer__link"
+        expect(page).to have_link "Terms and conditions", href: "/terms-and-conditions", class: "govuk-footer__link"
+        expect(page).to have_link "Feedback", href: "https://get-help-buying-for-schools.education.gov.uk/customer_satisfaction_surveys/new?service=find_a_buying_solution&source=footer_link", class: "govuk-footer__link"
       end
     end
   end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Combined the two footers into one (the shared _dfe_footer) so it is consistent across all pages in GHBS
- Edit the names of the links to GDS standards, change the order in which they appear, and split into two rows
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
Before:
<img width="1675" height="282" alt="Screenshot 2026-06-15 at 11 48 27" src="https://github.com/user-attachments/assets/15fb51cd-dcb7-459d-ab50-4385b6fa049a" />
After:
<img width="1724" height="294" alt="Screenshot 2026-06-15 at 11 48 48" src="https://github.com/user-attachments/assets/ecc77ab9-74a9-4710-80aa-3199b0dcc3e9" />

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.


  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
