### PR TITLE
Remove unused ENV var from Github actions

### DIFF
--- a/.github/workflows/ci-full-pipeline.yml
+++ b/.github/workflows/ci-full-pipeline.yml
@@ -156,7 +156,6 @@ jobs:
             -e QUALTRICS_SURVEY_URL=https://dferesearch.fra1.qualtrics.com \
             -e SUPPORT_EMAIL=email@example.gov.uk \
             -e FAF_WEBHOOK_SECRET=test \
-            -e GHBS_HOMEPAGE_URL=https://example.com \
             -e CI_NODE_TOTAL=${{ matrix.ci_node_total }} \
             -e CI_NODE_INDEX=${{ matrix.ci_node_index }} \
             ${{ needs.build_test.outputs.docker_image }} \
@@ -234,7 +233,6 @@ jobs:
             -e QUALTRICS_SURVEY_URL=https://dferesearch.fra1.qualtrics.com \
             -e SUPPORT_EMAIL=email@example.gov.uk \
             -e FAF_WEBHOOK_SECRET=test \
-            -e GHBS_HOMEPAGE_URL=https://example.com \
             ${{ needs.build_test.outputs.docker_image }} \
             bash -c "bundle exec rspec --tag flaky || bundle exec rspec --only-failure"
       - name: Get coverage from container
@@ -373,7 +371,6 @@ jobs:
             -e QUALTRICS_SURVEY_URL=https://dferesearch.fra1.qualtrics.com \
             -e SUPPORT_EMAIL=email@example.gov.uk \
             -e FAF_WEBHOOK_SECRET=test \
-            -e GHBS_HOMEPAGE_URL=https://example.com \
             ${{ needs.build_test.outputs.docker_image }} \
             bash -c "RAILS_ENV=test bundle exec rake enums:check"
 


### PR DESCRIPTION
Follow up PR from CORE-260 - this removes the now unused `GHBS_HOMEPAGE_URL` from the Docker images built as part of the Github actions CI flow.