### PR TITLE
CORE-280 | fix incorrect routing on sign-in failure

### DIFF
--- a/app/controllers/evaluation/signin_controller.rb
+++ b/app/controllers/evaluation/signin_controller.rb
@@ -7,6 +7,7 @@ module Evaluation
       session.delete(:energy_onboarding)
       session.delete(:faf_referrer)
       session[:email_evaluator_link] = evaluation_task_path(id: params[:id], host: request.host)
+      session[:evaluator_signin_link] = evaluation_signin_path(id: params[:id])
     end
   end
 end

--- a/app/controllers/my_procurements/signin_controller.rb
+++ b/app/controllers/my_procurements/signin_controller.rb
@@ -7,6 +7,7 @@ module MyProcurements
       session.delete(:energy_onboarding)
       session.delete(:faf_referrer)
       session[:email_school_buyer_link] = my_procurements_task_path(id: params[:id], host: request.host)
+      session[:school_buyer_signin_link] = my_procurements_signin_path(id: params[:id])
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,10 +29,10 @@ class SessionsController < ApplicationController
   def failure
     # DSI: report the DSI user uid in the session if it exists
     track_event("Sessions/Failure", dfe_sign_in_uid: session[:dfe_sign_in_uid])
-
+    redirect_path = exit_path
     # DSI: users would need to signout manually to proceed otherwise
     if session.destroy
-      redirect_to root_path, notice: I18n.t("banner.session.failure")
+      redirect_to redirect_path, notice: I18n.t("banner.session.failure")
     end
   end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -103,4 +103,29 @@ describe SessionsController do
       end
     end
   end
+
+  describe "#failure and flash messages" do
+    it "sets the failure flash message" do
+      get(:failure, session:)
+
+      expect(flash[:notice]).to eq(I18n.t("banner.session.failure"))
+    end
+
+    it "redirects to cms_signin_path when no other links are available on the session" do
+      expect(get(:failure, session:)).to redirect_to(cms_signin_path)
+    end
+
+    it "redirects to energy_start_path when energy_onboarding flag is present" do
+      session[:energy_onboarding] = true
+
+      expect(get(:failure, session:)).to redirect_to(energy_start_path)
+    end
+
+    it "redirects to evaluator_signin_link when evaluator_signin_link is present" do
+      evaluation_signin_path = evaluation_signin_path(id: "123")
+      session[:evaluator_signin_link] = evaluation_signin_path
+
+      expect(get(:failure, session:)).to redirect_to(evaluation_signin_path)
+    end
+  end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR

Ticket: https://dfedigital.atlassian.net/browse/CORE-280

This is fix for the incorrect routing on sign-in failure, currently if any auth failure it redirects to home page. This fix will redirect to correct page with sign in failure error message.

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
<img width="1012" height="766" alt="image" src="https://github.com/user-attachments/assets/041e36e6-eb21-4bec-8e8b-630f9ce7b123" />

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
