### PR TITLE
Tweak dev deploy process to better reflect feature branch status

### DIFF
--- a/bin/deploy_dev
+++ b/bin/deploy_dev
@@ -17,9 +17,8 @@ echo "Deploying feature branch '$current_branch' onto development..."
 
 git fetch
 git checkout development
-git reset --hard origin/development
-git rebase "$current_branch"
-git push --force-with-lease
+git reset --hard "$current_branch"
+git push --force-with-lease origin development
 
 echo "Returning to $current_branch..."
 git checkout "$current_branch"

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -58,22 +58,21 @@ Development deployment is automated with github actions, but you will need to
 update the `development` branch for it to deploy changes.
 
 Switch to the `development` branch, ensure it is updated from origin, then
-rebase it with `main`.
+reset it to the feature branch you want deployed.
 
 ```
 $ git fetch
 $ git checkout development
-$ git reset --hard origin/development
-$ git rebase your-feature-branch
-$ git push --force-with-lease
+$ git reset --hard your-feature-branch
+$ git push --force-with-lease origin development
 ```
 
 NOTE: `git push --force-with-lease` is important, the force push will be
 rejected if changes have been made in origin that differ from your local branch.
 This ensures you don't overwrite other developer's changes on development.
 
-If you need to make repeated changes, always reset `development` and then
-rebase your feature branch again.
+If you need to make repeated changes, update your feature branch and then
+reset `development` to it again.
 
 Monitor the [github actions
 page](https://github.com/DFE-Digital/buy-for-your-school/actions/workflows/ci-full-pipeline.yml)


### PR DESCRIPTION
Currently deployments to dev use rebase of the development branch which means the branch often contains stale commits from other feature branches. This gets particularly bad when two branches are working in the same area of code as merge collisions must be resolved on each deployment, rather than just by rebasing the current branch. This change updates the deploy process for dev to align development branch with the current feature branch meaning much better alignment between local and development environments. It also fixes the weird commit history seen when looking at the development branch.

It's good practice to regularly rebase a feature branch against main but this should not be part of the deploy process. Also if a feature branch deviates too far from main, Github will block merging of the PR so this new approach doesn't introduce any new risk.