### PR TITLE
CORE-602 - Spike to investigate Azure AI search

### DIFF
--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -111,8 +111,37 @@
   padding-top: 20px;
 }
 
+.search-results-comparison {
+  border-top: 2px solid govuk-colour("black");
+  padding-top: 20px;
+}
+
+.search-results-comparison__grid {
+  display: grid;
+  gap: 30px;
+
+  @media (min-width: 48em) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.search-results-comparison__column {
+  border-top: 1px solid #b1b4b6;
+  padding-top: 15px;
+}
+
 .search-container {
   margin-bottom: 2rem;
+}
+
+.search-comparison-container {
+  background: govuk-colour("light-grey");
+  margin-bottom: 2rem;
+  padding: 20px;
+}
+
+.search-comparison-container__label {
+  margin-bottom: 10px;
 }
 
 .search-input-container {

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,6 +16,7 @@ class SearchController < Fabs::ApplicationController
       @solutions = Solution.search(query:)
       @categories = FABS::Category.search(query:)
       @results_count = @solutions.count + @categories.count
+      build_search_comparison(query) if compare_search?
     end
 
     render layout: "search"
@@ -42,5 +43,24 @@ private
     else
       false
     end
+  end
+
+  def compare_search?
+    ActiveModel::Type::Boolean.new.cast(params[:compare_search])
+  end
+
+  def build_search_comparison(query)
+    @search_comparison_enabled = true
+    @opensearch_solutions = comparison_results("OpenSearch") { SolutionSearcher.new(query:).search }
+    @azure_solutions = comparison_results("Azure AI Search") { AzureAiSearch::SolutionSearcher.new(query:).search }
+  end
+
+  def comparison_results(label)
+    yield
+  rescue StandardError => e
+    Rollbar.warning("#{label} comparison search failed", error: e.message) if defined?(Rollbar)
+    @comparison_errors ||= {}
+    @comparison_errors[label] = e.message
+    []
   end
 end

--- a/app/models/search_client.rb
+++ b/app/models/search_client.rb
@@ -2,7 +2,7 @@ class SearchClient
   include Singleton
   extend Forwardable
 
-  def_delegators :@client, :get, :delete, :index, :indices, :bulk, :search
+  def_delegators :@client, :get, :delete, :delete_by_query, :index, :indices, :bulk, :search
 
   def initialize
     @client = build_client
@@ -22,6 +22,7 @@ private
 
     def get(*, **, &) = raise_not_configured
     def delete(*, **, &) = raise_not_configured
+    def delete_by_query(*, **, &) = raise_not_configured
     def index(*, **, &) = raise_not_configured
     def indices(*, **, &) = raise_not_configured
     def bulk(*, **, &) = raise_not_configured

--- a/app/services/azure_ai_search/client.rb
+++ b/app/services/azure_ai_search/client.rb
@@ -1,0 +1,84 @@
+require "json"
+require "net/http"
+require "uri"
+
+module AzureAiSearch
+  class Client
+    DEFAULT_API_VERSION = "2024-07-01"
+
+    Error = Class.new(StandardError)
+    NotFound = Class.new(Error)
+    NotConfigured = Class.new(Error)
+
+    def initialize(
+      endpoint: ENV["AZURE_AI_SEARCH_ENDPOINT"],
+      api_key: ENV["AZURE_AI_SEARCH_API_KEY"],
+      api_version: ENV.fetch("AZURE_AI_SEARCH_API_VERSION", DEFAULT_API_VERSION)
+    )
+      @endpoint = endpoint&.delete_suffix("/")
+      @api_key = api_key
+      @api_version = api_version
+    end
+
+    def search(index_name:, body:)
+      post(path: "/indexes('#{index_name}')/docs/search.post.search", body:)
+    end
+
+    def index_documents(index_name:, documents:)
+      post(path: "/indexes('#{index_name}')/docs/search.index", body: { value: documents })
+    end
+
+    def document_count(index_name:)
+      get(path: "/indexes('#{index_name}')/docs/$count")
+    end
+
+    def create_index(body:)
+      post(path: "/indexes", body:)
+    end
+
+    def index_exists?(index_name:)
+      get(path: "/indexes('#{index_name}')")
+      true
+    rescue NotFound
+      false
+    end
+
+  private
+
+    attr_reader :endpoint, :api_key, :api_version
+
+    def get(path:)
+      request(path:, request_class: Net::HTTP::Get)
+    end
+
+    def post(path:, body:)
+      request(path:, request_class: Net::HTTP::Post, body:)
+    end
+
+    def request(path:, request_class:, body: nil)
+      ensure_configured!
+
+      uri = URI("#{endpoint}#{path}?api-version=#{api_version}")
+      request = request_class.new(uri)
+      request["Content-Type"] = "application/json"
+      request["api-key"] = api_key
+      request.body = JSON.generate(body) if body
+
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+        http.request(request)
+      end
+
+      parsed_response = response.body.present? ? JSON.parse(response.body) : {}
+      return parsed_response if response.is_a?(Net::HTTPSuccess) || response.code == "207"
+
+      raise NotFound, "Azure AI Search resource was not found: #{parsed_response}" if response.code == "404"
+
+      raise Error, "Azure AI Search request failed with #{response.code}: #{parsed_response}"
+    end
+
+    def ensure_configured!
+      raise NotConfigured, "AZURE_AI_SEARCH_ENDPOINT is not configured" if endpoint.blank?
+      raise NotConfigured, "AZURE_AI_SEARCH_API_KEY is not configured" if api_key.blank?
+    end
+  end
+end

--- a/app/services/azure_ai_search/client.rb
+++ b/app/services/azure_ai_search/client.rb
@@ -36,6 +36,10 @@ module AzureAiSearch
       post(path: "/indexes", body:)
     end
 
+    def delete_index(index_name:)
+      delete(path: "/indexes('#{index_name}')")
+    end
+
     def index_exists?(index_name:)
       get(path: "/indexes('#{index_name}')")
       true
@@ -49,6 +53,10 @@ module AzureAiSearch
 
     def get(path:)
       request(path:, request_class: Net::HTTP::Get)
+    end
+
+    def delete(path:)
+      request(path:, request_class: Net::HTTP::Delete)
     end
 
     def post(path:, body:)

--- a/app/services/azure_ai_search/solution_document.rb
+++ b/app/services/azure_ai_search/solution_document.rb
@@ -1,0 +1,41 @@
+module AzureAiSearch
+  class SolutionDocument
+    def self.from_solution(solution, action: "mergeOrUpload")
+      {
+        "@search.action": action,
+        id: string_value(solution.id),
+        title: string_value(solution.title),
+        description: string_value(solution.description),
+        summary: string_value(solution.summary),
+        slug: string_value(solution.slug),
+        provider_reference: string_value(solution.provider_reference),
+        primary_category: primary_category(solution.primary_category),
+      }.compact
+    end
+
+    def self.delete(id)
+      {
+        "@search.action": "delete",
+        id:,
+      }
+    end
+
+    def self.primary_category(category)
+      return nil unless category
+
+      {
+        id: string_value(category.id),
+        title: string_value(category.title),
+        slug: string_value(category.slug),
+      }
+    end
+    private_class_method :primary_category
+
+    def self.string_value(value)
+      return nil if value.nil? || value == false || value == true
+
+      value.to_s
+    end
+    private_class_method :string_value
+  end
+end

--- a/app/services/azure_ai_search/solution_index_schema.rb
+++ b/app/services/azure_ai_search/solution_index_schema.rb
@@ -1,0 +1,56 @@
+module AzureAiSearch
+  class SolutionIndexSchema
+    INDEX = ENV.fetch("AZURE_AI_SEARCH_INDEX_NAME", "solution-data")
+    SEMANTIC_CONFIGURATION = ENV.fetch("AZURE_AI_SEARCH_SEMANTIC_CONFIGURATION", "solution-semantic-config")
+
+    def self.to_h
+      {
+        name: INDEX,
+        fields: fields,
+        semantic: semantic_configuration,
+      }
+    end
+
+    def self.fields
+      [
+        { name: "id", type: "Edm.String", key: true, searchable: false, filterable: true, retrievable: true },
+        { name: "title", type: "Edm.String", searchable: true, filterable: true, sortable: true, retrievable: true },
+        { name: "description", type: "Edm.String", searchable: true, retrievable: true },
+        { name: "summary", type: "Edm.String", searchable: true, retrievable: true },
+        { name: "slug", type: "Edm.String", searchable: false, filterable: true, retrievable: true },
+        { name: "provider_reference", type: "Edm.String", searchable: true, filterable: true, retrievable: true },
+        {
+          name: "primary_category",
+          type: "Edm.ComplexType",
+          fields: [
+            { name: "id", type: "Edm.String", searchable: false, filterable: true, retrievable: true },
+            { name: "title", type: "Edm.String", searchable: true, filterable: true, retrievable: true },
+            { name: "slug", type: "Edm.String", searchable: false, filterable: true, retrievable: true },
+          ],
+        },
+      ]
+    end
+    private_class_method :fields
+
+    def self.semantic_configuration
+      {
+        configurations: [
+          {
+            name: SEMANTIC_CONFIGURATION,
+            prioritizedFields: {
+              titleField: { fieldName: "title" },
+              prioritizedContentFields: [
+                { fieldName: "description" },
+                { fieldName: "summary" },
+              ],
+              prioritizedKeywordsFields: [
+                { fieldName: "provider_reference" },
+              ],
+            },
+          },
+        ],
+      }
+    end
+    private_class_method :semantic_configuration
+  end
+end

--- a/app/services/azure_ai_search/solution_index_schema.rb
+++ b/app/services/azure_ai_search/solution_index_schema.rb
@@ -2,6 +2,7 @@ module AzureAiSearch
   class SolutionIndexSchema
     INDEX = ENV.fetch("AZURE_AI_SEARCH_INDEX_NAME", "solution-data")
     SEMANTIC_CONFIGURATION = ENV.fetch("AZURE_AI_SEARCH_SEMANTIC_CONFIGURATION", "solution-semantic-config")
+    ENGLISH_ANALYZER = "en.microsoft"
 
     def self.to_h
       {
@@ -14,9 +15,9 @@ module AzureAiSearch
     def self.fields
       [
         { name: "id", type: "Edm.String", key: true, searchable: false, filterable: true, retrievable: true },
-        { name: "title", type: "Edm.String", searchable: true, filterable: true, sortable: true, retrievable: true },
-        { name: "description", type: "Edm.String", searchable: true, retrievable: true },
-        { name: "summary", type: "Edm.String", searchable: true, retrievable: true },
+        { name: "title", type: "Edm.String", searchable: true, filterable: true, sortable: true, retrievable: true, analyzer: ENGLISH_ANALYZER },
+        { name: "description", type: "Edm.String", searchable: true, retrievable: true, analyzer: ENGLISH_ANALYZER },
+        { name: "summary", type: "Edm.String", searchable: true, retrievable: true, analyzer: ENGLISH_ANALYZER },
         { name: "slug", type: "Edm.String", searchable: false, filterable: true, retrievable: true },
         { name: "provider_reference", type: "Edm.String", searchable: true, filterable: true, retrievable: true },
         {
@@ -24,7 +25,7 @@ module AzureAiSearch
           type: "Edm.ComplexType",
           fields: [
             { name: "id", type: "Edm.String", searchable: false, filterable: true, retrievable: true },
-            { name: "title", type: "Edm.String", searchable: true, filterable: true, retrievable: true },
+            { name: "title", type: "Edm.String", searchable: true, filterable: true, retrievable: true, analyzer: ENGLISH_ANALYZER },
             { name: "slug", type: "Edm.String", searchable: false, filterable: true, retrievable: true },
           ],
         },

--- a/app/services/azure_ai_search/solution_indexer.rb
+++ b/app/services/azure_ai_search/solution_indexer.rb
@@ -1,0 +1,52 @@
+module AzureAiSearch
+  class SolutionIndexer
+    INDEX = ENV.fetch("AZURE_AI_SEARCH_INDEX_NAME", "solution-data")
+    BATCH_SIZE = 100
+
+    def initialize(client: Client.new)
+      @client = client
+    end
+
+    def index_all(solutions = Solution.all)
+      responses = solutions.each_slice(BATCH_SIZE).map do |batch|
+        documents = batch.filter_map do |solution|
+          SolutionDocument.from_solution(solution) if solution.presentable?
+        end
+        next if documents.empty?
+
+        client.index_documents(index_name: INDEX, documents:)
+      end
+
+      responses.compact
+    end
+
+    def index_document(id)
+      solution = Solution.find_by_id!(id)
+      return false unless solution&.presentable?
+
+      response = client.index_documents(
+        index_name: INDEX,
+        documents: [SolutionDocument.from_solution(solution)],
+      )
+
+      successful_response?(response)
+    end
+
+    def delete_document(id)
+      response = client.index_documents(
+        index_name: INDEX,
+        documents: [SolutionDocument.delete(id)],
+      )
+
+      successful_response?(response)
+    end
+
+  private
+
+    attr_reader :client
+
+    def successful_response?(response)
+      Array(response["value"]).all? { |result| result["status"] == true }
+    end
+  end
+end

--- a/app/services/azure_ai_search/solution_searcher.rb
+++ b/app/services/azure_ai_search/solution_searcher.rb
@@ -1,0 +1,51 @@
+module AzureAiSearch
+  class SolutionSearcher
+    INDEX = ENV.fetch("AZURE_AI_SEARCH_INDEX_NAME", "solution-data")
+    SEMANTIC_CONFIGURATION = ENV.fetch("AZURE_AI_SEARCH_SEMANTIC_CONFIGURATION", "solution-semantic-config")
+
+    def initialize(query:, client: Client.new)
+      @query = query
+      @client = client
+    end
+
+    def search
+      response = client.search(index_name: INDEX, body: search_body)
+      Array(response["value"]).filter_map do |result|
+        Solution.rehydrate_from_search(result.except(*metadata_keys))
+      end.select(&:presentable?)
+    end
+
+  private
+
+    attr_reader :query, :client
+
+    def search_body
+      {
+        search: query,
+        queryType: query_type,
+        semanticConfiguration: semantic_search? ? SEMANTIC_CONFIGURATION : nil,
+        semanticErrorHandling: semantic_search? ? "partial" : nil,
+        captions: semantic_search? ? "extractive|highlight-true" : nil,
+        top: ENV.fetch("AZURE_AI_SEARCH_TOP", "10").to_i,
+        select: "id,title,description,summary,slug,provider_reference,primary_category",
+      }.compact
+    end
+
+    def query_type
+      ENV.fetch("AZURE_AI_SEARCH_QUERY_TYPE", "simple")
+    end
+
+    def semantic_search?
+      query_type == "semantic"
+    end
+
+    def metadata_keys
+      @metadata_keys ||= %w[
+        @search.score
+        @search.rerankerScore
+        @search.captions
+        @search.highlights
+      ]
+    end
+  end
+end

--- a/app/views/search/_comparison_results.html.erb
+++ b/app/views/search/_comparison_results.html.erb
@@ -1,0 +1,30 @@
+<div class="search-results-comparison govuk-!-margin-top-8">
+  <h2 class="govuk-heading-m">Search comparison</h2>
+  <p class="govuk-body">
+    Side-by-side comparison of OpenSearch and Azure AI Search results for this query.
+  </p>
+
+  <div class="search-results-comparison__grid">
+    <section class="search-results-comparison__column">
+      <h3 class="govuk-heading-s">OpenSearch</h3>
+      <% if @comparison_errors&.key?("OpenSearch") %>
+        <p class="govuk-body govuk-!-font-weight-bold">OpenSearch comparison failed.</p>
+        <p class="govuk-body-s"><%= @comparison_errors["OpenSearch"] %></p>
+      <% else %>
+        <p class="govuk-body-s"><%= t("results.count", count: @opensearch_solutions.count) %></p>
+        <%= render "search/solution_results", solutions: @opensearch_solutions %>
+      <% end %>
+    </section>
+
+    <section class="search-results-comparison__column">
+      <h3 class="govuk-heading-s">Azure AI Search</h3>
+      <% if @comparison_errors&.key?("Azure AI Search") %>
+        <p class="govuk-body govuk-!-font-weight-bold">Azure AI Search comparison failed.</p>
+        <p class="govuk-body-s"><%= @comparison_errors["Azure AI Search"] %></p>
+      <% else %>
+        <p class="govuk-body-s"><%= t("results.count", count: @azure_solutions.count) %></p>
+        <%= render "search/solution_results", solutions: @azure_solutions %>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/search/_full_width_search_box.html.erb
+++ b/app/views/search/_full_width_search_box.html.erb
@@ -20,3 +20,31 @@
     </div>
   </form>
 </div>
+
+<div class="search-comparison-container">
+  <form class="search-form" action="/search" method="get" role="search">
+    <input type="hidden" name="compare_search" value="true">
+    <div class="search-comparison-container__label">
+      <label class="govuk-label govuk-label--s" for="search-comparison">
+        Compare OpenSearch and Azure AI Search
+      </label>
+    </div>
+    <div class="search-input-container">
+      <input
+        class="govuk-input search-input govuk-body"
+        id="search-comparison"
+        name="query"
+        type="search"
+        value="<%= params[:query] %>"
+        placeholder="Search buying options"
+        autocomplete="off"
+      >
+      <button class="dfe-search__submit search-button" type="submit">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+          <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"/>
+        </svg>
+        <span class="govuk-visually-hidden">Compare search engines</span>
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/views/search/_solution_results.html.erb
+++ b/app/views/search/_solution_results.html.erb
@@ -1,0 +1,20 @@
+<% if solutions.any? %>
+  <div class="gem-c-cards__list gem-c-cards__list--one-column">
+    <ul class="govuk-list">
+      <% solutions.each do |solution| %>
+        <li class="gem-c-cards__list-item">
+          <div class="gem-c-cards__list-item-wrapper">
+            <h3 class="gem-c-cards__sub-heading govuk-heading-s">
+              <%= govuk_link_to solution.title, category_solution_path(slug: solution.slug, category_slug: solution.primary_category&.slug) %>
+            </h3>
+            <p class="govuk-body gem-c-cards__description">
+              <%= solution.description %>
+            </p>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% else %>
+  <p class="govuk-body">No buying options found.</p>
+<% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -34,22 +34,7 @@
           <h2 class="govuk-heading-m">
             <%= t("results.section.title.type.solution") %>
           </h2>
-          <div class="gem-c-cards__list gem-c-cards__list--one-column">
-            <ul class="govuk-list">
-              <% @solutions.each do |solution| %>
-                <li class="gem-c-cards__list-item">
-                  <div class="gem-c-cards__list-item-wrapper">
-                    <h3 class="gem-c-cards__sub-heading govuk-heading-s">
-                        <%= govuk_link_to solution.title, category_solution_path(slug: solution.slug, category_slug: solution.primary_category&.slug) %>
-                    </h3>
-                    <p class="govuk-body gem-c-cards__description">
-                      <%= solution.description %>
-                    </p>
-                  </div>
-                </li>
-              <% end %>
-            </ul>
-          </div>
+          <%= render "search/solution_results", solutions: @solutions %>
         </div>
       <% end %>
 
@@ -78,5 +63,7 @@
           </div>
         </div>
       <% end %>
+
+      <%= render "search/comparison_results" if @search_comparison_enabled %>
     </main>
   </div>

--- a/lib/tasks/azure_search.rake
+++ b/lib/tasks/azure_search.rake
@@ -1,0 +1,70 @@
+namespace :azure_search do
+  desc "Creates the Azure AI Search solution index"
+  task create_index: :environment do
+    index_name = AzureAiSearch::SolutionIndexSchema::INDEX
+    client = AzureAiSearch::Client.new
+
+    if client.index_exists?(index_name:)
+      puts "Azure AI Search index #{index_name} already exists."
+      next
+    end
+
+    puts "Creating Azure AI Search index #{index_name}..."
+    client.create_index(body: AzureAiSearch::SolutionIndexSchema.to_h)
+    puts "Created Azure AI Search index #{index_name}."
+  end
+
+  desc "Syncs Contentful solutions to Azure AI Search"
+  task index: :environment do
+    puts "Starting Contentful to Azure AI Search sync..."
+
+    index_name = AzureAiSearch::SolutionIndexer::INDEX
+    solutions = Solution.all
+    client = AzureAiSearch::Client.new
+    responses = AzureAiSearch::SolutionIndexer.new(client:).index_all(solutions)
+    indexed_count = responses.sum { |response| Array(response["value"]).count { |result| result["status"] == true } }
+
+    puts "Successfully indexed #{indexed_count} of #{solutions.size} solutions into Azure AI Search."
+    puts "Azure AI Search document count for #{index_name}: #{client.document_count(index_name:)}"
+  end
+
+  desc "Counts documents in the Azure AI Search solution index"
+  task count: :environment do
+    index_name = AzureAiSearch::SolutionIndexer::INDEX
+
+    puts "Azure AI Search document count for #{index_name}: #{AzureAiSearch::Client.new.document_count(index_name:)}"
+  end
+
+  desc "Deletes all documents from the Azure AI Search solution index"
+  task clear: :environment do
+    index_name = AzureAiSearch::SolutionIndexer::INDEX
+    client = AzureAiSearch::Client.new
+
+    puts "Clearing Azure AI Search index #{index_name}..."
+
+    document_ids = client.search(
+      index_name:,
+      body: {
+        search: "*",
+        select: "id",
+        top: 1000,
+      },
+    )["value"].map { |document| document["id"] }
+
+    if document_ids.empty?
+      puts "Azure AI Search index #{index_name} is already empty."
+      next
+    end
+
+    responses = document_ids.each_slice(AzureAiSearch::SolutionIndexer::BATCH_SIZE).map do |ids|
+      client.index_documents(
+        index_name:,
+        documents: ids.map { |id| AzureAiSearch::SolutionDocument.delete(id) },
+      )
+    end
+    deleted_count = responses.sum { |response| Array(response["value"]).count { |result| result["status"] == true } }
+
+    puts "Deleted #{deleted_count} documents from Azure AI Search index #{index_name}."
+    puts "Azure AI Search document count for #{index_name}: #{client.document_count(index_name:)}"
+  end
+end

--- a/lib/tasks/azure_search.rake
+++ b/lib/tasks/azure_search.rake
@@ -14,6 +14,21 @@ namespace :azure_search do
     puts "Created Azure AI Search index #{index_name}."
   end
 
+  desc "Deletes the Azure AI Search solution index"
+  task delete_index: :environment do
+    index_name = AzureAiSearch::SolutionIndexSchema::INDEX
+    client = AzureAiSearch::Client.new
+
+    unless client.index_exists?(index_name:)
+      puts "Azure AI Search index #{index_name} does not exist."
+      next
+    end
+
+    puts "Deleting Azure AI Search index #{index_name}..."
+    client.delete_index(index_name:)
+    puts "Deleted Azure AI Search index #{index_name}."
+  end
+
   desc "Syncs Contentful solutions to Azure AI Search"
   task index: :environment do
     puts "Starting Contentful to Azure AI Search sync..."

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -37,6 +37,28 @@ namespace :search do
     SearchClient.instance.bulk(body: bulk_actions)
     puts "Successfully indexed #{entries.size} entries into search index."
   end
+
+  desc "Deletes all documents from the search index"
+  task clear: :environment do
+    index_name = "solution-data"
+
+    unless SearchClient.instance.indices.exists?(index: index_name)
+      puts "Search index #{index_name} does not exist."
+      next
+    end
+
+    puts "Clearing search index #{index_name}..."
+    response = SearchClient.instance.delete_by_query(
+      index: index_name,
+      body: {
+        query: {
+          match_all: {},
+        },
+      },
+      refresh: true,
+    )
+    puts "Deleted #{response.fetch('deleted', 0)} documents from search index #{index_name}."
+  end
 end
 
 # Create the index and its mapping

--- a/spec/lib/tasks/azure_search_spec.rb
+++ b/spec/lib/tasks/azure_search_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+
+RSpec.describe "Azure search tasks" do
+  before do
+    Rake.application.rake_require("tasks/azure_search")
+    Rake::Task.define_task(:environment)
+  end
+
+  after do
+    Rake::Task["azure_search:create_index"].reenable
+    Rake::Task["azure_search:index"].reenable
+    Rake::Task["azure_search:count"].reenable
+    Rake::Task["azure_search:clear"].reenable
+  end
+
+  describe "azure_search:create_index" do
+    subject(:invoke_task) { Rake::Task["azure_search:create_index"].invoke }
+
+    let(:client) { instance_double(AzureAiSearch::Client) }
+
+    before do
+      allow(AzureAiSearch::Client).to receive(:new).and_return(client)
+    end
+
+    context "when the index does not exist" do
+      before do
+        allow(client).to receive(:index_exists?).with(index_name: "solution-data").and_return(false)
+        allow(client).to receive(:create_index)
+      end
+
+      it "creates the solution index" do
+        expect(client).to receive(:create_index).with(body: AzureAiSearch::SolutionIndexSchema.to_h)
+
+        expect { invoke_task }
+          .to output("Creating Azure AI Search index solution-data...\nCreated Azure AI Search index solution-data.\n")
+          .to_stdout
+      end
+    end
+
+    context "when the index already exists" do
+      before do
+        allow(client).to receive(:index_exists?).with(index_name: "solution-data").and_return(true)
+      end
+
+      it "does not recreate the index" do
+        expect(client).not_to receive(:create_index)
+
+        expect { invoke_task }
+          .to output("Azure AI Search index solution-data already exists.\n")
+          .to_stdout
+      end
+    end
+  end
+
+  describe "azure_search:index" do
+    subject(:invoke_task) { Rake::Task["azure_search:index"].invoke }
+
+    let(:client) { instance_double(AzureAiSearch::Client) }
+    let(:indexer) { instance_double(AzureAiSearch::SolutionIndexer) }
+
+    before do
+      allow(AzureAiSearch::Client).to receive(:new).and_return(client)
+      allow(AzureAiSearch::SolutionIndexer).to receive(:new).with(client:).and_return(indexer)
+      allow(Solution).to receive(:all).and_return(%w[solution-1 solution-2])
+      allow(indexer).to receive(:index_all).with(%w[solution-1 solution-2]).and_return(
+        [{ "value" => [{ "status" => true }, { "status" => false }] }],
+      )
+      allow(client).to receive(:document_count).with(index_name: "solution-data").and_return(1)
+    end
+
+    it "indexes solutions and prints the API document count" do
+      expect { invoke_task }
+        .to output(
+          "Starting Contentful to Azure AI Search sync...\n" \
+          "Successfully indexed 1 of 2 solutions into Azure AI Search.\n" \
+          "Azure AI Search document count for solution-data: 1\n",
+        )
+        .to_stdout
+    end
+  end
+
+  describe "azure_search:count" do
+    subject(:invoke_task) { Rake::Task["azure_search:count"].invoke }
+
+    let(:client) { instance_double(AzureAiSearch::Client) }
+
+    before do
+      allow(AzureAiSearch::Client).to receive(:new).and_return(client)
+      allow(client).to receive(:document_count).with(index_name: "solution-data").and_return(64)
+    end
+
+    it "prints the API document count" do
+      expect { invoke_task }
+        .to output("Azure AI Search document count for solution-data: 64\n")
+        .to_stdout
+    end
+  end
+
+  describe "azure_search:clear" do
+    subject(:invoke_task) { Rake::Task["azure_search:clear"].invoke }
+
+    let(:client) { instance_double(AzureAiSearch::Client) }
+
+    before do
+      allow(AzureAiSearch::Client).to receive(:new).and_return(client)
+      allow(client).to receive(:document_count).with(index_name: "solution-data").and_return(0)
+    end
+
+    context "when the index has documents" do
+      before do
+        allow(client).to receive(:search).with(
+          index_name: "solution-data",
+          body: {
+            search: "*",
+            select: "id",
+            top: 1000,
+          },
+        ).and_return("value" => [{ "id" => "solution-1" }, { "id" => "solution-2" }])
+        allow(client).to receive(:index_documents).and_return(
+          "value" => [{ "status" => true }, { "status" => true }],
+        )
+      end
+
+      it "deletes documents from the index" do
+        expect(client).to receive(:index_documents).with(
+          index_name: "solution-data",
+          documents: [
+            { "@search.action": "delete", id: "solution-1" },
+            { "@search.action": "delete", id: "solution-2" },
+          ],
+        )
+
+        expect { invoke_task }
+          .to output(
+            "Clearing Azure AI Search index solution-data...\n" \
+            "Deleted 2 documents from Azure AI Search index solution-data.\n" \
+            "Azure AI Search document count for solution-data: 0\n",
+          )
+          .to_stdout
+      end
+    end
+
+    context "when the index is already empty" do
+      before do
+        allow(client).to receive(:search).and_return("value" => [])
+      end
+
+      it "does not send delete actions" do
+        expect(client).not_to receive(:index_documents)
+
+        expect { invoke_task }
+          .to output(
+            "Clearing Azure AI Search index solution-data...\n" \
+            "Azure AI Search index solution-data is already empty.\n",
+          )
+          .to_stdout
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/azure_search_spec.rb
+++ b/spec/lib/tasks/azure_search_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Azure search tasks" do
 
   after do
     Rake::Task["azure_search:create_index"].reenable
+    Rake::Task["azure_search:delete_index"].reenable
     Rake::Task["azure_search:index"].reenable
     Rake::Task["azure_search:count"].reenable
     Rake::Task["azure_search:clear"].reenable
@@ -47,6 +48,45 @@ RSpec.describe "Azure search tasks" do
 
         expect { invoke_task }
           .to output("Azure AI Search index solution-data already exists.\n")
+          .to_stdout
+      end
+    end
+  end
+
+  describe "azure_search:delete_index" do
+    subject(:invoke_task) { Rake::Task["azure_search:delete_index"].invoke }
+
+    let(:client) { instance_double(AzureAiSearch::Client) }
+
+    before do
+      allow(AzureAiSearch::Client).to receive(:new).and_return(client)
+    end
+
+    context "when the index exists" do
+      before do
+        allow(client).to receive(:index_exists?).with(index_name: "solution-data").and_return(true)
+        allow(client).to receive(:delete_index)
+      end
+
+      it "deletes the index" do
+        expect(client).to receive(:delete_index).with(index_name: "solution-data")
+
+        expect { invoke_task }
+          .to output("Deleting Azure AI Search index solution-data...\nDeleted Azure AI Search index solution-data.\n")
+          .to_stdout
+      end
+    end
+
+    context "when the index does not exist" do
+      before do
+        allow(client).to receive(:index_exists?).with(index_name: "solution-data").and_return(false)
+      end
+
+      it "does not attempt to delete the index" do
+        expect(client).not_to receive(:delete_index)
+
+        expect { invoke_task }
+          .to output("Azure AI Search index solution-data does not exist.\n")
           .to_stdout
       end
     end

--- a/spec/lib/tasks/search_spec.rb
+++ b/spec/lib/tasks/search_spec.rb
@@ -4,10 +4,15 @@ RSpec.describe "Search tasks" do
     Rake::Task.define_task(:environment)
   end
 
+  after do
+    Rake::Task["search:index"].reenable
+    Rake::Task["search:clear"].reenable
+  end
+
   describe "search:index" do
     subject(:invoke_task) { Rake::Task["search:index"].invoke }
 
-    let(:search_client) { double("search client", indices:) }
+    let(:search_client) { instance_double(SearchClient, indices:) }
     let(:indices) { double("indices") }
     let(:category) { instance_double(FABS::Category, id: "category-id", title: "ICT", slug: "ict") }
     let(:solution_with_category) do
@@ -114,6 +119,57 @@ RSpec.describe "Search tasks" do
         expect(indices).not_to receive(:create)
 
         invoke_task
+      end
+    end
+  end
+
+  describe "search:clear" do
+    subject(:invoke_task) { Rake::Task["search:clear"].invoke }
+
+    let(:search_client) { instance_double(SearchClient, indices:) }
+    let(:indices) { double("indices") }
+
+    before do
+      allow(SearchClient).to receive(:instance).and_return(search_client)
+    end
+
+    context "when the search index exists" do
+      before do
+        allow(indices).to receive(:exists?).with(index: "solution-data").and_return(true)
+        allow(search_client).to receive(:delete_by_query).and_return("deleted" => 64)
+      end
+
+      it "deletes all documents from the search index" do
+        expect(search_client).to receive(:delete_by_query).with(
+          index: "solution-data",
+          body: {
+            query: {
+              match_all: {},
+            },
+          },
+          refresh: true,
+        )
+
+        expect { invoke_task }
+          .to output(
+            "Clearing search index solution-data...\n" \
+            "Deleted 64 documents from search index solution-data.\n",
+          )
+          .to_stdout
+      end
+    end
+
+    context "when the search index does not exist" do
+      before do
+        allow(indices).to receive(:exists?).with(index: "solution-data").and_return(false)
+      end
+
+      it "does not attempt to delete documents" do
+        expect(search_client).not_to receive(:delete_by_query)
+
+        expect { invoke_task }
+          .to output("Search index solution-data does not exist.\n")
+          .to_stdout
       end
     end
   end

--- a/spec/requests/fabs/search_spec.rb
+++ b/spec/requests/fabs/search_spec.rb
@@ -33,6 +33,34 @@ RSpec.describe "FABS search", type: :request do
     expect(response.body).to include("Catering")
   end
 
+  it "renders side-by-side comparison results when requested" do
+    opensearch_solution = instance_double(
+      Solution,
+      title: "OpenSearch result",
+      description: "OpenSearch description",
+      slug: "opensearch-result",
+      primary_category: category,
+    )
+    azure_solution = instance_double(
+      Solution,
+      title: "Azure result",
+      description: "Azure description",
+      slug: "azure-result",
+      primary_category: category,
+    )
+
+    allow(Solution).to receive(:search).with(query: "catering").and_return([solution])
+    allow(FABS::Category).to receive(:search).with(query: "catering").and_return([])
+    allow(SolutionSearcher).to receive(:new).with(query: "catering").and_return(instance_double(SolutionSearcher, search: [opensearch_solution]))
+    allow(AzureAiSearch::SolutionSearcher).to receive(:new).with(query: "catering").and_return(instance_double(AzureAiSearch::SolutionSearcher, search: [azure_solution]))
+
+    get search_path(query: "catering", compare_search: "true")
+
+    expect(response.body).to include("Search comparison")
+    expect(response.body).to include("OpenSearch result")
+    expect(response.body).to include("Azure result")
+  end
+
   it "escapes HTML in the page title" do
     allow(Solution).to receive(:search).with(query: "<b>catering</b>").and_return([])
     allow(FABS::Category).to receive(:search).with(query: "<b>catering</b>").and_return([])

--- a/spec/services/azure_ai_search/client_spec.rb
+++ b/spec/services/azure_ai_search/client_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe AzureAiSearch::Client do
     end
   end
 
+  describe "#delete_index" do
+    it "deletes the index from Azure AI Search" do
+      request = stub_request(:delete, "https://devghbs-search.search.windows.net/indexes('solution-data')?api-version=2024-07-01")
+        .with(headers: { "api-key" => "primary-key", "Content-Type" => "application/json" })
+        .to_return(status: 204, body: "")
+
+      expect(client.delete_index(index_name: "solution-data")).to eq({})
+      expect(request).to have_been_requested
+    end
+  end
+
   describe "#document_count" do
     it "returns the document count from Azure AI Search" do
       stub_request(:get, "https://devghbs-search.search.windows.net/indexes('solution-data')/docs/$count?api-version=2024-07-01")

--- a/spec/services/azure_ai_search/client_spec.rb
+++ b/spec/services/azure_ai_search/client_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe AzureAiSearch::Client do
+  subject(:client) do
+    described_class.new(
+      endpoint: "https://devghbs-search.search.windows.net",
+      api_key: "primary-key",
+    )
+  end
+
+  describe "#create_index" do
+    it "posts the index schema to Azure AI Search" do
+      request = stub_request(:post, "https://devghbs-search.search.windows.net/indexes?api-version=2024-07-01")
+        .with(
+          body: { name: "solution-data" }.to_json,
+          headers: { "api-key" => "primary-key", "Content-Type" => "application/json" },
+        )
+        .to_return(status: 201, body: { name: "solution-data" }.to_json)
+
+      expect(client.create_index(body: { name: "solution-data" })).to eq("name" => "solution-data")
+      expect(request).to have_been_requested
+    end
+  end
+
+  describe "#index_exists?" do
+    it "returns true when Azure AI Search returns the index" do
+      stub_request(:get, "https://devghbs-search.search.windows.net/indexes('solution-data')?api-version=2024-07-01")
+        .to_return(status: 200, body: { name: "solution-data" }.to_json)
+
+      expect(client.index_exists?(index_name: "solution-data")).to be true
+    end
+
+    it "returns false when Azure AI Search returns a 404" do
+      stub_request(:get, "https://devghbs-search.search.windows.net/indexes('solution-data')?api-version=2024-07-01")
+        .to_return(status: 404, body: { error: { message: "Not found" } }.to_json)
+
+      expect(client.index_exists?(index_name: "solution-data")).to be false
+    end
+  end
+
+  describe "#document_count" do
+    it "returns the document count from Azure AI Search" do
+      stub_request(:get, "https://devghbs-search.search.windows.net/indexes('solution-data')/docs/$count?api-version=2024-07-01")
+        .to_return(status: 200, body: "64")
+
+      expect(client.document_count(index_name: "solution-data")).to eq(64)
+    end
+  end
+end

--- a/spec/services/azure_ai_search/solution_index_schema_spec.rb
+++ b/spec/services/azure_ai_search/solution_index_schema_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe AzureAiSearch::SolutionIndexSchema do
+  describe ".to_h" do
+    it "builds the Azure AI Search index schema for solution documents" do
+      schema = described_class.to_h
+
+      expect(schema).to include(
+        name: "solution-data",
+        fields: include(
+          include(name: "id", type: "Edm.String", key: true),
+          include(name: "title", type: "Edm.String", searchable: true),
+          include(name: "provider_reference", type: "Edm.String", searchable: true),
+          include(name: "primary_category", type: "Edm.ComplexType"),
+        ),
+      )
+      expect(schema[:fields]).not_to include(include(name: "provider_name"))
+      expect(schema[:fields]).not_to include(include(name: "buying_option_type"))
+      expect(schema.dig(:semantic, :configurations, 0)).to include(
+        name: "solution-semantic-config",
+        prioritizedFields: include(
+          titleField: { fieldName: "title" },
+          prioritizedContentFields: include({ fieldName: "description" }, { fieldName: "summary" }),
+        ),
+      )
+    end
+  end
+end

--- a/spec/services/azure_ai_search/solution_index_schema_spec.rb
+++ b/spec/services/azure_ai_search/solution_index_schema_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AzureAiSearch::SolutionIndexSchema do
         name: "solution-data",
         fields: include(
           include(name: "id", type: "Edm.String", key: true),
-          include(name: "title", type: "Edm.String", searchable: true),
+          include(name: "title", type: "Edm.String", searchable: true, analyzer: "en.microsoft"),
           include(name: "provider_reference", type: "Edm.String", searchable: true),
           include(name: "primary_category", type: "Edm.ComplexType"),
         ),

--- a/spec/services/azure_ai_search/solution_indexer_spec.rb
+++ b/spec/services/azure_ai_search/solution_indexer_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe AzureAiSearch::SolutionIndexer do
+  subject(:indexer) { described_class.new(client:) }
+
+  let(:client) { instance_double(AzureAiSearch::Client) }
+  let(:category) { instance_double(FABS::Category, id: "cat-1", title: "Catering", slug: "catering") }
+  let(:solution) do
+    instance_double(
+      Solution,
+      id: "solution-1",
+      title: "Catering solution",
+      description: "Buy catering",
+      summary: "Catering summary",
+      slug: "catering-solution",
+      provider_reference: "ref-1",
+      primary_category: category,
+      presentable?: true,
+    )
+  end
+
+  describe "#index_all" do
+    before do
+      allow(client).to receive(:index_documents).and_return("value" => [{ "status" => true }])
+    end
+
+    it "sends presentable solutions to Azure AI Search" do
+      indexer.index_all([solution])
+
+      expect(client).to have_received(:index_documents).with(
+        index_name: "solution-data",
+        documents: [
+          hash_including(
+            "@search.action": "mergeOrUpload",
+            id: "solution-1",
+            title: "Catering solution",
+            primary_category: {
+              id: "cat-1",
+              title: "Catering",
+              slug: "catering",
+            },
+          ),
+        ],
+      )
+    end
+
+    context "when Contentful returns false for an unset text field" do
+      let(:sent_documents) { [] }
+
+      before do
+        allow(solution).to receive(:provider_reference).and_return(false)
+        allow(client).to receive(:index_documents) do |documents:, **|
+          sent_documents.concat(documents)
+          { "value" => [{ "status" => true }] }
+        end
+      end
+
+      it "omits the field instead of sending a boolean to Azure AI Search" do
+        indexer.index_all([solution])
+
+        expect(sent_documents.first).to include(
+          "@search.action": "mergeOrUpload",
+          id: "solution-1",
+        )
+        expect(sent_documents.first).not_to include(:provider_reference)
+      end
+    end
+  end
+end

--- a/spec/services/azure_ai_search/solution_searcher_spec.rb
+++ b/spec/services/azure_ai_search/solution_searcher_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe AzureAiSearch::SolutionSearcher do
+  subject(:searcher) { described_class.new(query:, client:) }
+
+  let(:query) { "laptops" }
+  let(:client) { instance_double(AzureAiSearch::Client) }
+
+  before do
+    allow(client).to receive(:search).and_return(search_response)
+  end
+
+  describe "#search" do
+    let(:search_response) do
+      {
+        "value" => [
+          {
+            "@search.score" => 1.2,
+            "id" => "presentable-solution",
+            "title" => "Laptop buying option",
+          },
+          {
+            "@search.score" => 0.8,
+            "id" => "draft-solution",
+          },
+        ],
+      }
+    end
+    let(:presentable_solution) { instance_double(Solution, presentable?: true) }
+    let(:draft_solution) { instance_double(Solution, presentable?: false) }
+
+    before do
+      allow(Solution).to receive(:rehydrate_from_search)
+        .with({ "id" => "presentable-solution", "title" => "Laptop buying option" })
+        .and_return(presentable_solution)
+      allow(Solution).to receive(:rehydrate_from_search)
+        .with({ "id" => "draft-solution" })
+        .and_return(draft_solution)
+    end
+
+    it "queries Azure AI Search and returns presentable solutions" do
+      expect(searcher.search).to eq([presentable_solution])
+      expect(client).to have_received(:search).with(
+        index_name: "solution-data",
+        body: hash_including(
+          search: "laptops",
+          queryType: "simple",
+        ),
+      )
+    end
+
+    context "when semantic search is enabled" do
+      around do |example|
+        ClimateControl.modify(AZURE_AI_SEARCH_QUERY_TYPE: "semantic") do
+          example.run
+        end
+      end
+
+      it "sends semantic search parameters" do
+        searcher.search
+
+        expect(client).to have_received(:search).with(
+          index_name: "solution-data",
+          body: hash_including(
+            queryType: "semantic",
+            semanticConfiguration: "solution-semantic-config",
+            captions: "extractive|highlight-true",
+          ),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes in this PR

- Adds a new Azure AI search service mirroring the existing ElasticSearch approach
- Adds rake tasks to create, populate and clear Azure AI search index
- Adds a temporary side by side comparison view under the existing search results page
- Requires new `ENV` vars to be populated (DM me for details)
- Azure search infrastructure currently only exists for Dev environment

**N.B.** This requires further work before turning into production code but serves to demonstrate the Azure search capability.