### PR TITLE
Drastic speed improvement for energy spreadsheet generation specs

### DIFF
--- a/spec/features/frameworks/register/agent_can_categorise_framework_spec.rb
+++ b/spec/features/frameworks/register/agent_can_categorise_framework_spec.rb
@@ -14,7 +14,8 @@ describe "Agent can categorise framework" do
     click_on "Save changes"
 
     within ".govuk-summary-card", text: "Basic Details" do
-      expect(page).to have_content("Laptops, Electricity")
+      expect(page).to have_content("Laptops")
+      expect(page).to have_content("Electricity")
     end
 
     within "#framework-activity" do

--- a/spec/services/energy/documents/site_addition_form_edf_spec.rb
+++ b/spec/services/energy/documents/site_addition_form_edf_spec.rb
@@ -51,135 +51,122 @@ RSpec.describe Energy::Documents::SiteAdditionFormEdf, type: :model do
 
     after { FileUtils.rm_f(service.output_file_xl) }
 
-    describe "creates site addition details on xl document" do
-      before do
-        energy_electricity_meter
-        service.call
-      end
+    it "creates site addition details for a single meter" do
+      energy_electricity_meter
+      service.call
 
-      it "creates new xl file" do
+      row = worksheet[starting_row]
+
+      aggregate_failures "file output" do
         expect(File.exist?(service.output_file_xl)).to be true
       end
 
-      context "with site and billing addresses" do
-        context "when single school" do
-          it "matches site details and address" do
-            expect(worksheet[starting_row][0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
-            expect(worksheet[starting_row][1].value).to eq(support_organisation.name)
+      aggregate_failures "site details and address" do
+        site_address_line2 = "#{support_organisation.address['street']}, #{support_organisation.address['locality']}"
 
-            site_address_line2 = "#{support_organisation.address['street']}, #{support_organisation.address['locality']}"
-            expect(worksheet[starting_row][2].value).to eq(site_address_line2)
-            expect(worksheet[starting_row][4].value).to eq(support_organisation.address["postcode"])
-          end
-
-          it "matches billing address" do
-            expect(worksheet[starting_row][5].value).to eq(support_organisation.name)
-
-            billing_address_line2 = "#{input_values[:billing_invoice_address][:street]}, #{input_values[:billing_invoice_address][:locality]}"
-            expect(worksheet[starting_row][6].value).to eq(billing_address_line2)
-            expect(worksheet[starting_row][7].value).to eq(input_values[:billing_invoice_address][:town])
-            expect(worksheet[starting_row][8].value).to eq(input_values[:billing_invoice_address][:postcode])
-          end
-        end
+        expect(row[0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
+        expect(row[1].value).to eq(support_organisation.name)
+        expect(row[2].value).to eq(site_address_line2)
+        expect(row[4].value).to eq(support_organisation.address["postcode"])
       end
 
-      it "matches contract dates" do
-        expect(worksheet[starting_row][9].value).to eq(electricity_end_date.strftime("%d/%m/%Y"))
-        expect(worksheet[starting_row][10].value).to eq((electricity_end_date + 1.day).strftime("%d/%m/%Y"))
+      aggregate_failures "billing address" do
+        billing_address_line2 = "#{input_values[:billing_invoice_address][:street]}, #{input_values[:billing_invoice_address][:locality]}"
+
+        expect(row[5].value).to eq(support_organisation.name)
+        expect(row[6].value).to eq(billing_address_line2)
+        expect(row[7].value).to eq(input_values[:billing_invoice_address][:town])
+        expect(row[8].value).to eq(input_values[:billing_invoice_address][:postcode])
       end
 
-      context "with bacs" do
-        it "matches payment details" do
-          expect(worksheet[starting_row][18].value).to eq("BACS")
-          expect(worksheet[starting_row][19].value).to eq("14")
-          expect(worksheet[starting_row][20].value).to eq("Standard")
-          expect(worksheet[starting_row][21].value).to eq("Yes")
-        end
+      aggregate_failures "contract dates" do
+        expect(row[9].value).to eq(electricity_end_date.strftime("%d/%m/%Y"))
+        expect(row[10].value).to eq((electricity_end_date + 1.day).strftime("%d/%m/%Y"))
       end
 
-      context "with direct debit" do
-        let(:payment_method) { :direct_debit }
-        let(:payment_term) { :days21 }
-        let(:is_bill_consolidated) { false }
-
-        it "matches payment details" do
-          expect(worksheet[starting_row][18].value).to eq("Direct Debit")
-          expect(worksheet[starting_row][19].value).to eq("21")
-          expect(worksheet[starting_row][21].value).to eq("No")
-        end
+      aggregate_failures "meter details" do
+        expect(onboarding_case_organisation.electricity_meters.count).to eq(1)
+        expect(row[11].value).to eq(electricity_meter_values[:mpan])
+        expect(row[12].value).to eq("HH")
+        expect(row[13].value).to eq(electricity_meter_values[:supply_capacity])
+        expect(row[14].value).to eq(electricity_meter_values[:electricity_usage])
+        expect(row[15].value).to eq(electricity_meter_values[:data_aggregator])
+        expect(row[16].value).to eq(electricity_meter_values[:data_collector])
+        expect(row[17].value).to eq(electricity_meter_values[:meter_operator])
       end
 
-      it "matches key business contact details" do
-        expect(worksheet[starting_row][22].value).to eq("Annette Harrison")
-        expect(worksheet[starting_row][24].value).to eq("Department for Education")
-        expect(worksheet[starting_row][27].value).to eq("SW1P 3BT")
+      aggregate_failures "payment details" do
+        expect(row[18].value).to eq("BACS")
+        expect(row[19].value).to eq("14")
+        expect(row[20].value).to eq("Standard")
+        expect(row[21].value).to eq("Yes")
+      end
+
+      aggregate_failures "key business contact details" do
+        expect(row[22].value).to eq("Annette Harrison")
+        expect(row[24].value).to eq("Department for Education")
+        expect(row[27].value).to eq("SW1P 3BT")
       end
     end
 
-    describe "single meter" do
-      before do
+    context "with direct debit" do
+      let(:payment_method) { :direct_debit }
+      let(:payment_term) { :days21 }
+      let(:is_bill_consolidated) { false }
+
+      it "matches payment details" do
         energy_electricity_meter
         service.call
-      end
 
-      context "with single meter" do
-        it "matches meter details" do
-          expect(onboarding_case_organisation.electricity_meters.count).to eq(1)
+        row = worksheet[starting_row]
 
-          expect(worksheet[starting_row][11].value).to eq(electricity_meter_values[:mpan])
-          expect(worksheet[starting_row][12].value).to eq("HH")
-          expect(worksheet[starting_row][13].value).to eq(electricity_meter_values[:supply_capacity])
-          expect(worksheet[starting_row][14].value).to eq(electricity_meter_values[:electricity_usage])
-
-          expect(worksheet[starting_row][15].value).to eq(electricity_meter_values[:data_aggregator])
-          expect(worksheet[starting_row][16].value).to eq(electricity_meter_values[:data_collector])
-          expect(worksheet[starting_row][17].value).to eq(electricity_meter_values[:meter_operator])
+        aggregate_failures "payment details" do
+          expect(row[18].value).to eq("Direct Debit")
+          expect(row[19].value).to eq("21")
+          expect(row[21].value).to eq("No")
         end
       end
     end
 
-    describe "multi meter" do
-      context "with multiple meters" do
-        let(:meter_type) { :multi }
-        let(:onboarding_case) { create(:onboarding_case, support_case:) }
-        let(:another_onboarding_case_organisation) { create(:energy_onboarding_case_organisation, onboarding_case:, onboardable: support_organisation, **input_values) }
-        let(:electicity_meter1) { create(:energy_electricity_meter, :another_meter, onboarding_case_organisation: another_onboarding_case_organisation) }
-        let(:electicity_meter2) { create(:energy_electricity_meter, :another_meter, onboarding_case_organisation: another_onboarding_case_organisation) }
+    context "with multiple meters" do
+      let(:meter_type) { :multi }
+      let(:another_onboarding_case_organisation) { create(:energy_onboarding_case_organisation, onboarding_case:, onboardable: support_organisation, **input_values) }
+      let(:electricity_meter1) { create(:energy_electricity_meter, :another_meter, onboarding_case_organisation: another_onboarding_case_organisation) }
+      let(:electricity_meter2) { create(:energy_electricity_meter, :another_meter, onboarding_case_organisation: another_onboarding_case_organisation) }
 
-        before do
-          electicity_meter1
-          electicity_meter2
-          service.call
-        end
+      it "creates site addition details for each meter" do
+        electricity_meter1
+        electricity_meter2
+        service.call
 
-        it "2 meter rows for meter details" do
+        first_row = worksheet[starting_row]
+        second_row = worksheet[starting_row + 1]
+
+        aggregate_failures "meter count" do
           expect(another_onboarding_case_organisation.electricity_meters.count).to eq(2)
         end
 
-        it "has same organisation details on each row" do
-          expect(worksheet[starting_row][0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
-          expect(worksheet[starting_row + 1][0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
+        aggregate_failures "organisation details" do
+          expect(first_row[0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
+          expect(second_row[0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
         end
 
-        it "has same site details and address on each row" do
-          expect(worksheet[starting_row][1].value).to eq(support_organisation.name)
-          expect(worksheet[starting_row + 1][1].value).to eq(support_organisation.name)
-
-          expect(worksheet[starting_row][4].value).to eq(support_organisation.address["postcode"])
-          expect(worksheet[starting_row + 1][4].value).to eq(support_organisation.address["postcode"])
+        aggregate_failures "site details and address" do
+          expect(first_row[1].value).to eq(support_organisation.name)
+          expect(second_row[1].value).to eq(support_organisation.name)
+          expect(first_row[4].value).to eq(support_organisation.address["postcode"])
+          expect(second_row[4].value).to eq(support_organisation.address["postcode"])
         end
 
-        it "has multiple rows for each meter" do
-          expect(worksheet[starting_row][11].value).to eq(electicity_meter1.mpan)
-          expect(worksheet[starting_row + 1][11].value).to eq(electicity_meter2.mpan)
+        aggregate_failures "meter details" do
+          expect(first_row[11].value).to eq(electricity_meter1.mpan)
+          expect(second_row[11].value).to eq(electricity_meter2.mpan)
           expect(worksheet[starting_row + 2][11].value).to be_nil
-
-          expect(worksheet[starting_row][13].value).to eq(electicity_meter1.supply_capacity)
-          expect(worksheet[starting_row + 1][13].value).to eq(electicity_meter2.supply_capacity)
+          expect(first_row[13].value).to eq(electricity_meter1.supply_capacity)
+          expect(second_row[13].value).to eq(electricity_meter2.supply_capacity)
           expect(worksheet[starting_row + 2][13].value).to be_nil
-
-          expect(worksheet[starting_row][14].value).to eq(electicity_meter1.electricity_usage)
-          expect(worksheet[starting_row + 1][14].value).to eq(electicity_meter2.electricity_usage)
+          expect(first_row[14].value).to eq(electricity_meter1.electricity_usage)
+          expect(second_row[14].value).to eq(electricity_meter2.electricity_usage)
           expect(worksheet[starting_row + 3][14].value).to be_nil
         end
       end

--- a/spec/services/energy/documents/site_addition_form_total_spec.rb
+++ b/spec/services/energy/documents/site_addition_form_total_spec.rb
@@ -52,179 +52,146 @@ RSpec.describe Energy::Documents::SiteAdditionFormTotal, type: :model do
 
     after { FileUtils.rm_f(service.output_file_xl) }
 
-    describe "creates site addition details on XL document" do
-      before do
-        energy_gas_meter
-        service.call
-      end
+    it "creates site addition details for a single meter" do
+      energy_gas_meter
+      service.call
 
-      it "creates new xl file" do
+      row = worksheet[starting_row]
+
+      aggregate_failures "file output" do
         expect(File.exist?(service.output_file_xl)).to be true
       end
 
-      it "matches organisation details" do
-        expect(worksheet[starting_row][0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
-        expect(worksheet[starting_row][1].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_ADDRESS_LINE1)
-        expect(worksheet[starting_row][5].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_ADDRESS_POSTCODE)
+      aggregate_failures "organisation details" do
+        expect(row[0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
+        expect(row[1].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_ADDRESS_LINE1)
+        expect(row[5].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_ADDRESS_POSTCODE)
       end
 
-      it "matches main contact details" do
-        expect(worksheet[starting_row][7].value).to eq("Annette")
-        expect(worksheet[starting_row][8].value).to eq("Harrison")
-        expect(worksheet[starting_row][13].value).to eq("S1 2JF")
-        expect(worksheet[starting_row][16].value).to include("education.gov.uk")
+      aggregate_failures "main contact details" do
+        expect(row[7].value).to eq("Annette")
+        expect(row[8].value).to eq("Harrison")
+        expect(row[13].value).to eq("S1 2JF")
+        expect(row[16].value).to include("education.gov.uk")
       end
 
-      context "when gas current supplier is Other" do
-        let(:gas_supplier) { :other }
-        let(:input_values) do
-          super().merge(gas_current_supplier_other: "Other gas supplier")
-        end
+      aggregate_failures "site and billing addresses" do
+        billing_address_line2 = "#{input_values[:billing_invoice_address][:street]}, #{input_values[:billing_invoice_address][:locality]}"
+        site_address_line2 = "#{support_organisation.address['street']}, #{support_organisation.address['locality']}"
 
-        it "matches gas supplier name" do
-          expect(worksheet[starting_row][38].value).to eq("Other gas supplier")
-        end
+        expect(row[18].value).to eq(support_organisation.name)
+        expect(row[21].value).to eq("School")
+        expect(row[22].value).to eq(input_values[:site_contact_first_name])
+        expect(row[23].value).to eq(input_values[:site_contact_last_name])
+        expect(row[25].value).to eq(input_values[:site_contact_email])
+        expect(row[27].value).to eq(support_organisation.name)
+        expect(row[28].value).to eq(billing_address_line2)
+        expect(row[29].value).to eq(input_values[:billing_invoice_address][:town])
+        expect(row[31].value).to eq(input_values[:billing_invoice_address][:postcode])
+        expect(row[33].value).to eq(support_organisation.name)
+        expect(row[34].value).to eq(site_address_line2)
+        expect(row[36].value).to eq(support_organisation.address["postcode"])
+        expect(row[37].value).to eq(support_organisation.address["town"])
       end
 
-      context "with site and billing addresses" do
-        context "when single school without trust" do
-          it "matches site and billing addresses" do
-            expect(worksheet[starting_row][18].value).to eq(support_organisation.name)
-            expect(worksheet[starting_row][21].value).to eq("School")
-            expect(worksheet[starting_row][22].value).to eq(input_values[:site_contact_first_name])
-            expect(worksheet[starting_row][23].value).to eq(input_values[:site_contact_last_name])
-            expect(worksheet[starting_row][25].value).to eq(input_values[:site_contact_email])
-            # Billing address
-            expect(worksheet[starting_row][27].value).to eq(support_organisation.name)
-            billing_address_line2 = "#{input_values[:billing_invoice_address][:street]}, #{input_values[:billing_invoice_address][:locality]}"
-
-            expect(worksheet[starting_row][28].value).to eq(billing_address_line2)
-            expect(worksheet[starting_row][29].value).to eq(input_values[:billing_invoice_address][:town])
-            expect(worksheet[starting_row][31].value).to eq(input_values[:billing_invoice_address][:postcode])
-
-            # Site address
-            expect(worksheet[starting_row][33].value).to eq(support_organisation.name)
-            site_address_line2 = "#{support_organisation.address['street']}, #{support_organisation.address['locality']}"
-            expect(worksheet[starting_row][34].value).to eq(site_address_line2)
-            expect(worksheet[starting_row][36].value).to eq(support_organisation.address["postcode"])
-            expect(worksheet[starting_row][37].value).to eq(support_organisation.address["town"])
-          end
-        end
-      end
-
-      it "matches gas supplier and details" do
-        expect(worksheet[starting_row][38].value).to eq(edf_energy)
-        expect(worksheet[starting_row][39].value).to eq(contract_end_date.strftime("%d/%m/%Y"))
-        expect(worksheet[starting_row][40].value).to eq("No")
-        expect(worksheet[starting_row][41].value).to eq("No")
-
-        expect(worksheet[starting_row][42].value).to eq(gas_meter_values[:mprn])
-        expect(worksheet[starting_row][43].value).to eq((contract_end_date + 1.day).strftime("%d/%m/%Y"))
-        expect(worksheet[starting_row][44].value).to eq(gas_meter_values[:gas_usage])
-
-        expect(worksheet[starting_row][45].value).to eq("Bacs")
-        expect(worksheet[starting_row][46].value).to eq("14")
-        expect(worksheet[starting_row][47].value).to eq(20)
-        expect(worksheet[starting_row][48].value).to eq("Single meter site")
-        expect(worksheet[starting_row][50].value).to eq("Paper")
-        expect(worksheet[starting_row][52].value).to eq("Email invoice notification with link to TGP Portal")
+      aggregate_failures "gas supplier and meter details" do
+        expect(onboarding_case_organisation.gas_meters.count).to eq(1)
+        expect(row[38].value).to eq(edf_energy)
+        expect(row[39].value).to eq(contract_end_date.strftime("%d/%m/%Y"))
+        expect(row[40].value).to eq("No")
+        expect(row[41].value).to eq("No")
+        expect(row[42].value).to eq(gas_meter_values[:mprn])
+        expect(row[43].value).to eq((contract_end_date + 1.day).strftime("%d/%m/%Y"))
+        expect(row[44].value).to eq(gas_meter_values[:gas_usage])
+        expect(row[45].value).to eq("Bacs")
+        expect(row[46].value).to eq("14")
+        expect(row[47].value).to eq(20)
+        expect(row[48].value).to eq("Single meter site")
+        expect(row[50].value).to eq("Paper")
+        expect(row[52].value).to eq("Email invoice notification with link to TGP Portal")
       end
     end
 
-    describe "single meter" do
-      before do
+    context "when gas current supplier is Other" do
+      let(:gas_supplier) { :other }
+      let(:input_values) do
+        super().merge(gas_current_supplier_other: "Other gas supplier")
+      end
+
+      it "matches gas supplier name" do
         energy_gas_meter
         service.call
-      end
 
-      it "matches meter details" do
-        expect(onboarding_case_organisation.gas_meters.count).to eq(1)
-        expect(worksheet[starting_row][42].value).to eq(gas_meter_values[:mprn])
-        expect(worksheet[starting_row][44].value).to eq(gas_meter_values[:gas_usage])
+        expect(worksheet[starting_row][38].value).to eq("Other gas supplier")
       end
     end
 
-    describe "multi meter" do
-      context "with multiple meters" do
-        let(:meter_type) { :multi }
-        let(:onboarding_case) { create(:onboarding_case, support_case:) }
-        let(:another_onboarding_case_organisation) { create(:energy_onboarding_case_organisation, onboarding_case:, onboardable: support_organisation, **input_values) }
-        let(:gas_meter1) { create(:energy_gas_meter, mprn: 123_456_789, gas_usage: 1000, onboarding_case_organisation: another_onboarding_case_organisation) }
-        let(:gas_meter2) { create(:energy_gas_meter, mprn: 223_456_789, gas_usage: 2000, onboarding_case_organisation: another_onboarding_case_organisation) }
+    context "with multiple meters" do
+      let(:meter_type) { :multi }
+      let(:another_onboarding_case_organisation) { create(:energy_onboarding_case_organisation, onboarding_case:, onboardable: support_organisation, **input_values) }
+      let(:gas_meter1) { create(:energy_gas_meter, mprn: 123_456_789, gas_usage: 1000, onboarding_case_organisation: another_onboarding_case_organisation) }
+      let(:gas_meter2) { create(:energy_gas_meter, mprn: 223_456_789, gas_usage: 2000, onboarding_case_organisation: another_onboarding_case_organisation) }
 
-        before do
-          gas_meter1
-          gas_meter2
-          service.call
-        end
+      it "creates site addition details for each meter" do
+        gas_meter1
+        gas_meter2
+        service.call
 
-        it "2 meter rows for meter details" do
+        first_row = worksheet[starting_row]
+        second_row = worksheet[starting_row + 1]
+
+        aggregate_failures "meter count" do
           expect(another_onboarding_case_organisation.gas_meters.count).to eq(2)
         end
 
-        it "has same organisation details on each row with same data" do
-          expect(worksheet[starting_row][0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
-          expect(worksheet[starting_row + 1][0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
-
-          expect(worksheet[starting_row][1].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_ADDRESS_LINE1)
-          expect(worksheet[starting_row + 1][1].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_ADDRESS_LINE1)
+        aggregate_failures "organisation details" do
+          expect(first_row[0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
+          expect(second_row[0].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_NAME)
+          expect(first_row[1].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_ADDRESS_LINE1)
+          expect(second_row[1].value).to eq(Energy::Documents::SiteAdditionForm::CUSTOMER_ADDRESS_LINE1)
         end
 
-        it "has multiple rows for main contact details with same data" do
-          expect(worksheet[starting_row][7].value).to eq("Annette")
-          expect(worksheet[starting_row + 1][7].value).to eq("Annette")
-
-          expect(worksheet[starting_row][8].value).to eq("Harrison")
-          expect(worksheet[starting_row + 1][8].value).to eq("Harrison")
-
-          expect(worksheet[starting_row][13].value).to eq("S1 2JF")
-          expect(worksheet[starting_row + 1][13].value).to eq("S1 2JF")
+        aggregate_failures "main contact details" do
+          expect(first_row[7].value).to eq("Annette")
+          expect(second_row[7].value).to eq("Annette")
+          expect(first_row[8].value).to eq("Harrison")
+          expect(second_row[8].value).to eq("Harrison")
+          expect(first_row[13].value).to eq("S1 2JF")
+          expect(second_row[13].value).to eq("S1 2JF")
         end
 
-        it "has multiple rows for site and billing addresses with same data" do
-          expect(worksheet[starting_row][18].value).to eq(support_organisation.name)
-          expect(worksheet[starting_row + 1][18].value).to eq(support_organisation.name)
-
-          expect(worksheet[starting_row][22].value).to eq(input_values[:site_contact_first_name])
-          expect(worksheet[starting_row][22].value).to eq(input_values[:site_contact_first_name])
-
-          expect(worksheet[starting_row][25].value).to eq(input_values[:site_contact_email])
-          expect(worksheet[starting_row + 1][25].value).to eq(input_values[:site_contact_email])
-
-          expect(worksheet[starting_row][27].value).to eq(support_organisation.name)
-          expect(worksheet[starting_row + 1][27].value).to eq(support_organisation.name)
-
-          expect(worksheet[starting_row][31].value).to eq(input_values[:billing_invoice_address][:postcode])
-          expect(worksheet[starting_row + 1][31].value).to eq(input_values[:billing_invoice_address][:postcode])
-
-          # Site address
-          expect(worksheet[starting_row][33].value).to eq(support_organisation.name)
-          expect(worksheet[starting_row + 1][33].value).to eq(support_organisation.name)
-
+        aggregate_failures "site and billing addresses" do
           site_address_line2 = "#{support_organisation.address['street']}, #{support_organisation.address['locality']}"
-          expect(worksheet[starting_row][34].value).to eq(site_address_line2)
-          expect(worksheet[starting_row + 1][34].value).to eq(site_address_line2)
 
-          expect(worksheet[starting_row][36].value).to eq(support_organisation.address["postcode"])
-          expect(worksheet[starting_row + 1][36].value).to eq(support_organisation.address["postcode"])
+          expect(first_row[18].value).to eq(support_organisation.name)
+          expect(second_row[18].value).to eq(support_organisation.name)
+          expect(first_row[22].value).to eq(input_values[:site_contact_first_name])
+          expect(second_row[22].value).to eq(input_values[:site_contact_first_name])
+          expect(first_row[25].value).to eq(input_values[:site_contact_email])
+          expect(second_row[25].value).to eq(input_values[:site_contact_email])
+          expect(first_row[27].value).to eq(support_organisation.name)
+          expect(second_row[27].value).to eq(support_organisation.name)
+          expect(first_row[31].value).to eq(input_values[:billing_invoice_address][:postcode])
+          expect(second_row[31].value).to eq(input_values[:billing_invoice_address][:postcode])
+          expect(first_row[33].value).to eq(support_organisation.name)
+          expect(second_row[33].value).to eq(support_organisation.name)
+          expect(first_row[34].value).to eq(site_address_line2)
+          expect(second_row[34].value).to eq(site_address_line2)
+          expect(first_row[36].value).to eq(support_organisation.address["postcode"])
+          expect(second_row[36].value).to eq(support_organisation.address["postcode"])
         end
 
-        it "has multiple rows for meter details" do
-          expect(worksheet[starting_row][38].value).to eq(edf_energy)
-          expect(worksheet[starting_row + 1][38].value).to eq(edf_energy)
-
-          expect(worksheet[starting_row][42].value).to eq(gas_meter_values[:mprn])
-          expect(worksheet[starting_row][42].value).to eq(gas_meter1.mprn)
-          expect(worksheet[starting_row + 1][42].value).to eq(gas_meter2.mprn)
-
-          expect(worksheet[starting_row][44].value).to eq(gas_meter1.gas_usage)
-          expect(worksheet[starting_row + 1][44].value).to eq(gas_meter2.gas_usage)
-
-          expect(worksheet[starting_row][45].value).to eq("Bacs")
-          expect(worksheet[starting_row + 1][45].value).to eq("Bacs")
-
-          expect(worksheet[starting_row][48].value).to eq("Multi meter site")
-          expect(worksheet[starting_row + 1][48].value).to eq("Multi meter site")
+        aggregate_failures "meter details" do
+          expect(first_row[38].value).to eq(edf_energy)
+          expect(second_row[38].value).to eq(edf_energy)
+          expect(first_row[42].value).to eq(gas_meter1.mprn)
+          expect(second_row[42].value).to eq(gas_meter2.mprn)
+          expect(first_row[44].value).to eq(gas_meter1.gas_usage)
+          expect(second_row[44].value).to eq(gas_meter2.gas_usage)
+          expect(first_row[45].value).to eq("Bacs")
+          expect(second_row[45].value).to eq("Bacs")
+          expect(first_row[48].value).to eq("Multi meter site")
+          expect(second_row[48].value).to eq("Multi meter site")
         end
       end
     end


### PR DESCRIPTION
These were both written to repeatedly seed database models, generate a spreadsheet on disk, read/parse and finally delete it for lots of individual checks on various rows of the spreadsheet. This is inefficient, adding around 5 seconds per spec. Refactored to generate the spreadsheet one for each specific case and group related row checks together using `aggregate_failures` so any failing rows are still reported nicely with semantic documentation.

This reduces the runtime for just these two specs locally from 87 seconds to 19 seconds (over a minute faster) without reducing coverage.