### PR TITLE
CORE-637 | Change the header link to always be the homepage of ghbs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
 
 protected
 
-  helper_method :current_user, :cookie_policy, :internal_portal?, :google_analytics_id, :hosted_development?, :hosted_production?, :hosted_staging?, :record_ga?, :engagement_portal?, :support_portal?, :frameworks_portal?, :cec_portal?, :current_url_b64, :header_link
+  helper_method :current_user, :cookie_policy, :internal_portal?, :google_analytics_id, :hosted_development?, :hosted_production?, :hosted_staging?, :record_ga?, :engagement_portal?, :support_portal?, :frameworks_portal?, :cec_portal?, :current_url_b64
 
   # @return [User, Guest]
   #
@@ -77,10 +77,6 @@ protected
     portal_namespace.to_s.inquiry.frameworks?
   end
 
-  def procurement_support_portal?
-    portal_namespace.to_s.inquiry.procurement_support?
-  end
-
   def cec_portal?
     portal_namespace.to_s.inquiry.cec?
   end
@@ -123,12 +119,6 @@ protected
 
   def cookie_policy
     CookiePolicy.new(cookies)
-  end
-
-  def header_link
-    return framework_requests_path if procurement_support_portal?
-
-    root_path
   end
 
   def current_url_b64(tab = nil)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
       <div class="govuk-width-container <%= container_width_class %>">
         <div class="govuk-service-navigation__container">
           <span class="govuk-service-navigation__service-name">
-            <a href="<%= header_link %>" class="govuk-service-navigation__link">
+            <a href="/" class="govuk-service-navigation__link">
               <%= I18n.t("app.name") %>
             </a>
           </span>


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Fixes the bug where on RFH the header link goes to the RFH page, now anywhere there is a header link it will just go to the home page
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
