### PR TITLE
CORE-664 | Prevent any further changes to RFH request once its been submitted

### DIFF
--- a/app/controllers/framework_requests/base_controller.rb
+++ b/app/controllers/framework_requests/base_controller.rb
@@ -45,8 +45,12 @@ module FrameworkRequests
       ], *form_params).merge(id: framework_request_id, user: current_user)
     end
 
+    def framework_request_record
+      @framework_request_record ||= FrameworkRequest.find(framework_request_id)
+    end
+
     def framework_request
-      @framework_request ||= FrameworkRequestPresenter.new(FrameworkRequest.find(framework_request_id))
+      @framework_request ||= FrameworkRequestPresenter.new(framework_request_record)
     end
 
     def framework_request_id
@@ -76,9 +80,9 @@ module FrameworkRequests
     end
 
     def redirect_if_submitted
-      return unless framework_request.submitted?
+      return unless framework_request_record.submitted?
 
-      redirect_to framework_request_submission_path(framework_request)
+      redirect_to framework_request_submission_path(framework_request_record)
     end
 
     def flow

--- a/app/controllers/framework_requests/base_controller.rb
+++ b/app/controllers/framework_requests/base_controller.rb
@@ -1,5 +1,6 @@
 module FrameworkRequests
   class BaseController < ApplicationController
+    prepend_before_action :redirect_if_submitted, except: %i[index]
     before_action :form, only: %i[index create update edit]
     before_action :back_url, except: %i[edit]
     before_action :framework_request, only: %i[edit]
@@ -72,6 +73,12 @@ module FrameworkRequests
       return sign_in_framework_requests_path(framework_support_form: @form.common, back_to: current_url_b64) if current_user.guest?
 
       confirm_sign_in_framework_requests_path
+    end
+
+    def redirect_if_submitted
+      return unless framework_request.submitted?
+
+      redirect_to framework_request_submission_path(framework_request)
     end
 
     def flow

--- a/app/controllers/framework_requests/base_controller.rb
+++ b/app/controllers/framework_requests/base_controller.rb
@@ -31,6 +31,13 @@ module FrameworkRequests
 
   private
 
+    def redirect_if_submitted
+      framework_request_record = FrameworkRequest.find(framework_request_id)
+      return unless framework_request_record.submitted?
+
+      redirect_to framework_request_submission_path(framework_request_record)
+    end
+
     def form
       @form ||= FrameworkRequests::BaseForm.new(all_form_params)
     end
@@ -45,12 +52,8 @@ module FrameworkRequests
       ], *form_params).merge(id: framework_request_id, user: current_user)
     end
 
-    def framework_request_record
-      @framework_request_record ||= FrameworkRequest.find(framework_request_id)
-    end
-
     def framework_request
-      @framework_request ||= FrameworkRequestPresenter.new(framework_request_record)
+      @framework_request ||= FrameworkRequestPresenter.new(FrameworkRequest.find(framework_request_id))
     end
 
     def framework_request_id
@@ -77,12 +80,6 @@ module FrameworkRequests
       return sign_in_framework_requests_path(framework_support_form: @form.common, back_to: current_url_b64) if current_user.guest?
 
       confirm_sign_in_framework_requests_path
-    end
-
-    def redirect_if_submitted
-      return unless framework_request_record.submitted?
-
-      redirect_to framework_request_submission_path(framework_request_record)
     end
 
     def flow

--- a/app/controllers/framework_requests/framework_request_submissions_controller.rb
+++ b/app/controllers/framework_requests/framework_request_submissions_controller.rb
@@ -11,6 +11,7 @@ class FrameworkRequests::FrameworkRequestSubmissionsController < FrameworkReques
 
       session.delete(:framework_request_id)
       session.delete(:faf_referrer)
+      session[:framework_request_email] = framework_request.email
 
       redirect_to framework_request_submission_path(framework_request)
     else
@@ -21,6 +22,7 @@ class FrameworkRequests::FrameworkRequestSubmissionsController < FrameworkReques
   def show
     if framework_request.submitted?
       @framework_request = FrameworkRequestPresenter.new(framework_request)
+      @email = session.delete(:framework_request_email)
     else
       redirect_to framework_request_path(framework_request)
     end

--- a/app/views/framework_requests/framework_request_submissions/show.html.erb
+++ b/app/views/framework_requests/framework_request_submissions/show.html.erb
@@ -7,10 +7,12 @@
         <h1 class="govuk-panel__title">
           <%= I18n.t("faf_submissions.header.confirmation") %>
         </h1>
-        <div class="govuk-panel__body">
-          <%= I18n.t("faf_submissions.sub_header.confirmation") %>
-          <br><strong><%= @framework_request.email %></strong>
-        </div>
+        <% if @email.present? %>
+          <div class="govuk-panel__body">
+            <%= I18n.t("faf_submissions.sub_header.confirmation") %>
+            <br><strong><%= @email %></strong>
+          </div>
+        <% end %>
       </div>
 
       <% if @framework_request.flow.energy? %>

--- a/spec/controllers/framework_requests/bill_uploads_controller_spec.rb
+++ b/spec/controllers/framework_requests/bill_uploads_controller_spec.rb
@@ -77,4 +77,32 @@ describe FrameworkRequests::BillUploadsController, type: :controller do
       expect(response).to redirect_to("/procurement-support/#{framework_request.id}")
     end
   end
+
+  describe "submitted request redirects" do
+    let(:framework_request) { create(:framework_request, submitted: true, category: create(:request_for_help_category, flow: "energy")) }
+
+    it "redirects list requests to the submission confirmation page" do
+      allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+      get(:list, params: { id: framework_request.id })
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+    end
+
+    it "redirects upload requests to the submission confirmation page" do
+      allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+      post(:upload, params: { id: framework_request.id })
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+    end
+
+    it "redirects remove requests to the submission confirmation page" do
+      allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+      delete(:remove, params: { id: framework_request.id, file_id: "123" })
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+    end
+
+    it "redirects edit requests to the submission confirmation page" do
+      allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+      get(:edit, params: { id: framework_request.id })
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+    end
+  end
 end

--- a/spec/controllers/framework_requests/categories_controller_spec.rb
+++ b/spec/controllers/framework_requests/categories_controller_spec.rb
@@ -111,6 +111,26 @@ describe FrameworkRequests::CategoriesController, type: :controller do
     end
   end
 
+  describe "submitted request redirects" do
+    let(:framework_request) { create(:framework_request, submitted: true, category:, group:, org_id:) }
+
+    describe "on edit" do
+      before { get :edit, params: { id: framework_request.id } }
+
+      it "redirects to the submission confirmation page" do
+        expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+      end
+    end
+
+    describe "on update" do
+      before { patch :update, params: { id: framework_request.id, framework_support_form: { category_slug: nil } } }
+
+      it "redirects to the submission confirmation page" do
+        expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+      end
+    end
+  end
+
   describe "on create" do
     context "when the user has not chosen a category" do
       before { post :create, params: { framework_support_form: { category_slug: nil } }, session: { framework_request_id: framework_request.id } }

--- a/spec/controllers/framework_requests/document_uploads_controller_spec.rb
+++ b/spec/controllers/framework_requests/document_uploads_controller_spec.rb
@@ -8,6 +8,19 @@ describe FrameworkRequests::DocumentUploadsController, type: :controller do
       post(:create)
       expect(response).to redirect_to "/procurement-support/special_requirements"
     end
+
+    context "when the request is already submitted" do
+      let(:framework_request) { create(:framework_request, submitted: true, category: create(:request_for_help_category, flow: "services")) }
+
+      before do
+        allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+        post(:create, session: { framework_request_id: framework_request.id })
+      end
+
+      it "redirects to the submission confirmation page" do
+        expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+      end
+    end
   end
 
   describe "on update" do
@@ -19,6 +32,34 @@ describe FrameworkRequests::DocumentUploadsController, type: :controller do
 
     it "redirects to the check-your-answers page" do
       expect(response).to redirect_to("/procurement-support/#{framework_request.id}")
+    end
+  end
+
+  describe "submitted request redirects" do
+    let(:framework_request) { create(:framework_request, submitted: true, category: create(:request_for_help_category, flow: "services")) }
+
+    it "redirects list requests to the submission confirmation page" do
+      allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+      get(:list, params: { id: framework_request.id })
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+    end
+
+    it "redirects upload requests to the submission confirmation page" do
+      allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+      post(:upload, params: { id: framework_request.id })
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+    end
+
+    it "redirects remove requests to the submission confirmation page" do
+      allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+      delete(:remove, params: { id: framework_request.id, file_id: "123" })
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+    end
+
+    it "redirects edit requests to the submission confirmation page" do
+      allow(controller).to receive(:framework_request).and_return(FrameworkRequestPresenter.new(framework_request))
+      get(:edit, params: { id: framework_request.id })
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
     end
   end
 

--- a/spec/controllers/framework_requests/framework_request_submissions_controller_spec.rb
+++ b/spec/controllers/framework_requests/framework_request_submissions_controller_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe FrameworkRequests::FrameworkRequestSubmissionsController, type: :controller do
+  render_views
+
+  describe "on update" do
+    let(:framework_request) { create(:framework_request, category: create(:request_for_help_category, flow: "services")) }
+
+    before do
+      submitter = instance_double(SubmitFrameworkRequest, call: true)
+      allow(SubmitFrameworkRequest).to receive(:new).and_return(submitter)
+      patch :update, params: { id: framework_request.id }
+    end
+
+    it "redirects to the submission confirmation page" do
+      expect(response).to redirect_to("/procurement-support-submissions/#{framework_request.id}")
+    end
+
+    it "stores the framework email for the confirmation page" do
+      expect(session[:framework_request_email]).to eq(framework_request.email)
+    end
+  end
+
+  describe "on show" do
+    let(:framework_request) { create(:framework_request, submitted: true, category: create(:request_for_help_category, flow: "services")) }
+
+    context "when the email was set by the submission flow" do
+      before do
+        session[:framework_request_email] = framework_request.email
+        get :show, params: { id: framework_request.id }
+      end
+
+      it "exposes the email to the view" do
+        expect(controller.view_assigns["email"]).to eq(framework_request.email)
+      end
+
+      it "removes the email from the session" do
+        expect(session[:framework_request_email]).to be_nil
+      end
+
+      it "shows the email in the confirmation page" do
+        expect(response.body).to include(framework_request.email)
+      end
+    end
+
+    context "when the page is reached directly" do
+      before do
+        get :show, params: { id: framework_request.id }
+      end
+
+      it "does not expose the email to the view" do
+        expect(controller.view_assigns["email"]).to be_nil
+      end
+
+      it "does not render the email in the confirmation page" do
+        expect(response.body).not_to include(framework_request.email)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a before filter to all of the framework request (RFH) child controllers so that any actions other than `index` are redirected to the submitted request page if the request has been previously submitted. This prevents re-use of a known RFH GUID to manipulate existing data. In addition, modified the show view for the "submitted" page so that the framework email address is not shown, unless the user landed on this page after following the correct redirect route after submitting their complete RFH. This uses a short lived session cookie to pass the email address between `update` and `show` actions rather than a query string.

This means that for a user following the RFH flow nothing changes but if they attempt to revisit or edit anything in the wizard for that request they are redirected to the submitted page, minus any PII.