### PR TITLE
CORE-687 | Fix wrong letter case on check your answers invoicing method

### DIFF
--- a/app/models/energy/task_list.rb
+++ b/app/models/energy/task_list.rb
@@ -269,7 +269,7 @@ private
     Task.new(title: __method__, status:, path:).tap do |t|
       t.add_attribute(:billing_payment_method, case_org, text: case_org.billing_payment_method.present? ? I18n.t("energy.check_your_answers.billing_preferences.#{case_org.billing_payment_method}") : "")
       t.add_attribute(:billing_payment_terms, case_org, text: case_org.billing_payment_terms.present? ? I18n.t("energy.check_your_answers.billing_preferences.#{case_org.billing_payment_terms}") : "")
-      t.add_attribute(:billing_invoicing_method, case_org)
+      t.add_attribute(:billing_invoicing_method, case_org, text: case_org.billing_invoicing_method.present? ? I18n.t("energy.check_your_answers.billing_preferences.#{case_org.billing_invoicing_method}") : "")
 
       if case_org.billing_invoicing_method == "email"
         t.add_attribute(:billing_invoicing_email, case_org)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -850,6 +850,8 @@ en:
         days28: 28 days
         days30: 30 days
         billing_invoicing_method: How would you like to receive your bills?
+        email: Email
+        paper: Paper
         billing_invoicing_email: Email for invoice
         billing_invoice_address: Address for invoice
       no_data: No onboarding data available for this case

--- a/spec/features/energy/check_your_answers_spec.rb
+++ b/spec/features/energy/check_your_answers_spec.rb
@@ -523,7 +523,7 @@ describe "'Check your answers' flows", :js do
         # Back to CYA
         expect(page).to have_text("Check your answers")
         expect(page).not_to have_text("Address for invoice")
-        expect(page).to have_text("paper")
+        expect(page).to have_text("Paper")
       end
     end
 
@@ -556,7 +556,7 @@ describe "'Check your answers' flows", :js do
         # Back to CYA
         expect(page).to have_text("Check your answers")
         expect(page).to have_text("Address for invoice")
-        expect(page).to have_text("paper")
+        expect(page).to have_text("Paper")
       end
     end
   end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Fix the letter case on a field for the energy check your answers page so it is Paper and Email rather than paper and email
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
