### PR TITLE
CORE-647 | Removes the link to create a spec from procurement support page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1322,7 +1322,6 @@ en:
       - read information on <a href="https://www.gov.uk/guidance/buying-procedures-and-procurement-law-for-schools" class="govuk-link">finding the right route to buy what you need</a> for your school
       - read about <a href="https://www.gov.uk/guidance/buying-for-schools-things-to-consider-before-you-start" class="govuk-link">what to consider for specific goods and services</a>
       - read about <a href="https://www.gov.uk/guidance/find-a-dfe-approved-framework-for-your-school" class="govuk-link">framework agreements</a>
-      - <a href="/" class="govuk-link">create a specification</a> for catering or multi-functional devices if you don't have one yet
       we_can_offer: 'Our team of procurement specialists can:'
       we_can_offer_points:
       - offer advice and guidance to make sure you're buying compliantly at any point, even if your procurement process is already in progress

--- a/spec/features/specify/framework_requests/start_page_spec.rb
+++ b/spec/features/specify/framework_requests/start_page_spec.rb
@@ -7,10 +7,6 @@ RSpec.feature "Starting a 'Find a Framework' request" do
     expect(page).to have_current_path "/procurement-support"
   end
 
-  it "links to the homepage" do
-    expect(page).to have_link "create a specification", href: "/", class: "govuk-link"
-  end
-
   describe "for authenticated users", :js do
     before do
       user_exists_in_dfe_sign_in


### PR DESCRIPTION

<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- There is a link on the procurement support page which says it goes to create a specification - this service no longer exists and instead the link goes to the GHBS homepage, so this entire bullet point is removed.
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
<img width="1258" height="1032" alt="Screenshot 2026-07-10 at 14 01 55" src="https://github.com/user-attachments/assets/fcee77a8-2f04-45b9-8e08-107ba600b0a1" />

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
