### PR TITLE
Force all of the error controller routes to return HTML templates

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -3,16 +3,19 @@ class ErrorsController < ApplicationController
 
   def internal_server_error
     render "errors/internal_server_error",
+           formats: [:html],
            status: :internal_server_error
   end
 
   def not_found
     render "errors/not_found",
+           formats: [:html],
            status: :not_found
   end
 
   def unacceptable
     render "errors/unacceptable",
+           formats: [:html],
            status: :unprocessable_entity
   end
 end

--- a/spec/features/energy/switch_energy_spec.rb
+++ b/spec/features/energy/switch_energy_spec.rb
@@ -29,7 +29,7 @@ describe "User can update energy type", :js do
 
     click_button "Save and continue"
 
-    expect(case_organisation.gas_meters.any?).to be(false)
+    expect(case_organisation.reload.gas_meters.any?).to be(false)
 
     create(:energy_electricity_meter, :with_valid_data, energy_onboarding_case_organisation_id: case_organisation.id)
 
@@ -43,6 +43,6 @@ describe "User can update energy type", :js do
 
     visit energy_case_switch_energy_path(onboarding_case, case_organisation)
 
-    expect(case_organisation.electricity_meters.any?).to be(false)
+    expect(case_organisation.reload.electricity_meters.any?).to be(false)
   end
 end


### PR DESCRIPTION
Force all of the error controller routes to return HTML templates, irrespective of the request format

We only have HTML templates implemented, so requests for any other format e.g. https://localhost:3000/404.json otherwise returns a 500 error as the corresponding JSON template format cannot be found.

This should resolve the majority of the exceptions that are logged to Rollbar each month, helping us to stay within our plan quota.