### PR TITLE
CORE-768 - Fix content on energy guidance and start pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,10 +384,10 @@ en:
         title: Benefits
         text: "Schools can make significant savings on their gas and electricity costs. Over 1,000 schools have already joined the scheme. The service also:"
         list:
-        - protect schools from market volatility and high prices
-        - save time spent on procurement process
-        - remove risk associated with unregulated energy brokers
-        - comply with procurement regulations
+        - helps protect schools from market volatility and high prices
+        - saves time spent on procurement process
+        - removes risk associated with unregulated energy brokers
+        - complies with procurement regulations
       mat_info:
       - The Energy for Schools online service is currently only available for individual state-funded schools, like local authority-maintained schools and single academy trusts.
       - Multi-academy trusts (MATs) can join the contract by filling in the <a class="govuk-link" href="%{form_url}">Register your interest form</a> and completing the process offline.
@@ -415,7 +415,7 @@ en:
         body:
         - Energy for Schools offers schools a simpler, safer way to manage their energy needs by helping schools switch to the same energy contract as the Department for Education (DfE).
         - DfE manages the contract on behalf of schools through procurement specialists Government Commercial Agency (GCA), formerly Crown Commercial Service. On the current contract, referred to as V30 or the V30 basket, electricity is supplied by EDF, and gas is supplied by TotalEnergies.
-        - This service differs from other frameworks because it allows schools to benefit from the bulk purchasing power of a government-wide contract. It also saves schools from pouring over complex energy contracts because DfE handles the paperwork.
+        - This service differs from other frameworks because it allows schools to benefit from the bulk purchasing power of a government-wide contract. It also saves schools from comparing complex energy contracts because DfE handles the paperwork.
       benefits:
         title: Benefits
         body:


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
- Changes 'pouring over' to 'comparing' on the energy guidance page
- Pluralises the bullets on the energy start page to make sense and match with contentful
<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes
<img width="696" height="411" alt="Screenshot 2026-07-24 at 14 03 49" src="https://github.com/user-attachments/assets/397e9f6f-bbf9-4f9f-bdf7-cf046a09080f" />
<img width="672" height="297" alt="Screenshot 2026-07-24 at 14 17 08" src="https://github.com/user-attachments/assets/fd6cb377-9134-4d49-869f-cdc68c7ac617" />

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
