### PR TITLE
Stop logging unknown routes as Rollbar exceptions in production

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,51 +1,3 @@
-# Bot URL patterns to ignore for 404 reporting
-BOT_URL_PATTERNS = %w[
-  .php
-  .aspx
-  .asp
-  .jsp
-  .cgi
-  .env
-  .git
-  .gitignore
-  .well-known
-  wp-admin
-  wp-content
-  wp-json
-  wp-includes
-  wp-login
-  wlwmanifest
-  telerik
-  DialogHandler
-  RadEditorProvider
-  DesktopModules
-  App_Themes
-  phpunit
-  htmlawed
-  administrator
-  .xml
-  .txt
-  .bak
-  .sql
-  .config
-  .ini
-  cgi-bin
-  dana-na
-  dana-cached
-  jenkins
-  securityRealm
-  sitecore
-  joomla
-  geoserver
-  __/firebase
-  OA_HTML
-  owa/
-  ecp/
-  graphql
-  crx/packmgr
-  bin/querybuilder
-].freeze
-
 Rollbar.configure do |config|
   # Without configuration, Rollbar is enabled in all environments.
   # To disable in specific environments, set config.enabled=false.
@@ -117,12 +69,12 @@ Rollbar.configure do |config|
   # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
   config.environment = ENV.fetch("ROLLBAR_ENV", nil).presence || Rails.env
 
-  # Don't report bot/scanner 404s
+  # Don't report routing misses. They are handled as normal 404s by the
+  # application and are mostly bot noise in live environments.
   config.before_process << proc do |options|
     exception = options[:exception]
-    request_url = options.dig(:request_data, :url) || ""
 
-    if exception.is_a?(ActionController::RoutingError) && BOT_URL_PATTERNS.any? { |pattern| request_url.include?(pattern) }
+    if exception.is_a?(ActionController::RoutingError)
       throw(:ignore)
     end
   end


### PR DESCRIPTION
It's virtually impossible to maintain a blacklist of known bot attempts as they change so quickly, and I can't see any benefit in logging unknown routes anyway. We only have a free plan for Rollbar and the 5,000 occurrence limit is reached in a few days with spurious bot requests against Dev and Staging instances (Production is shielded quite well by the WAF). This change simply means that any request for an unknown route returns a 404 page and nothing is logged to Rollbar. This will vastly reduce the false positives we receive and hopefully make the free account useful again - although we have to wait for the next billing period to roll around on 21st August to be sure...