### PR TITLE
Add a new rake task to clear down Sidekiq queues in local dev environment

### DIFF
--- a/doc/clean-up.md
+++ b/doc/clean-up.md
@@ -5,3 +5,9 @@
 The following command can be run to stop any running Docker containers and remove all volumes used by the databases.
 
 - From within project root `$ docker-compose down -v --remove-orphans`
+
+## Clear Sidekiq queues
+
+The following task clears all Sidekiq queues, scheduled jobs, retries, and dead jobs in development.
+
+- From within project root `$ bundle exec rails sidekiq:clear`

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -1,0 +1,13 @@
+namespace :sidekiq do
+  desc "Clear all Sidekiq queues (development only)"
+  task clear: :environment do
+    abort("Only available in development") unless Rails.env.development?
+
+    Sidekiq::Queue.all.to_a.each(&:clear)
+    Sidekiq::ScheduledSet.new.clear
+    Sidekiq::RetrySet.new.clear
+    Sidekiq::DeadSet.new.clear
+
+    puts "Sidekiq queues cleared"
+  end
+end


### PR DESCRIPTION
Surprisingly Sidekiq doesn't include this out of the box and my local Sidekiq runner is filled with tonnes of DfE analytics jobs that keep throwing constant console noise (due to a missing `ENABLE_DFE_ANALYTICS=FALSE` ENV var at some point). This just clears everything and is restricted to running in development mode.