### PR TITLE
CORE-671 Import categories/subcategories/solution mapping

### DIFF
--- a/config/categories.yml
+++ b/config/categories.yml
@@ -82,7 +82,7 @@ categories:
   - name: Legal services
     slug: legal-services
 - category: HR, people and professional services
-  description: 'Recruitment, payroll and consultancy '
+  description: Recruitment, payroll and consultancy
   slug: hr-people-professional-services
   subcategories:
   - name: Catering staff

--- a/config/categories.yml
+++ b/config/categories.yml
@@ -114,4 +114,6 @@ categories:
 - category: Transport
   description: Daily transport and educational trips
   slug: transport
-  subcategories: []
+  subcategories:
+  - name: N/A
+    slug: not-applicable

--- a/config/categories.yml
+++ b/config/categories.yml
@@ -1,0 +1,117 @@
+categories:
+- category: Buildings and maintenance
+  description: Cleaning services, grounds maintenance and sports facilities
+  slug: buildings-maintenance
+  subcategories:
+  - name: Buildings
+    slug: buildings
+  - name: Cleaning services and equipment
+    slug: cleaning-services-equipment
+  - name: Facilities management
+    slug: facilities-management
+  - name: Grounds, estates and maintenance
+    slug: grounds-estates-maintenance
+  - name: Health, safety and security
+    slug: health-safety-security
+  - name: Lighting
+    slug: lighting
+  - name: Sports grounds, facilities and equipment
+    slug: sports-grounds-facilities-equipment
+- category: Catering
+  description: Food, vending machines, catering services and equipment
+  slug: catering
+  subcategories:
+  - name: Breakfast club
+    slug: breakfast-club
+  - name: Catering equipment
+    slug: catering-equipment
+  - name: Catering services and staff
+    slug: catering-services-staff
+  - name: Food
+    slug: food
+  - name: Vending machines
+    slug: vending-machines
+- category: Classroom, curriculum and office supplies
+  description: Books, classroom tech, furniture and sensory equipment
+  slug: classroom-curriculum-office-supplies
+  subcategories:
+  - name: Arts, crafts and music
+    slug: arts-crafts-music
+  - name: Books
+    slug: books
+  - name: Classroom and office supplies
+    slug: classroom-office-supplies
+  - name: Furniture
+    slug: furniture
+  - name: Laptops, AV and classroom tech
+    slug: laptops-av-classroom-tech
+  - name: Printed materials
+    slug: printed-materials
+  - name: SEND products
+    slug: send-products
+  - name: Sports equipment
+    slug: sports-equipment
+- category: Energy and utilities
+  description: Gas and electricity supplies, solar panels and water
+  slug: energy-utilities
+  subcategories:
+  - name: Electricity
+    slug: electricity
+  - name: Energy audits, savings and debt resolution
+    slug: energy-audits-savings-debt-resolution
+  - name: Gas
+    slug: gas
+  - name: Lighting
+    slug: lighting
+  - name: Other fuels
+    slug: other-fuels
+  - name: Renewables and energy-saving products
+    slug: renewables-energysaving-products
+  - name: Water
+    slug: water
+- category: Finance, legal and insurance
+  description: Insurance solutions, audits and legal services
+  slug: finance-legal-insurance
+  subcategories:
+  - name: Debt resolution and services
+    slug: debt-resolution-services
+  - name: Financial, audit and payroll
+    slug: financial-audit-payroll
+  - name: Insurance
+    slug: insurance
+  - name: Legal services
+    slug: legal-services
+- category: HR, people and professional services
+  description: 'Recruitment, payroll and consultancy '
+  slug: hr-people-professional-services
+  subcategories:
+  - name: Catering staff
+    slug: catering-staff
+  - name: HR and recruitment
+    slug: hr-recruitment
+  - name: Language services
+    slug: language-services
+  - name: Professional services
+    slug: professional-services
+  - name: Training and development
+    slug: training-development
+- category: ICT and business systems
+  description: Hardware, software and management systems
+  slug: ict-business-systems
+  subcategories:
+  - name: Cameras and AV equipment
+    slug: cameras-av-equipment
+  - name: Broadband, wifi and telecomms
+    slug: broadband-wifi-telecomms
+  - name: Cloud services, AI and data storage
+    slug: cloud-services-ai-data-storage
+  - name: Cyber security
+    slug: cyber-security
+  - name: ICT software and systems
+    slug: ict-software-systems
+  - name: Laptops, printers and ICT hardware
+    slug: laptops-printers-ict-hardware
+- category: Transport
+  description: Daily transport and educational trips
+  slug: transport
+  subcategories: []

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -1,0 +1,50 @@
+redirects:
+  - title: About this service
+    source_path: /about-this-service
+    destination_path: /about-our-service
+    redirect_type: permanent
+
+  - title: Legacy category Banking and finance
+    source_path: /categories/banking-finance/*
+    destination_path: /categories/finance-legal-insurance/*
+    redirect_type: permanent
+
+  - title: Legacy category Catalogues
+    source_path: /categories/catalogues/*
+    destination_path: /
+    redirect_type: permanent
+
+  - title: Legacy category Energy
+    source_path: /categories/energy/*
+    destination_path: /categories/energy-utilities/*
+    redirect_type: permanent
+
+  - title: Legacy category Facilities management and estates
+    source_path: /categories/facilities-management-estates/*
+    destination_path: /categories/buildings-maintenance/*
+    redirect_type: permanent
+
+  - title: Legacy category IT
+    source_path: /categories/it/*
+    destination_path: /categories/ict-business-systems/*
+    redirect_type: permanent
+
+  - title: Legacy category Legal
+    source_path: /categories/legal/*
+    destination_path: /categories/finance-legal-insurance/*
+    redirect_type: permanent
+
+  - title: Legacy category Office and education supplies
+    source_path: /categories/office-education-supplies/*
+    destination_path: /categories/classroom-curriculum-office-supplies/*
+    redirect_type: permanent
+
+  - title: Legacy category Professional services
+    source_path: /categories/consultancy-services/*
+    destination_path: /categories/hr-people-professional-services/*
+    redirect_type: permanent
+
+  - title: Legacy category Recruitment, HR and training
+    source_path: /categories/recruitment-hr-training/*
+    destination_path: /categories/hr-people-professional-services/*
+    redirect_type: permanent

--- a/config/solutions.yml
+++ b/config/solutions.yml
@@ -447,6 +447,8 @@ solutions:
   primary_category: classroom-curriculum-office-supplies
   categories:
   - classroom-curriculum-office-supplies
+  - catering
+  - buildings-maintenance
   subcategories:
   - books
   - classroom-office-supplies

--- a/config/solutions.yml
+++ b/config/solutions.yml
@@ -4,154 +4,855 @@ solutions:
   slug: ambient-chilled-frozen-foods-and-fresh-fruit-vegetables-and-salad
 - title: Apprenticeships and associated training
   slug: apprenticeships-and-associated-training
+  category_slugs:
+  - hr-people-professional-services
+  subcategory_slugs:
+  - training-development
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - training-development
 - title: Asbestos inspection & removal services
   slug: asbestos-inspection-and-removal-services
 - title: Audio-Visual equipment and installation services
   slug: audio-visual-equipment-and-installation-services
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  - ict-business-systems
+  subcategory_slugs:
+  - laptops-av-classroom-tech
+  - cameras-av-equipment
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  - ict-business-systems
+  subcategories:
+  - laptops-av-classroom-tech
+  - cameras-av-equipment
 - title: Audio Visual Solutions
   slug: audio-visual-solutions
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  - ict-business-systems
+  subcategory_slugs:
+  - laptops-av-classroom-tech
+  - cameras-av-equipment
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  - ict-business-systems
+  subcategories:
+  - laptops-av-classroom-tech
+  - cameras-av-equipment
 - title: Audit and financial services
   slug: audit-and-financial-services
+  category_slugs:
+  - finance-legal-insurance
+  subcategory_slugs:
+  - financial-audit-payroll
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - financial-audit-payroll
 - title: Books, e-books and associated services
   slug: books-e-books-and-associated-services
 - title: Building cleaning
   slug: building-cleaning
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - cleaning-services-equipment
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - cleaning-services-equipment
 - title: Buildings internal fit-out and maintenance  - dynamic purchasing system (DPS)
   slug: buildings-internal-fit-out-and-maintenance-dps
 - title: Business support services
   slug: business-support-services
+  category_slugs:
+  - hr-people-professional-services
+  - finance-legal-insurance
+  subcategory_slugs:
+  - hr-recruitment
+  - professional-services
+  - financial-audit-payroll
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  - finance-legal-insurance
+  subcategories:
+  - hr-recruitment
+  - professional-services
+  - financial-audit-payroll
 - title: Buying better food and drink
   slug: buying-better-food-and-drink
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - food
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - food
 - title: Catering services - dynamic purchasing system (DPS)
   slug: catering-services-dps
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - catering-services-staff
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - catering-services-staff
 - title: Catering, vending machines & water cooler solutions
   slug: catering-vending-machines-and-water-cooler-solutions
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - breakfast-club
+  - vending-machines
+  - catering-equipment
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - breakfast-club
+  - vending-machines
+  - catering-equipment
 - title: CCTV access solutions and security services
   slug: cctv-access-solutions-and-security-services
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - grounds-estates-maintenance
+  - health-safety-security
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - grounds-estates-maintenance
+  - health-safety-security
 - title: Cleaning services
   slug: cleaning-services
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - cleaning-services-equipment
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - cleaning-services-equipment
 - title: Cloud services, AI, data centre management and transformation solutions
   slug: cloud-services-ai-data-centre-management-and-transformation-solutions
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - cloud-services-ai-data-storage
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - cloud-services-ai-data-storage
 - title: Communications solutions
   slug: communications-solutions
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - broadband-wifi-telecomms
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - broadband-wifi-telecomms
 - title: Communications solutions and associated telephony services
   slug: communications-telephony
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - broadband-wifi-telecomms
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - broadband-wifi-telecomms
 - title: Corporate software and related products and services
   slug: corporate-software
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - ict-software-systems
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
 - title: Cyber security services 3 DPS
   slug: cyber-security-services-dps
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - cyber-security
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - cyber-security
 - title: Debt resolution services Lot 1 only
   slug: debt-resolution-services
+  category_slugs:
+  - finance-legal-insurance
+  subcategory_slugs:
+  - debt-resolution-services
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - debt-resolution-services
 - title: Early years furniture framework
   slug: early-years-furniture
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - furniture
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - furniture
 - title: Education decarbonisation
   slug: education-decarbonisation
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - renewables-energysaving-products
+  - energy-audits-savings-debt-resolution
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - renewables-energysaving-products
+  - energy-audits-savings-debt-resolution
 - title: Education management systems
   slug: education-management-systems
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - ict-software-systems
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
 - title: Education Professional Services
   slug: education-professional-services
 - title: Education services
   slug: education-services
+  category_slugs:
+  - hr-people-professional-services
+  subcategory_slugs:
+  - professional-services
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - professional-services
 - title: Electric Vehicle Charging Points – Supply, installation, maintenance and
     consultancy
   slug: electric-vehicle-charging-points-supply-installation-maintenance-and-consultancy
+  category_slugs:
+  - buildings-maintenance
+  - energy-utilities
+  subcategory_slugs:
+  - grounds-estates-maintenance
+  - renewables-energysaving-products
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  - energy-utilities
+  subcategories:
+  - grounds-estates-maintenance
+  - renewables-energysaving-products
 - title: Electrical Testing services
   slug: electrical-testing-services
+  category_slugs:
+  - buildings-maintenance
+  - ict-business-systems
+  subcategory_slugs:
+  - buildings
+  - laptops-printers-ict-hardware
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  - ict-business-systems
+  subcategories:
+  - buildings
+  - laptops-printers-ict-hardware
 - title: Electricity (for supply during 2024-2028)
   slug: electricity-espo
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - electricity
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - electricity
 - title: Electronic catering management and payment solutions
   slug: electronic-catering-management-and-payment-solutions
+  category_slugs:
+  - ict-business-systems
+  - catering
+  subcategory_slugs:
+  - ict-software-systems
+  - catering-equipment
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  - catering
+  subcategories:
+  - ict-software-systems
+  - catering-equipment
 - title: Supply of energy 2
   slug: energy-ancillary
+  category_slugs:
+  - energy-utilities
+  - hr-people-professional-services
+  subcategory_slugs:
+  - gas
+  - electricity
+  - professional-services
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  - hr-people-professional-services
+  subcategories:
+  - gas
+  - electricity
+  - professional-services
 - title: Energy cost recovery services for schools
   slug: energy-cost-recovery-services
 - title: DfE Energy for Schools
   slug: energy-for-schools
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - electricity
+  - gas
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - electricity
+  - gas
 - title: Engineering inspection services
   slug: engineering-inspection-services
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - health-safety-security
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - health-safety-security
 - title: ESPO catalogue
   slug: espo-catalogue
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - books
+  - classroom-office-supplies
+  - arts-crafts-music
+  - sports-equipment
+  - furniture
+  - laptops-av-classroom-tech
+  - catering-services-staff
+  - cleaning-services-equipment
+  - health-safety-security
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - books
+  - classroom-office-supplies
+  - arts-crafts-music
+  - sports-equipment
+  - furniture
+  - laptops-av-classroom-tech
+  - catering-services-staff
+  - cleaning-services-equipment
+  - health-safety-security
 - title: Estates and facilities professional services (DPS)
   slug: estates-and-facilities-professional-services
+  category_slugs:
+  - buildings-maintenance
+  - hr-people-professional-services
+  subcategory_slugs:
+  - grounds-estates-maintenance
+  - professional-services
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  - hr-people-professional-services
+  subcategories:
+  - grounds-estates-maintenance
+  - professional-services
 - title: Exterior building services DPS
   slug: exterior-building-services-dps
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - buildings
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - buildings
 - title: Facilities supplies
   slug: facilities-supplies
+  category_slugs:
+  - energy-utilities
+  - buildings-maintenance
+  subcategory_slugs:
+  - renewables-energysaving-products
+  - lighting
+  - grounds-estates-maintenance
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  - buildings-maintenance
+  subcategories:
+  - renewables-energysaving-products
+  - lighting
+  - grounds-estates-maintenance
 - title: Financial leasing solutions
   slug: financial-leasing-solutions
+  category_slugs:
+  - finance-legal-insurance
+  subcategory_slugs:
+  - financial-audit-payroll
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - financial-audit-payroll
 - title: Findel Education catalogue
   slug: findel-education-catalogue
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - books
+  - classroom-office-supplies
+  - arts-crafts-music
+  - furniture
+  - sports-equipment
+  - send-products
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - books
+  - classroom-office-supplies
+  - arts-crafts-music
+  - furniture
+  - sports-equipment
+  - send-products
 - title: Fire safety products and services
   slug: fire-safety-products-and-services
 - title: Fixed and flexible electricity and gas frameworks
   slug: fixed-and-flexible-gas
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - gas
+  - electricity
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - gas
+  - electricity
 - title: Flexible electricity
   slug: flex-electricity
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - electricity
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - electricity
 - title: Flexible gas
   slug: flexible-gas-framework
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - gas
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - gas
 - title: Building in use - support services DPS
   slug: fm-support-services-dps
+  category_slugs:
+  - buildings-maintenance
+  - catering
+  subcategory_slugs:
+  - facilities-management
+  - health-safety-security
+  - catering-staff
+  - catering-services-staff
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  - catering
+  subcategories:
+  - facilities-management
+  - health-safety-security
+  - catering-staff
+  - catering-services-staff
 - title: Facilities management and workplace services DPS
   slug: fm-workplace-dps
+  category_slugs:
+  - buildings-maintenance
+  - catering
+  subcategory_slugs:
+  - facilities-management
+  - health-safety-security
+  - grounds-estates-maintenance
+  - catering-staff
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  - catering
+  subcategories:
+  - facilities-management
+  - health-safety-security
+  - grounds-estates-maintenance
+  - catering-staff
 - title: Food and drink - dynamic purchasing system (DPS)
   slug: food-and-drink-dynamic-purchasing-system-dps
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - food
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - food
 - title: Food and drink - framework
   slug: food-and-drink-framework
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - food
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - food
 - title: Food and drink vending solution
   slug: food-and-drink-vending-solution
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - catering-equipment
+  - vending-machines
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - catering-equipment
+  - vending-machines
 - title: Furniture and associated services
   slug: furniture-and-associated-services
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - furniture
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - furniture
 - title: G-Cloud 14
   slug: g-cloud
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - ict-software-systems
+  - laptops-printers-ict-hardware
+  - broadband-wifi-telecomms
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
+  - laptops-printers-ict-hardware
+  - broadband-wifi-telecomms
 - title: Language services
   slug: gca-language-services
 - title: GCA purchasing platform catalogue
   slug: gca-purchasing-platform-catalogue
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - ict-software-systems
+  - cameras-av-equipment
+  - laptops-printers-ict-hardware
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
+  - cameras-av-equipment
+  - laptops-printers-ict-hardware
 - title: Grounds maintenance & associated services
   slug: grounds-maintenance-and-associated-services
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - grounds-estates-maintenance
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - grounds-estates-maintenance
 - title: Grounds maintenance services
   slug: grounds-maintenance-services
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - grounds-estates-maintenance
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - grounds-estates-maintenance
 - title: HR, payroll and employee screening services
   slug: hr-payroll-and-employee-screening
+  category_slugs:
+  - hr-people-professional-services
+  subcategory_slugs:
+  - hr-recruitment
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - hr-recruitment
 - title: HR support services
   slug: hr-support-services
+  category_slugs:
+  - hr-people-professional-services
+  subcategory_slugs:
+  - hr-recruitment
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - hr-recruitment
 - title: ICT hardware and peripherals equipment
   slug: ict-hardware-and-peripherals-equipment
 - title: ICT Managed services & consultancy
   slug: ict-managed-services-and-consultancy
+  category_slugs:
+  - ict-business-systems
+  - hr-people-professional-services
+  subcategory_slugs:
+  - ict-software-systems
+  - cyber-security
+  - professional-services
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  - hr-people-professional-services
+  subcategories:
+  - ict-software-systems
+  - cyber-security
+  - professional-services
 - title: ICT network, storage and service solutions
   slug: ict-network-storage-and-service-solutions
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - cyber-security
+  - cloud-services-ai-data-storage
+  - broadband-wifi-telecomms
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - cyber-security
+  - cloud-services-ai-data-storage
+  - broadband-wifi-telecomms
 - title: Everything ICT
   slug: ict-procurement
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - cloud-services-ai-data-storage
+  - broadband-wifi-telecomms
+  - ict-software-systems
+  - laptops-printers-ict-hardware
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - cloud-services-ai-data-storage
+  - broadband-wifi-telecomms
+  - ict-software-systems
+  - laptops-printers-ict-hardware
 - title: Insurance and associated services (Lot 3 only)
   slug: insurance-and-associated-services-lot-three-only
+  category_slugs:
+  - finance-legal-insurance
+  subcategory_slugs:
+  - insurance
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - insurance
 - title: Internal audit, assurance and counter fraud investigation services
   slug: internal-audit-assurance-and-counter-fraud-investigation-services
+  category_slugs:
+  - finance-legal-insurance
+  subcategory_slugs:
+  - financial-audit-payroll
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - financial-audit-payroll
 - title: IT, hardware, ITAD & associated services
   slug: it-hardware-itad-and-associated-services
 - title: Language services
   slug: language-services
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - language-services
+  - professional-services
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - language-services
+  - professional-services
 - title: LED Lighting
   slug: led-lighting
 - title: LED Lighting
   slug: led-lights
+  category_slugs:
+  - energy-utilities
+  - buildings-maintenance
+  subcategory_slugs:
+  - renewables-energysaving-products
+  - lighting
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  - buildings-maintenance
+  subcategories:
+  - renewables-energysaving-products
+  - lighting
 - title: Legal Services
   slug: legal-services
+  category_slugs:
+  - finance-legal-insurance
+  subcategory_slugs:
+  - legal-services
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - legal-services
 - title: Legal services – wider public sector
   slug: legal-services-wider-public-sector
+  category_slugs:
+  - finance-legal-insurance
+  subcategory_slugs:
+  - legal-services
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - legal-services
 - title: Library resources, software and associated services
   slug: library-resources-software-and-associated-services
 - title: Liquid fuels
   slug: liquid-fuel-espo
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - other-fuels
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - other-fuels
 - title: Low energy lighting DPS
   slug: low-energy-lighting-dps
+  category_slugs:
+  - energy-utilities
+  - buildings-maintenance
+  subcategory_slugs:
+  - renewables-energysaving-products
+  - lighting
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  - buildings-maintenance
+  subcategories:
+  - renewables-energysaving-products
+  - lighting
 - title: Mains gas 2023
   slug: mains-gas-espo
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - gas
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - gas
 - title: Multifunctional devices and associated products and services (including print
     and design)
   slug: mfd-and-associated-products-and-services-including-print-and-design
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - cloud-services-ai-data-storage
+  - laptops-printers-ict-hardware
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - cloud-services-ai-data-storage
+  - laptops-printers-ict-hardware
 - title: Minor works DPS 2
   slug: minor-works-dps-2
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - buildings
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - buildings
 - title: Multifunctional Devices, GovPrint Hardware, Managed Print Provision and Digital
     Workflow Software Services
   slug: multifunctional-devices-govprint-hardware-managed-print-provision-digital-workflow-software-services
@@ -159,93 +860,433 @@ solutions:
   slug: musical-instruments-equipment-and-technology
 - title: Network connectivity and telecommunication solutions
   slug: network-connectivity-and-telecommunication-solutions
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - broadband-wifi-telecomms
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - broadband-wifi-telecomms
 - title: National professional qualification (NPQ) courses
   slug: npq
 - title: Occupational health services
   slug: occupational-health-services
+  category_slugs:
+  - hr-people-professional-services
+  subcategory_slugs:
+  - hr-recruitment
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - hr-recruitment
 - title: Outdoor playground equipment, fitness and sport facilities and equipment
   slug: outdoor-playground-equipment-fitness-and-sport-facilities-and-equipment
 - title: Outdoor sports surfaces and activity equipment
   slug: outdoor-sports-surfaces-and-activity-equipment
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  - buildings-maintenance
+  subcategory_slugs:
+  - sports-equipment
+  - send-products
+  - sports-grounds-facilities-equipment
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  - buildings-maintenance
+  subcategories:
+  - sports-equipment
+  - send-products
+  - sports-grounds-facilities-equipment
 - title: Catering services
   slug: outsourced-catering
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - catering-services-staff
+  - breakfast-club
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - catering-services-staff
+  - breakfast-club
 - title: Outsourced catering services
   slug: outsourced-catering-cpc
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - catering-services-staff
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - catering-services-staff
 - title: Pest control products & services
   slug: pest-control-products-and-services
 - title: Photographic equipment and consumables
   slug: photographic-equipment-and-consumables
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  - ict-business-systems
+  subcategory_slugs:
+  - laptops-av-classroom-tech
+  - cameras-av-equipment
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  - ict-business-systems
+  subcategories:
+  - laptops-av-classroom-tech
+  - cameras-av-equipment
 - title: Playground, fitness and sports facilities and leisure facilities
   slug: playground-fitness-and-sports-facilities-and-leisure-facilities
 - title: Print books
   slug: print-books
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - books
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - books
 - title: Print Marketplace 2
   slug: print-marketplace-2
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - printed-materials
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - printed-materials
 - title: Promotional merchandise
   slug: promotional-merchandise
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - printed-materials
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - printed-materials
 - title: Property refurbishment, maintenance and management
   slug: property-refurbishment-maintenance-and-management
+  category_slugs:
+  - buildings-maintenance
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
 - title: Public sector legal services
   slug: public-sector-legal-services
+  category_slugs:
+  - finance-legal-insurance
+  subcategory_slugs:
+  - legal-services
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - legal-services
 - title: Records information management
   slug: records-information-management
 - title: Risk protection arrangement – alternative to commercial insurance
   slug: rpa
 - title: Sandwiches and food to go
   slug: sandwiches-and-food-to-go
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - food
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - food
 - title: Sandwiches, ready meals, meal concepts and food to go
   slug: sandwiches-ready-meals-meal-concepts-and-food-to-go
+  category_slugs:
+  - catering
+  subcategory_slugs:
+  - food
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - food
 - title: Sensory equipment and associated services
   slug: sensory-equipment-and-associated-services
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - send-products
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - send-products
 - title: Signs and associated services
   slug: signs-and-associated-services
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - buildings
+  - health-safety-security
+  - grounds-estates-maintenance
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - buildings
+  - health-safety-security
+  - grounds-estates-maintenance
 - title: Software application solutions - dynamic purchasing system (DPS)
   slug: software-application-solutions-dps
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - ict-software-systems
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
 - title: Software licenses and associated services for academies and schools
   slug: software-licenses
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - ict-software-systems
+  - cyber-security
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
+  - cyber-security
 - title: Software products & associated services
   slug: software-products-and-associated-services
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - ict-software-systems
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
 - title: Solar photovoltaic
   slug: solar-photovoltaic
 - title: Specialist professional services
   slug: specialist-professional-services
+  category_slugs:
+  - hr-people-professional-services
+  subcategory_slugs:
+  - professional-services
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - professional-services
 - title: Sports facilities installation, refurbishment and maintenance
   slug: sports-facilities-installation-refurbishment-and-maintenance
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - sports-grounds-facilities-equipment
+  - buildings
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - sports-grounds-facilities-equipment
+  - buildings
 - title: Staff absence protection and reimbursement services 2025
   slug: staff-absence-protection-and-reimbursement-services
+  category_slugs:
+  - hr-people-professional-services
+  - finance-legal-insurance
+  subcategory_slugs:
+  - hr-recruitment
+  - insurance
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  - finance-legal-insurance
+  subcategories:
+  - hr-recruitment
+  - insurance
 - title: Stationery, paper and education supplies
   slug: stationery-paper-and-education-supplies
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - classroom-office-supplies
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - classroom-office-supplies
 - title: Supply and installation of Solar PV
   slug: supply-and-installation-of-solar-pv
 - title: Supply of mains gas
   slug: supply-of-mains-gas
+  category_slugs:
+  - energy-utilities
+  subcategory_slugs:
+  - gas
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - gas
 - title: Supply Teachers and Education Recruitment
   slug: supply-teachers
+  category_slugs:
+  - hr-people-professional-services
+  subcategory_slugs:
+  - hr-recruitment
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - hr-recruitment
 - title: Sustainable hardware, asset recycling and data destruction
   slug: sustainable-hardware-asset-recycling-and-data-destruction
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - laptops-printers-ict-hardware
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - laptops-printers-ict-hardware
 - title: Technology products and associated services 2
   slug: technology-products-and-associated-services-2
+  category_slugs:
+  - ict-business-systems
+  subcategory_slugs:
+  - ict-software-systems
+  - laptops-printers-ict-hardware
+  - cloud-services-ai-data-storage
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
+  - laptops-printers-ict-hardware
+  - cloud-services-ai-data-storage
 - title: Temporary and semi-permanent buildings
   slug: temporary-and-semi-permanent-buildings
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - buildings
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - buildings
 - title: Total cleaning service solutions
   slug: total-cleaning-service-solutions
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - cleaning-services-equipment
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - cleaning-services-equipment
 - title: Total facilities management
   slug: total-facilities-management
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - facilities-management
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - facilities-management
 - title: Training, learning and development managed services
   slug: training-learning-and-development-managed-services
 - title: Student transport DPS
   slug: transport
+  category_slugs:
+  - transport
+  primary_category: transport
+  categories:
+  - transport
 - title: Utilities supplies and services
   slug: utilities-supply-services
+  category_slugs:
+  - energy-utilities
+  - hr-people-professional-services
+  subcategory_slugs:
+  - energy-audits-savings-debt-resolution
+  - renewables-energysaving-products
+  - professional-services
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  - hr-people-professional-services
+  subcategories:
+  - energy-audits-savings-debt-resolution
+  - renewables-energysaving-products
+  - professional-services
 - title: Vehicle daily rental
   slug: vehicle-daily-rental
 - title: Vehicle purchase
   slug: vehicle-purchase
+  category_slugs:
+  - transport
+  primary_category: transport
+  categories:
+  - transport
 - title: Waste management services
   slug: waste-management-services
+  category_slugs:
+  - buildings-maintenance
+  subcategory_slugs:
+  - buildings
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - buildings
 - title: Water, wastewater and ancillary services
   slug: water-wastewater-and-ancillary-services
 - title: Wheelie bin containers and kerbside recycling containers
   slug: wheelie-bin-containers-and-kerbside-recycling-containers
 - title: YPO procurement product catalogue
   slug: ypo-procurement
+  category_slugs:
+  - classroom-curriculum-office-supplies
+  subcategory_slugs:
+  - books
+  - classroom-office-supplies
+  - arts-crafts-music
+  - furniture
+  - sports-equipment
+  - send-products
+  - laptops-av-classroom-tech
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - books
+  - classroom-office-supplies
+  - arts-crafts-music
+  - furniture
+  - sports-equipment
+  - send-products
+  - laptops-av-classroom-tech

--- a/config/solutions.yml
+++ b/config/solutions.yml
@@ -80,6 +80,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - books
+  ways_to_buy: framework
 - title: Building cleaning
   slug: building-cleaning
   category_slugs:
@@ -304,6 +305,7 @@ solutions:
   subcategories:
   - professional-services
   - language-services
+  ways_to_buy: framework
 - title: Education services
   slug: education-services
   category_slugs:
@@ -856,6 +858,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - laptops-printers-ict-hardware
+  ways_to_buy: framework
 - title: Language services
   slug: language-services
   category_slugs:
@@ -929,6 +932,7 @@ solutions:
   subcategories:
   - books
   - ict-software-systems
+  ways_to_buy: framework
 - title: Liquid fuels
   slug: liquid-fuel-espo
   category_slugs:
@@ -1004,6 +1008,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - laptops-printers-ict-hardware
+  ways_to_buy: framework
 - title: Musical instruments, equipment and technology
   slug: musical-instruments-equipment-and-technology
   primary_category: classroom-curriculum-office-supplies
@@ -1012,6 +1017,7 @@ solutions:
   subcategories:
   - arts-crafts-music
   - laptops-av-classroom-tech
+  ways_to_buy: dfe_deal
 - title: Network connectivity and telecommunication solutions
   slug: network-connectivity-and-telecommunication-solutions
   category_slugs:
@@ -1031,6 +1037,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - training-development
+  ways_to_buy: dfe_deal
 - title: Occupational health services
   slug: occupational-health-services
   category_slugs:
@@ -1196,6 +1203,7 @@ solutions:
   subcategories:
   - ict-software-systems
   - cyber-security
+  ways_to_buy: framework
 - title: Risk protection arrangement – alternative to commercial insurance
   slug: rpa
   primary_category: finance-legal-insurance
@@ -1296,6 +1304,12 @@ solutions:
   ways_to_buy: framework
 - title: Solar photovoltaic
   slug: solar-photovoltaic
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - renewables-energysaving-products
+  ways_to_buy: framework
 - title: Specialist professional services
   slug: specialist-professional-services
   category_slugs:
@@ -1352,6 +1366,12 @@ solutions:
   ways_to_buy: framework
 - title: Supply and installation of Solar PV
   slug: supply-and-installation-of-solar-pv
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  subcategories:
+  - renewables-energysaving-products
+  ways_to_buy: framework
 - title: Supply of mains gas
   slug: supply-of-mains-gas
   category_slugs:
@@ -1442,6 +1462,12 @@ solutions:
   ways_to_buy: framework
 - title: Training, learning and development managed services
   slug: training-learning-and-development-managed-services
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - training-development
+  ways_to_buy: framework
 - title: Student transport DPS
   slug: transport
   category_slugs:
@@ -1473,6 +1499,7 @@ solutions:
   primary_category: transport
   categories:
   - transport
+  ways_to_buy: framework
 - title: Vehicle purchase
   slug: vehicle-purchase
   category_slugs:

--- a/config/solutions.yml
+++ b/config/solutions.yml
@@ -8,7 +8,7 @@ solutions:
   slug: asbestos-inspection-and-removal-services
 - title: Audio-Visual equipment and installation services
   slug: audio-visual-equipment-and-installation-services
-- title: 'Audio Visual Solutions '
+- title: Audio Visual Solutions
   slug: audio-visual-solutions
 - title: Audit and financial services
   slug: audit-and-financial-services
@@ -30,7 +30,7 @@ solutions:
   slug: cctv-access-solutions-and-security-services
 - title: Cleaning services
   slug: cleaning-services
-- title: 'Cloud services, AI, data centre management and transformation solutions '
+- title: Cloud services, AI, data centre management and transformation solutions
   slug: cloud-services-ai-data-centre-management-and-transformation-solutions
 - title: Communications solutions
   slug: communications-solutions
@@ -57,9 +57,9 @@ solutions:
   slug: electric-vehicle-charging-points-supply-installation-maintenance-and-consultancy
 - title: Electrical Testing services
   slug: electrical-testing-services
-- title: 'Electricity (for supply during 2024-2028) '
+- title: Electricity (for supply during 2024-2028)
   slug: electricity-espo
-- title: 'Electronic catering management and payment solutions '
+- title: Electronic catering management and payment solutions
   slug: electronic-catering-management-and-payment-solutions
 - title: Supply of energy 2
   slug: energy-ancillary
@@ -77,7 +77,7 @@ solutions:
   slug: exterior-building-services-dps
 - title: Facilities supplies
   slug: facilities-supplies
-- title: 'Financial leasing solutions '
+- title: Financial leasing solutions
   slug: financial-leasing-solutions
 - title: Findel Education catalogue
   slug: findel-education-catalogue
@@ -115,7 +115,7 @@ solutions:
   slug: hr-payroll-and-employee-screening
 - title: HR support services
   slug: hr-support-services
-- title: 'ICT hardware and peripherals equipment '
+- title: ICT hardware and peripherals equipment
   slug: ict-hardware-and-peripherals-equipment
 - title: ICT Managed services & consultancy
   slug: ict-managed-services-and-consultancy
@@ -169,23 +169,23 @@ solutions:
   slug: outdoor-sports-surfaces-and-activity-equipment
 - title: Catering services
   slug: outsourced-catering
-- title: 'Outsourced catering services '
+- title: Outsourced catering services
   slug: outsourced-catering-cpc
 - title: Pest control products & services
   slug: pest-control-products-and-services
-- title: 'Photographic equipment and consumables '
+- title: Photographic equipment and consumables
   slug: photographic-equipment-and-consumables
 - title: Playground, fitness and sports facilities and leisure facilities
   slug: playground-fitness-and-sports-facilities-and-leisure-facilities
 - title: Print books
   slug: print-books
-- title: 'Print Marketplace 2 '
+- title: Print Marketplace 2
   slug: print-marketplace-2
 - title: Promotional merchandise
   slug: promotional-merchandise
 - title: Property refurbishment, maintenance and management
   slug: property-refurbishment-maintenance-and-management
-- title: 'Public sector legal services '
+- title: Public sector legal services
   slug: public-sector-legal-services
 - title: Records information management
   slug: records-information-management
@@ -201,7 +201,7 @@ solutions:
   slug: signs-and-associated-services
 - title: Software application solutions - dynamic purchasing system (DPS)
   slug: software-application-solutions-dps
-- title: 'Software licenses and associated services for academies and schools '
+- title: Software licenses and associated services for academies and schools
   slug: software-licenses
 - title: Software products & associated services
   slug: software-products-and-associated-services
@@ -221,7 +221,7 @@ solutions:
   slug: supply-of-mains-gas
 - title: Supply Teachers and Education Recruitment
   slug: supply-teachers
-- title: 'Sustainable hardware, asset recycling and data destruction '
+- title: Sustainable hardware, asset recycling and data destruction
   slug: sustainable-hardware-asset-recycling-and-data-destruction
 - title: Technology products and associated services 2
   slug: technology-products-and-associated-services-2
@@ -229,7 +229,7 @@ solutions:
   slug: temporary-and-semi-permanent-buildings
 - title: Total cleaning service solutions
   slug: total-cleaning-service-solutions
-- title: 'Total facilities management '
+- title: Total facilities management
   slug: total-facilities-management
 - title: Training, learning and development managed services
   slug: training-learning-and-development-managed-services

--- a/config/solutions.yml
+++ b/config/solutions.yml
@@ -13,6 +13,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - training-development
+  ways_to_buy: Framework
 - title: Asbestos inspection & removal services
   slug: asbestos-inspection-and-removal-services
 - title: Audio-Visual equipment and installation services
@@ -30,6 +31,7 @@ solutions:
   subcategories:
   - laptops-av-classroom-tech
   - cameras-av-equipment
+  ways_to_buy: Framework
 - title: Audio Visual Solutions
   slug: audio-visual-solutions
   category_slugs:
@@ -45,6 +47,7 @@ solutions:
   subcategories:
   - laptops-av-classroom-tech
   - cameras-av-equipment
+  ways_to_buy: Framework
 - title: Audit and financial services
   slug: audit-and-financial-services
   category_slugs:
@@ -56,6 +59,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - financial-audit-payroll
+  ways_to_buy: Framework
 - title: Books, e-books and associated services
   slug: books-e-books-and-associated-services
 - title: Building cleaning
@@ -69,6 +73,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - cleaning-services-equipment
+  ways_to_buy: Framework
 - title: Buildings internal fit-out and maintenance  - dynamic purchasing system (DPS)
   slug: buildings-internal-fit-out-and-maintenance-dps
 - title: Business support services
@@ -88,6 +93,7 @@ solutions:
   - hr-recruitment
   - professional-services
   - financial-audit-payroll
+  ways_to_buy: Framework
 - title: Buying better food and drink
   slug: buying-better-food-and-drink
   category_slugs:
@@ -99,6 +105,7 @@ solutions:
   - catering
   subcategories:
   - food
+  ways_to_buy: Framework
 - title: Catering services - dynamic purchasing system (DPS)
   slug: catering-services-dps
   category_slugs:
@@ -110,6 +117,7 @@ solutions:
   - catering
   subcategories:
   - catering-services-staff
+  ways_to_buy: DPS
 - title: Catering, vending machines & water cooler solutions
   slug: catering-vending-machines-and-water-cooler-solutions
   category_slugs:
@@ -125,6 +133,7 @@ solutions:
   - breakfast-club
   - vending-machines
   - catering-equipment
+  ways_to_buy: Framework
 - title: CCTV access solutions and security services
   slug: cctv-access-solutions-and-security-services
   category_slugs:
@@ -138,6 +147,7 @@ solutions:
   subcategories:
   - grounds-estates-maintenance
   - health-safety-security
+  ways_to_buy: Framework
 - title: Cleaning services
   slug: cleaning-services
   category_slugs:
@@ -149,6 +159,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - cleaning-services-equipment
+  ways_to_buy: Framework
 - title: Cloud services, AI, data centre management and transformation solutions
   slug: cloud-services-ai-data-centre-management-and-transformation-solutions
   category_slugs:
@@ -160,6 +171,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - cloud-services-ai-data-storage
+  ways_to_buy: Framework
 - title: Communications solutions
   slug: communications-solutions
   category_slugs:
@@ -171,6 +183,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - broadband-wifi-telecomms
+  ways_to_buy: Framework
 - title: Communications solutions and associated telephony services
   slug: communications-telephony
   category_slugs:
@@ -182,6 +195,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - broadband-wifi-telecomms
+  ways_to_buy: Framework
 - title: Corporate software and related products and services
   slug: corporate-software
   category_slugs:
@@ -193,6 +207,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - ict-software-systems
+  ways_to_buy: Framework
 - title: Cyber security services 3 DPS
   slug: cyber-security-services-dps
   category_slugs:
@@ -204,6 +219,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - cyber-security
+  ways_to_buy: Framework
 - title: Debt resolution services Lot 1 only
   slug: debt-resolution-services
   category_slugs:
@@ -215,6 +231,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - debt-resolution-services
+  ways_to_buy: Framework
 - title: Early years furniture framework
   slug: early-years-furniture
   category_slugs:
@@ -226,6 +243,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - furniture
+  ways_to_buy: Framework
 - title: Education decarbonisation
   slug: education-decarbonisation
   category_slugs:
@@ -239,6 +257,7 @@ solutions:
   subcategories:
   - renewables-energysaving-products
   - energy-audits-savings-debt-resolution
+  ways_to_buy: Framework
 - title: Education management systems
   slug: education-management-systems
   category_slugs:
@@ -250,6 +269,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - ict-software-systems
+  ways_to_buy: Framework
 - title: Education Professional Services
   slug: education-professional-services
 - title: Education services
@@ -263,6 +283,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - professional-services
+  ways_to_buy: Framework
 - title: Electric Vehicle Charging Points – Supply, installation, maintenance and
     consultancy
   slug: electric-vehicle-charging-points-supply-installation-maintenance-and-consultancy
@@ -279,6 +300,7 @@ solutions:
   subcategories:
   - grounds-estates-maintenance
   - renewables-energysaving-products
+  ways_to_buy: Framework
 - title: Electrical Testing services
   slug: electrical-testing-services
   category_slugs:
@@ -294,6 +316,7 @@ solutions:
   subcategories:
   - buildings
   - laptops-printers-ict-hardware
+  ways_to_buy: Framework
 - title: Electricity (for supply during 2024-2028)
   slug: electricity-espo
   category_slugs:
@@ -305,6 +328,7 @@ solutions:
   - energy-utilities
   subcategories:
   - electricity
+  ways_to_buy: Framework
 - title: Electronic catering management and payment solutions
   slug: electronic-catering-management-and-payment-solutions
   category_slugs:
@@ -320,6 +344,7 @@ solutions:
   subcategories:
   - ict-software-systems
   - catering-equipment
+  ways_to_buy: Framework
 - title: Supply of energy 2
   slug: energy-ancillary
   category_slugs:
@@ -337,6 +362,7 @@ solutions:
   - gas
   - electricity
   - professional-services
+  ways_to_buy: Framework
 - title: Energy cost recovery services for schools
   slug: energy-cost-recovery-services
 - title: DfE Energy for Schools
@@ -352,6 +378,7 @@ solutions:
   subcategories:
   - electricity
   - gas
+  ways_to_buy: DfE deal
 - title: Engineering inspection services
   slug: engineering-inspection-services
   category_slugs:
@@ -363,6 +390,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - health-safety-security
+  ways_to_buy: Framework
 - title: ESPO catalogue
   slug: espo-catalogue
   category_slugs:
@@ -390,6 +418,7 @@ solutions:
   - catering-services-staff
   - cleaning-services-equipment
   - health-safety-security
+  ways_to_buy: Catalogue
 - title: Estates and facilities professional services (DPS)
   slug: estates-and-facilities-professional-services
   category_slugs:
@@ -405,6 +434,7 @@ solutions:
   subcategories:
   - grounds-estates-maintenance
   - professional-services
+  ways_to_buy: DPS
 - title: Exterior building services DPS
   slug: exterior-building-services-dps
   category_slugs:
@@ -416,6 +446,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - buildings
+  ways_to_buy: DPS
 - title: Facilities supplies
   slug: facilities-supplies
   category_slugs:
@@ -433,6 +464,7 @@ solutions:
   - renewables-energysaving-products
   - lighting
   - grounds-estates-maintenance
+  ways_to_buy: Framework
 - title: Financial leasing solutions
   slug: financial-leasing-solutions
   category_slugs:
@@ -444,6 +476,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - financial-audit-payroll
+  ways_to_buy: Framework
 - title: Findel Education catalogue
   slug: findel-education-catalogue
   category_slugs:
@@ -465,6 +498,7 @@ solutions:
   - furniture
   - sports-equipment
   - send-products
+  ways_to_buy: Catalogue
 - title: Fire safety products and services
   slug: fire-safety-products-and-services
 - title: Fixed and flexible electricity and gas frameworks
@@ -480,6 +514,7 @@ solutions:
   subcategories:
   - gas
   - electricity
+  ways_to_buy: Framework
 - title: Flexible electricity
   slug: flex-electricity
   category_slugs:
@@ -491,6 +526,7 @@ solutions:
   - energy-utilities
   subcategories:
   - electricity
+  ways_to_buy: Framework
 - title: Flexible gas
   slug: flexible-gas-framework
   category_slugs:
@@ -502,6 +538,7 @@ solutions:
   - energy-utilities
   subcategories:
   - gas
+  ways_to_buy: Framework
 - title: Building in use - support services DPS
   slug: fm-support-services-dps
   category_slugs:
@@ -521,6 +558,7 @@ solutions:
   - health-safety-security
   - catering-staff
   - catering-services-staff
+  ways_to_buy: DPS
 - title: Facilities management and workplace services DPS
   slug: fm-workplace-dps
   category_slugs:
@@ -540,6 +578,7 @@ solutions:
   - health-safety-security
   - grounds-estates-maintenance
   - catering-staff
+  ways_to_buy: DPS
 - title: Food and drink - dynamic purchasing system (DPS)
   slug: food-and-drink-dynamic-purchasing-system-dps
   category_slugs:
@@ -551,6 +590,7 @@ solutions:
   - catering
   subcategories:
   - food
+  ways_to_buy: DPS
 - title: Food and drink - framework
   slug: food-and-drink-framework
   category_slugs:
@@ -562,6 +602,7 @@ solutions:
   - catering
   subcategories:
   - food
+  ways_to_buy: Framework
 - title: Food and drink vending solution
   slug: food-and-drink-vending-solution
   category_slugs:
@@ -575,6 +616,7 @@ solutions:
   subcategories:
   - catering-equipment
   - vending-machines
+  ways_to_buy: Framework
 - title: Furniture and associated services
   slug: furniture-and-associated-services
   category_slugs:
@@ -586,6 +628,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - furniture
+  ways_to_buy: Framework
 - title: G-Cloud 14
   slug: g-cloud
   category_slugs:
@@ -601,6 +644,7 @@ solutions:
   - ict-software-systems
   - laptops-printers-ict-hardware
   - broadband-wifi-telecomms
+  ways_to_buy: Framework
 - title: Language services
   slug: gca-language-services
 - title: GCA purchasing platform catalogue
@@ -618,6 +662,7 @@ solutions:
   - ict-software-systems
   - cameras-av-equipment
   - laptops-printers-ict-hardware
+  ways_to_buy: Catalogue
 - title: Grounds maintenance & associated services
   slug: grounds-maintenance-and-associated-services
   category_slugs:
@@ -629,6 +674,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - grounds-estates-maintenance
+  ways_to_buy: Framework
 - title: Grounds maintenance services
   slug: grounds-maintenance-services
   category_slugs:
@@ -640,6 +686,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - grounds-estates-maintenance
+  ways_to_buy: Framework
 - title: HR, payroll and employee screening services
   slug: hr-payroll-and-employee-screening
   category_slugs:
@@ -651,6 +698,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - hr-recruitment
+  ways_to_buy: Framework
 - title: HR support services
   slug: hr-support-services
   category_slugs:
@@ -662,6 +710,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - hr-recruitment
+  ways_to_buy: Framework
 - title: ICT hardware and peripherals equipment
   slug: ict-hardware-and-peripherals-equipment
 - title: ICT Managed services & consultancy
@@ -681,6 +730,7 @@ solutions:
   - ict-software-systems
   - cyber-security
   - professional-services
+  ways_to_buy: Framework
 - title: ICT network, storage and service solutions
   slug: ict-network-storage-and-service-solutions
   category_slugs:
@@ -696,6 +746,7 @@ solutions:
   - cyber-security
   - cloud-services-ai-data-storage
   - broadband-wifi-telecomms
+  ways_to_buy: Framework
 - title: Everything ICT
   slug: ict-procurement
   category_slugs:
@@ -713,6 +764,7 @@ solutions:
   - broadband-wifi-telecomms
   - ict-software-systems
   - laptops-printers-ict-hardware
+  ways_to_buy: Framework
 - title: Insurance and associated services (Lot 3 only)
   slug: insurance-and-associated-services-lot-three-only
   category_slugs:
@@ -724,6 +776,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - insurance
+  ways_to_buy: Framework
 - title: Internal audit, assurance and counter fraud investigation services
   slug: internal-audit-assurance-and-counter-fraud-investigation-services
   category_slugs:
@@ -735,6 +788,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - financial-audit-payroll
+  ways_to_buy: Framework
 - title: IT, hardware, ITAD & associated services
   slug: it-hardware-itad-and-associated-services
 - title: Language services
@@ -750,6 +804,7 @@ solutions:
   subcategories:
   - language-services
   - professional-services
+  ways_to_buy: Framework
 - title: LED Lighting
   slug: led-lighting
 - title: LED Lighting
@@ -767,6 +822,7 @@ solutions:
   subcategories:
   - renewables-energysaving-products
   - lighting
+  ways_to_buy: Framework
 - title: Legal Services
   slug: legal-services
   category_slugs:
@@ -778,6 +834,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - legal-services
+  ways_to_buy: Framework
 - title: Legal services – wider public sector
   slug: legal-services-wider-public-sector
   category_slugs:
@@ -789,6 +846,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - legal-services
+  ways_to_buy: Framework
 - title: Library resources, software and associated services
   slug: library-resources-software-and-associated-services
 - title: Liquid fuels
@@ -802,6 +860,7 @@ solutions:
   - energy-utilities
   subcategories:
   - other-fuels
+  ways_to_buy: Framework
 - title: Low energy lighting DPS
   slug: low-energy-lighting-dps
   category_slugs:
@@ -817,6 +876,7 @@ solutions:
   subcategories:
   - renewables-energysaving-products
   - lighting
+  ways_to_buy: DPS
 - title: Mains gas 2023
   slug: mains-gas-espo
   category_slugs:
@@ -828,6 +888,7 @@ solutions:
   - energy-utilities
   subcategories:
   - gas
+  ways_to_buy: Framework
 - title: Multifunctional devices and associated products and services (including print
     and design)
   slug: mfd-and-associated-products-and-services-including-print-and-design
@@ -842,6 +903,7 @@ solutions:
   subcategories:
   - cloud-services-ai-data-storage
   - laptops-printers-ict-hardware
+  ways_to_buy: Framework
 - title: Minor works DPS 2
   slug: minor-works-dps-2
   category_slugs:
@@ -853,6 +915,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - buildings
+  ways_to_buy: DPS
 - title: Multifunctional Devices, GovPrint Hardware, Managed Print Provision and Digital
     Workflow Software Services
   slug: multifunctional-devices-govprint-hardware-managed-print-provision-digital-workflow-software-services
@@ -869,6 +932,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - broadband-wifi-telecomms
+  ways_to_buy: Framework
 - title: National professional qualification (NPQ) courses
   slug: npq
 - title: Occupational health services
@@ -882,6 +946,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - hr-recruitment
+  ways_to_buy: Framework
 - title: Outdoor playground equipment, fitness and sport facilities and equipment
   slug: outdoor-playground-equipment-fitness-and-sport-facilities-and-equipment
 - title: Outdoor sports surfaces and activity equipment
@@ -901,6 +966,7 @@ solutions:
   - sports-equipment
   - send-products
   - sports-grounds-facilities-equipment
+  ways_to_buy: Framework
 - title: Catering services
   slug: outsourced-catering
   category_slugs:
@@ -914,6 +980,7 @@ solutions:
   subcategories:
   - catering-services-staff
   - breakfast-club
+  ways_to_buy: Framework
 - title: Outsourced catering services
   slug: outsourced-catering-cpc
   category_slugs:
@@ -925,6 +992,7 @@ solutions:
   - catering
   subcategories:
   - catering-services-staff
+  ways_to_buy: Framework
 - title: Pest control products & services
   slug: pest-control-products-and-services
 - title: Photographic equipment and consumables
@@ -942,6 +1010,7 @@ solutions:
   subcategories:
   - laptops-av-classroom-tech
   - cameras-av-equipment
+  ways_to_buy: Framework
 - title: Playground, fitness and sports facilities and leisure facilities
   slug: playground-fitness-and-sports-facilities-and-leisure-facilities
 - title: Print books
@@ -955,6 +1024,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - books
+  ways_to_buy: Framework
 - title: Print Marketplace 2
   slug: print-marketplace-2
   category_slugs:
@@ -966,6 +1036,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - printed-materials
+  ways_to_buy: Framework
 - title: Promotional merchandise
   slug: promotional-merchandise
   category_slugs:
@@ -977,6 +1048,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - printed-materials
+  ways_to_buy: Framework
 - title: Property refurbishment, maintenance and management
   slug: property-refurbishment-maintenance-and-management
   category_slugs:
@@ -984,6 +1056,7 @@ solutions:
   primary_category: buildings-maintenance
   categories:
   - buildings-maintenance
+  ways_to_buy: Framework
 - title: Public sector legal services
   slug: public-sector-legal-services
   category_slugs:
@@ -995,6 +1068,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - legal-services
+  ways_to_buy: Framework
 - title: Records information management
   slug: records-information-management
 - title: Risk protection arrangement – alternative to commercial insurance
@@ -1010,6 +1084,7 @@ solutions:
   - catering
   subcategories:
   - food
+  ways_to_buy: Framework
 - title: Sandwiches, ready meals, meal concepts and food to go
   slug: sandwiches-ready-meals-meal-concepts-and-food-to-go
   category_slugs:
@@ -1021,6 +1096,7 @@ solutions:
   - catering
   subcategories:
   - food
+  ways_to_buy: Framework
 - title: Sensory equipment and associated services
   slug: sensory-equipment-and-associated-services
   category_slugs:
@@ -1032,6 +1108,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - send-products
+  ways_to_buy: Framework
 - title: Signs and associated services
   slug: signs-and-associated-services
   category_slugs:
@@ -1047,6 +1124,7 @@ solutions:
   - buildings
   - health-safety-security
   - grounds-estates-maintenance
+  ways_to_buy: Framework
 - title: Software application solutions - dynamic purchasing system (DPS)
   slug: software-application-solutions-dps
   category_slugs:
@@ -1058,6 +1136,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - ict-software-systems
+  ways_to_buy: DPS
 - title: Software licenses and associated services for academies and schools
   slug: software-licenses
   category_slugs:
@@ -1071,6 +1150,7 @@ solutions:
   subcategories:
   - ict-software-systems
   - cyber-security
+  ways_to_buy: Framework
 - title: Software products & associated services
   slug: software-products-and-associated-services
   category_slugs:
@@ -1082,6 +1162,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - ict-software-systems
+  ways_to_buy: Framework
 - title: Solar photovoltaic
   slug: solar-photovoltaic
 - title: Specialist professional services
@@ -1095,6 +1176,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - professional-services
+  ways_to_buy: Framework
 - title: Sports facilities installation, refurbishment and maintenance
   slug: sports-facilities-installation-refurbishment-and-maintenance
   category_slugs:
@@ -1108,6 +1190,7 @@ solutions:
   subcategories:
   - sports-grounds-facilities-equipment
   - buildings
+  ways_to_buy: Framework
 - title: Staff absence protection and reimbursement services 2025
   slug: staff-absence-protection-and-reimbursement-services
   category_slugs:
@@ -1123,6 +1206,7 @@ solutions:
   subcategories:
   - hr-recruitment
   - insurance
+  ways_to_buy: Framework
 - title: Stationery, paper and education supplies
   slug: stationery-paper-and-education-supplies
   category_slugs:
@@ -1134,6 +1218,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - classroom-office-supplies
+  ways_to_buy: Framework
 - title: Supply and installation of Solar PV
   slug: supply-and-installation-of-solar-pv
 - title: Supply of mains gas
@@ -1147,6 +1232,7 @@ solutions:
   - energy-utilities
   subcategories:
   - gas
+  ways_to_buy: Framework
 - title: Supply Teachers and Education Recruitment
   slug: supply-teachers
   category_slugs:
@@ -1158,6 +1244,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - hr-recruitment
+  ways_to_buy: Framework
 - title: Sustainable hardware, asset recycling and data destruction
   slug: sustainable-hardware-asset-recycling-and-data-destruction
   category_slugs:
@@ -1169,6 +1256,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - laptops-printers-ict-hardware
+  ways_to_buy: Framework
 - title: Technology products and associated services 2
   slug: technology-products-and-associated-services-2
   category_slugs:
@@ -1184,6 +1272,7 @@ solutions:
   - ict-software-systems
   - laptops-printers-ict-hardware
   - cloud-services-ai-data-storage
+  ways_to_buy: Framework
 - title: Temporary and semi-permanent buildings
   slug: temporary-and-semi-permanent-buildings
   category_slugs:
@@ -1195,6 +1284,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - buildings
+  ways_to_buy: Framework
 - title: Total cleaning service solutions
   slug: total-cleaning-service-solutions
   category_slugs:
@@ -1206,6 +1296,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - cleaning-services-equipment
+  ways_to_buy: Framework
 - title: Total facilities management
   slug: total-facilities-management
   category_slugs:
@@ -1217,6 +1308,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - facilities-management
+  ways_to_buy: Framework
 - title: Training, learning and development managed services
   slug: training-learning-and-development-managed-services
 - title: Student transport DPS
@@ -1226,6 +1318,7 @@ solutions:
   primary_category: transport
   categories:
   - transport
+  ways_to_buy: DPS
 - title: Utilities supplies and services
   slug: utilities-supply-services
   category_slugs:
@@ -1243,6 +1336,7 @@ solutions:
   - energy-audits-savings-debt-resolution
   - renewables-energysaving-products
   - professional-services
+  ways_to_buy: Framework
 - title: Vehicle daily rental
   slug: vehicle-daily-rental
 - title: Vehicle purchase
@@ -1252,6 +1346,7 @@ solutions:
   primary_category: transport
   categories:
   - transport
+  ways_to_buy: Framework
 - title: Waste management services
   slug: waste-management-services
   category_slugs:
@@ -1263,6 +1358,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - buildings
+  ways_to_buy: Framework
 - title: Water, wastewater and ancillary services
   slug: water-wastewater-and-ancillary-services
 - title: Wheelie bin containers and kerbside recycling containers
@@ -1290,3 +1386,4 @@ solutions:
   - sports-equipment
   - send-products
   - laptops-av-classroom-tech
+  ways_to_buy: Catalogue

--- a/config/solutions.yml
+++ b/config/solutions.yml
@@ -1,0 +1,251 @@
+---
+solutions:
+- title: Ambient, chilled, frozen foods and fresh fruit, vegetables and salad
+  slug: ambient-chilled-frozen-foods-and-fresh-fruit-vegetables-and-salad
+- title: Apprenticeships and associated training
+  slug: apprenticeships-and-associated-training
+- title: Asbestos inspection & removal services
+  slug: asbestos-inspection-and-removal-services
+- title: Audio-Visual equipment and installation services
+  slug: audio-visual-equipment-and-installation-services
+- title: 'Audio Visual Solutions '
+  slug: audio-visual-solutions
+- title: Audit and financial services
+  slug: audit-and-financial-services
+- title: Books, e-books and associated services
+  slug: books-e-books-and-associated-services
+- title: Building cleaning
+  slug: building-cleaning
+- title: Buildings internal fit-out and maintenance  - dynamic purchasing system (DPS)
+  slug: buildings-internal-fit-out-and-maintenance-dps
+- title: Business support services
+  slug: business-support-services
+- title: Buying better food and drink
+  slug: buying-better-food-and-drink
+- title: Catering services - dynamic purchasing system (DPS)
+  slug: catering-services-dps
+- title: Catering, vending machines & water cooler solutions
+  slug: catering-vending-machines-and-water-cooler-solutions
+- title: CCTV access solutions and security services
+  slug: cctv-access-solutions-and-security-services
+- title: Cleaning services
+  slug: cleaning-services
+- title: 'Cloud services, AI, data centre management and transformation solutions '
+  slug: cloud-services-ai-data-centre-management-and-transformation-solutions
+- title: Communications solutions
+  slug: communications-solutions
+- title: Communications solutions and associated telephony services
+  slug: communications-telephony
+- title: Corporate software and related products and services
+  slug: corporate-software
+- title: Cyber security services 3 DPS
+  slug: cyber-security-services-dps
+- title: Debt resolution services Lot 1 only
+  slug: debt-resolution-services
+- title: Early years furniture framework
+  slug: early-years-furniture
+- title: Education decarbonisation
+  slug: education-decarbonisation
+- title: Education management systems
+  slug: education-management-systems
+- title: Education Professional Services
+  slug: education-professional-services
+- title: Education services
+  slug: education-services
+- title: Electric Vehicle Charging Points – Supply, installation, maintenance and
+    consultancy
+  slug: electric-vehicle-charging-points-supply-installation-maintenance-and-consultancy
+- title: Electrical Testing services
+  slug: electrical-testing-services
+- title: 'Electricity (for supply during 2024-2028) '
+  slug: electricity-espo
+- title: 'Electronic catering management and payment solutions '
+  slug: electronic-catering-management-and-payment-solutions
+- title: Supply of energy 2
+  slug: energy-ancillary
+- title: Energy cost recovery services for schools
+  slug: energy-cost-recovery-services
+- title: DfE Energy for Schools
+  slug: energy-for-schools
+- title: Engineering inspection services
+  slug: engineering-inspection-services
+- title: ESPO catalogue
+  slug: espo-catalogue
+- title: Estates and facilities professional services (DPS)
+  slug: estates-and-facilities-professional-services
+- title: Exterior building services DPS
+  slug: exterior-building-services-dps
+- title: Facilities supplies
+  slug: facilities-supplies
+- title: 'Financial leasing solutions '
+  slug: financial-leasing-solutions
+- title: Findel Education catalogue
+  slug: findel-education-catalogue
+- title: Fire safety products and services
+  slug: fire-safety-products-and-services
+- title: Fixed and flexible electricity and gas frameworks
+  slug: fixed-and-flexible-gas
+- title: Flexible electricity
+  slug: flex-electricity
+- title: Flexible gas
+  slug: flexible-gas-framework
+- title: Building in use - support services DPS
+  slug: fm-support-services-dps
+- title: Facilities management and workplace services DPS
+  slug: fm-workplace-dps
+- title: Food and drink - dynamic purchasing system (DPS)
+  slug: food-and-drink-dynamic-purchasing-system-dps
+- title: Food and drink - framework
+  slug: food-and-drink-framework
+- title: Food and drink vending solution
+  slug: food-and-drink-vending-solution
+- title: Furniture and associated services
+  slug: furniture-and-associated-services
+- title: G-Cloud 14
+  slug: g-cloud
+- title: Language services
+  slug: gca-language-services
+- title: GCA purchasing platform catalogue
+  slug: gca-purchasing-platform-catalogue
+- title: Grounds maintenance & associated services
+  slug: grounds-maintenance-and-associated-services
+- title: Grounds maintenance services
+  slug: grounds-maintenance-services
+- title: HR, payroll and employee screening services
+  slug: hr-payroll-and-employee-screening
+- title: HR support services
+  slug: hr-support-services
+- title: 'ICT hardware and peripherals equipment '
+  slug: ict-hardware-and-peripherals-equipment
+- title: ICT Managed services & consultancy
+  slug: ict-managed-services-and-consultancy
+- title: ICT network, storage and service solutions
+  slug: ict-network-storage-and-service-solutions
+- title: Everything ICT
+  slug: ict-procurement
+- title: Insurance and associated services (Lot 3 only)
+  slug: insurance-and-associated-services-lot-three-only
+- title: Internal audit, assurance and counter fraud investigation services
+  slug: internal-audit-assurance-and-counter-fraud-investigation-services
+- title: IT, hardware, ITAD & associated services
+  slug: it-hardware-itad-and-associated-services
+- title: Language services
+  slug: language-services
+- title: LED Lighting
+  slug: led-lighting
+- title: LED Lighting
+  slug: led-lights
+- title: Legal Services
+  slug: legal-services
+- title: Legal services – wider public sector
+  slug: legal-services-wider-public-sector
+- title: Library resources, software and associated services
+  slug: library-resources-software-and-associated-services
+- title: Liquid fuels
+  slug: liquid-fuel-espo
+- title: Low energy lighting DPS
+  slug: low-energy-lighting-dps
+- title: Mains gas 2023
+  slug: mains-gas-espo
+- title: Multifunctional devices and associated products and services (including print
+    and design)
+  slug: mfd-and-associated-products-and-services-including-print-and-design
+- title: Minor works DPS 2
+  slug: minor-works-dps-2
+- title: Multifunctional Devices, GovPrint Hardware, Managed Print Provision and Digital
+    Workflow Software Services
+  slug: multifunctional-devices-govprint-hardware-managed-print-provision-digital-workflow-software-services
+- title: Musical instruments, equipment and technology
+  slug: musical-instruments-equipment-and-technology
+- title: Network connectivity and telecommunication solutions
+  slug: network-connectivity-and-telecommunication-solutions
+- title: National professional qualification (NPQ) courses
+  slug: npq
+- title: Occupational health services
+  slug: occupational-health-services
+- title: Outdoor playground equipment, fitness and sport facilities and equipment
+  slug: outdoor-playground-equipment-fitness-and-sport-facilities-and-equipment
+- title: Outdoor sports surfaces and activity equipment
+  slug: outdoor-sports-surfaces-and-activity-equipment
+- title: Catering services
+  slug: outsourced-catering
+- title: 'Outsourced catering services '
+  slug: outsourced-catering-cpc
+- title: Pest control products & services
+  slug: pest-control-products-and-services
+- title: 'Photographic equipment and consumables '
+  slug: photographic-equipment-and-consumables
+- title: Playground, fitness and sports facilities and leisure facilities
+  slug: playground-fitness-and-sports-facilities-and-leisure-facilities
+- title: Print books
+  slug: print-books
+- title: 'Print Marketplace 2 '
+  slug: print-marketplace-2
+- title: Promotional merchandise
+  slug: promotional-merchandise
+- title: Property refurbishment, maintenance and management
+  slug: property-refurbishment-maintenance-and-management
+- title: 'Public sector legal services '
+  slug: public-sector-legal-services
+- title: Records information management
+  slug: records-information-management
+- title: Risk protection arrangement – alternative to commercial insurance
+  slug: rpa
+- title: Sandwiches and food to go
+  slug: sandwiches-and-food-to-go
+- title: Sandwiches, ready meals, meal concepts and food to go
+  slug: sandwiches-ready-meals-meal-concepts-and-food-to-go
+- title: Sensory equipment and associated services
+  slug: sensory-equipment-and-associated-services
+- title: Signs and associated services
+  slug: signs-and-associated-services
+- title: Software application solutions - dynamic purchasing system (DPS)
+  slug: software-application-solutions-dps
+- title: 'Software licenses and associated services for academies and schools '
+  slug: software-licenses
+- title: Software products & associated services
+  slug: software-products-and-associated-services
+- title: Solar photovoltaic
+  slug: solar-photovoltaic
+- title: Specialist professional services
+  slug: specialist-professional-services
+- title: Sports facilities installation, refurbishment and maintenance
+  slug: sports-facilities-installation-refurbishment-and-maintenance
+- title: Staff absence protection and reimbursement services 2025
+  slug: staff-absence-protection-and-reimbursement-services
+- title: Stationery, paper and education supplies
+  slug: stationery-paper-and-education-supplies
+- title: Supply and installation of Solar PV
+  slug: supply-and-installation-of-solar-pv
+- title: Supply of mains gas
+  slug: supply-of-mains-gas
+- title: Supply Teachers and Education Recruitment
+  slug: supply-teachers
+- title: 'Sustainable hardware, asset recycling and data destruction '
+  slug: sustainable-hardware-asset-recycling-and-data-destruction
+- title: Technology products and associated services 2
+  slug: technology-products-and-associated-services-2
+- title: Temporary and semi-permanent buildings
+  slug: temporary-and-semi-permanent-buildings
+- title: Total cleaning service solutions
+  slug: total-cleaning-service-solutions
+- title: 'Total facilities management '
+  slug: total-facilities-management
+- title: Training, learning and development managed services
+  slug: training-learning-and-development-managed-services
+- title: Student transport DPS
+  slug: transport
+- title: Utilities supplies and services
+  slug: utilities-supply-services
+- title: Vehicle daily rental
+  slug: vehicle-daily-rental
+- title: Vehicle purchase
+  slug: vehicle-purchase
+- title: Waste management services
+  slug: waste-management-services
+- title: Water, wastewater and ancillary services
+  slug: water-wastewater-and-ancillary-services
+- title: Wheelie bin containers and kerbside recycling containers
+  slug: wheelie-bin-containers-and-kerbside-recycling-containers
+- title: YPO procurement product catalogue
+  slug: ypo-procurement

--- a/config/solutions.yml
+++ b/config/solutions.yml
@@ -74,7 +74,7 @@ solutions:
   subcategories:
   - cleaning-services-equipment
   ways_to_buy: Framework
-- title: Buildings internal fit-out and maintenance  - dynamic purchasing system (DPS)
+- title: Buildings internal fit-out and maintenance - dynamic purchasing system (DPS)
   slug: buildings-internal-fit-out-and-maintenance-dps
 - title: Business support services
   slug: business-support-services

--- a/config/solutions.yml
+++ b/config/solutions.yml
@@ -2,6 +2,12 @@
 solutions:
 - title: Ambient, chilled, frozen foods and fresh fruit, vegetables and salad
   slug: ambient-chilled-frozen-foods-and-fresh-fruit-vegetables-and-salad
+  primary_category: catering
+  categories:
+  - catering
+  subcategories:
+  - food
+  ways_to_buy: framework
 - title: Apprenticeships and associated training
   slug: apprenticeships-and-associated-training
   category_slugs:
@@ -13,9 +19,16 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - training-development
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Asbestos inspection & removal services
   slug: asbestos-inspection-and-removal-services
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - buildings
+  - health-safety-security
+  ways_to_buy: framework
 - title: Audio-Visual equipment and installation services
   slug: audio-visual-equipment-and-installation-services
   category_slugs:
@@ -31,7 +44,7 @@ solutions:
   subcategories:
   - laptops-av-classroom-tech
   - cameras-av-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Audio Visual Solutions
   slug: audio-visual-solutions
   category_slugs:
@@ -47,7 +60,7 @@ solutions:
   subcategories:
   - laptops-av-classroom-tech
   - cameras-av-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Audit and financial services
   slug: audit-and-financial-services
   category_slugs:
@@ -59,9 +72,14 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - financial-audit-payroll
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Books, e-books and associated services
   slug: books-e-books-and-associated-services
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - books
 - title: Building cleaning
   slug: building-cleaning
   category_slugs:
@@ -73,9 +91,17 @@ solutions:
   - buildings-maintenance
   subcategories:
   - cleaning-services-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Buildings internal fit-out and maintenance - dynamic purchasing system (DPS)
   slug: buildings-internal-fit-out-and-maintenance-dps
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - grounds-estates-maintenance
+  - buildings
+  - facilities-management
+  ways_to_buy: dps
 - title: Business support services
   slug: business-support-services
   category_slugs:
@@ -93,7 +119,7 @@ solutions:
   - hr-recruitment
   - professional-services
   - financial-audit-payroll
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Buying better food and drink
   slug: buying-better-food-and-drink
   category_slugs:
@@ -105,7 +131,7 @@ solutions:
   - catering
   subcategories:
   - food
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Catering services - dynamic purchasing system (DPS)
   slug: catering-services-dps
   category_slugs:
@@ -117,7 +143,7 @@ solutions:
   - catering
   subcategories:
   - catering-services-staff
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Catering, vending machines & water cooler solutions
   slug: catering-vending-machines-and-water-cooler-solutions
   category_slugs:
@@ -133,7 +159,7 @@ solutions:
   - breakfast-club
   - vending-machines
   - catering-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: CCTV access solutions and security services
   slug: cctv-access-solutions-and-security-services
   category_slugs:
@@ -147,7 +173,7 @@ solutions:
   subcategories:
   - grounds-estates-maintenance
   - health-safety-security
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Cleaning services
   slug: cleaning-services
   category_slugs:
@@ -159,7 +185,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - cleaning-services-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Cloud services, AI, data centre management and transformation solutions
   slug: cloud-services-ai-data-centre-management-and-transformation-solutions
   category_slugs:
@@ -171,7 +197,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - cloud-services-ai-data-storage
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Communications solutions
   slug: communications-solutions
   category_slugs:
@@ -183,7 +209,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - broadband-wifi-telecomms
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Communications solutions and associated telephony services
   slug: communications-telephony
   category_slugs:
@@ -195,7 +221,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - broadband-wifi-telecomms
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Corporate software and related products and services
   slug: corporate-software
   category_slugs:
@@ -207,7 +233,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - ict-software-systems
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Cyber security services 3 DPS
   slug: cyber-security-services-dps
   category_slugs:
@@ -219,7 +245,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - cyber-security
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Debt resolution services Lot 1 only
   slug: debt-resolution-services
   category_slugs:
@@ -231,7 +257,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - debt-resolution-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Early years furniture framework
   slug: early-years-furniture
   category_slugs:
@@ -243,7 +269,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - furniture
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Education decarbonisation
   slug: education-decarbonisation
   category_slugs:
@@ -257,7 +283,7 @@ solutions:
   subcategories:
   - renewables-energysaving-products
   - energy-audits-savings-debt-resolution
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Education management systems
   slug: education-management-systems
   category_slugs:
@@ -269,9 +295,15 @@ solutions:
   - ict-business-systems
   subcategories:
   - ict-software-systems
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Education Professional Services
   slug: education-professional-services
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - professional-services
+  - language-services
 - title: Education services
   slug: education-services
   category_slugs:
@@ -283,7 +315,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - professional-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Electric Vehicle Charging Points – Supply, installation, maintenance and
     consultancy
   slug: electric-vehicle-charging-points-supply-installation-maintenance-and-consultancy
@@ -300,7 +332,7 @@ solutions:
   subcategories:
   - grounds-estates-maintenance
   - renewables-energysaving-products
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Electrical Testing services
   slug: electrical-testing-services
   category_slugs:
@@ -312,11 +344,10 @@ solutions:
   primary_category: buildings-maintenance
   categories:
   - buildings-maintenance
-  - ict-business-systems
   subcategories:
   - buildings
-  - laptops-printers-ict-hardware
-  ways_to_buy: Framework
+  - health-safety-security
+  ways_to_buy: framework
 - title: Electricity (for supply during 2024-2028)
   slug: electricity-espo
   category_slugs:
@@ -328,7 +359,7 @@ solutions:
   - energy-utilities
   subcategories:
   - electricity
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Electronic catering management and payment solutions
   slug: electronic-catering-management-and-payment-solutions
   category_slugs:
@@ -344,7 +375,7 @@ solutions:
   subcategories:
   - ict-software-systems
   - catering-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Supply of energy 2
   slug: energy-ancillary
   category_slugs:
@@ -362,9 +393,17 @@ solutions:
   - gas
   - electricity
   - professional-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Energy cost recovery services for schools
   slug: energy-cost-recovery-services
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  - hr-people-professional-services
+  subcategories:
+  - energy-audits-savings-debt-resolution
+  - professional-services
+  ways_to_buy: dfe_deal
 - title: DfE Energy for Schools
   slug: energy-for-schools
   category_slugs:
@@ -378,7 +417,7 @@ solutions:
   subcategories:
   - electricity
   - gas
-  ways_to_buy: DfE deal
+  ways_to_buy: dfe_deal
 - title: Engineering inspection services
   slug: engineering-inspection-services
   category_slugs:
@@ -390,7 +429,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - health-safety-security
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: ESPO catalogue
   slug: espo-catalogue
   category_slugs:
@@ -418,7 +457,7 @@ solutions:
   - catering-services-staff
   - cleaning-services-equipment
   - health-safety-security
-  ways_to_buy: Catalogue
+  ways_to_buy: catalogue
 - title: Estates and facilities professional services (DPS)
   slug: estates-and-facilities-professional-services
   category_slugs:
@@ -434,7 +473,7 @@ solutions:
   subcategories:
   - grounds-estates-maintenance
   - professional-services
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Exterior building services DPS
   slug: exterior-building-services-dps
   category_slugs:
@@ -446,7 +485,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - buildings
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Facilities supplies
   slug: facilities-supplies
   category_slugs:
@@ -464,7 +503,7 @@ solutions:
   - renewables-energysaving-products
   - lighting
   - grounds-estates-maintenance
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Financial leasing solutions
   slug: financial-leasing-solutions
   category_slugs:
@@ -476,7 +515,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - financial-audit-payroll
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Findel Education catalogue
   slug: findel-education-catalogue
   category_slugs:
@@ -498,9 +537,15 @@ solutions:
   - furniture
   - sports-equipment
   - send-products
-  ways_to_buy: Catalogue
+  ways_to_buy: catalogue
 - title: Fire safety products and services
   slug: fire-safety-products-and-services
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - health-safety-security
+  ways_to_buy: framework
 - title: Fixed and flexible electricity and gas frameworks
   slug: fixed-and-flexible-gas
   category_slugs:
@@ -514,7 +559,7 @@ solutions:
   subcategories:
   - gas
   - electricity
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Flexible electricity
   slug: flex-electricity
   category_slugs:
@@ -526,7 +571,7 @@ solutions:
   - energy-utilities
   subcategories:
   - electricity
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Flexible gas
   slug: flexible-gas-framework
   category_slugs:
@@ -538,7 +583,7 @@ solutions:
   - energy-utilities
   subcategories:
   - gas
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Building in use - support services DPS
   slug: fm-support-services-dps
   category_slugs:
@@ -558,7 +603,7 @@ solutions:
   - health-safety-security
   - catering-staff
   - catering-services-staff
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Facilities management and workplace services DPS
   slug: fm-workplace-dps
   category_slugs:
@@ -578,7 +623,7 @@ solutions:
   - health-safety-security
   - grounds-estates-maintenance
   - catering-staff
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Food and drink - dynamic purchasing system (DPS)
   slug: food-and-drink-dynamic-purchasing-system-dps
   category_slugs:
@@ -590,7 +635,7 @@ solutions:
   - catering
   subcategories:
   - food
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Food and drink - framework
   slug: food-and-drink-framework
   category_slugs:
@@ -602,7 +647,7 @@ solutions:
   - catering
   subcategories:
   - food
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Food and drink vending solution
   slug: food-and-drink-vending-solution
   category_slugs:
@@ -616,7 +661,7 @@ solutions:
   subcategories:
   - catering-equipment
   - vending-machines
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Furniture and associated services
   slug: furniture-and-associated-services
   category_slugs:
@@ -628,7 +673,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - furniture
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: G-Cloud 14
   slug: g-cloud
   category_slugs:
@@ -644,9 +689,16 @@ solutions:
   - ict-software-systems
   - laptops-printers-ict-hardware
   - broadband-wifi-telecomms
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Language services
   slug: gca-language-services
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - language-services
+  - professional-services
+  ways_to_buy: framework
 - title: GCA purchasing platform catalogue
   slug: gca-purchasing-platform-catalogue
   category_slugs:
@@ -662,7 +714,7 @@ solutions:
   - ict-software-systems
   - cameras-av-equipment
   - laptops-printers-ict-hardware
-  ways_to_buy: Catalogue
+  ways_to_buy: catalogue
 - title: Grounds maintenance & associated services
   slug: grounds-maintenance-and-associated-services
   category_slugs:
@@ -674,7 +726,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - grounds-estates-maintenance
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Grounds maintenance services
   slug: grounds-maintenance-services
   category_slugs:
@@ -686,7 +738,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - grounds-estates-maintenance
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: HR, payroll and employee screening services
   slug: hr-payroll-and-employee-screening
   category_slugs:
@@ -698,7 +750,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - hr-recruitment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: HR support services
   slug: hr-support-services
   category_slugs:
@@ -710,9 +762,15 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - hr-recruitment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: ICT hardware and peripherals equipment
   slug: ict-hardware-and-peripherals-equipment
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - laptops-printers-ict-hardware
+  ways_to_buy: framework
 - title: ICT Managed services & consultancy
   slug: ict-managed-services-and-consultancy
   category_slugs:
@@ -730,7 +788,7 @@ solutions:
   - ict-software-systems
   - cyber-security
   - professional-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: ICT network, storage and service solutions
   slug: ict-network-storage-and-service-solutions
   category_slugs:
@@ -746,7 +804,7 @@ solutions:
   - cyber-security
   - cloud-services-ai-data-storage
   - broadband-wifi-telecomms
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Everything ICT
   slug: ict-procurement
   category_slugs:
@@ -764,7 +822,7 @@ solutions:
   - broadband-wifi-telecomms
   - ict-software-systems
   - laptops-printers-ict-hardware
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Insurance and associated services (Lot 3 only)
   slug: insurance-and-associated-services-lot-three-only
   category_slugs:
@@ -776,7 +834,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - insurance
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Internal audit, assurance and counter fraud investigation services
   slug: internal-audit-assurance-and-counter-fraud-investigation-services
   category_slugs:
@@ -788,9 +846,14 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - financial-audit-payroll
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: IT, hardware, ITAD & associated services
   slug: it-hardware-itad-and-associated-services
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - laptops-printers-ict-hardware
 - title: Language services
   slug: language-services
   category_slugs:
@@ -798,15 +861,23 @@ solutions:
   subcategory_slugs:
   - language-services
   - professional-services
-  primary_category: classroom-curriculum-office-supplies
+  primary_category: hr-people-professional-services
   categories:
-  - classroom-curriculum-office-supplies
+  - hr-people-professional-services
   subcategories:
   - language-services
   - professional-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: LED Lighting
   slug: led-lighting
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  - buildings-maintenance
+  subcategories:
+  - renewables-energysaving-products
+  - lighting
+  ways_to_buy: framework
 - title: LED Lighting
   slug: led-lights
   category_slugs:
@@ -822,7 +893,7 @@ solutions:
   subcategories:
   - renewables-energysaving-products
   - lighting
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Legal Services
   slug: legal-services
   category_slugs:
@@ -834,7 +905,7 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - legal-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Legal services – wider public sector
   slug: legal-services-wider-public-sector
   category_slugs:
@@ -846,9 +917,16 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - legal-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Library resources, software and associated services
   slug: library-resources-software-and-associated-services
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  - ict-business-systems
+  subcategories:
+  - books
+  - ict-software-systems
 - title: Liquid fuels
   slug: liquid-fuel-espo
   category_slugs:
@@ -860,7 +938,7 @@ solutions:
   - energy-utilities
   subcategories:
   - other-fuels
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Low energy lighting DPS
   slug: low-energy-lighting-dps
   category_slugs:
@@ -876,7 +954,7 @@ solutions:
   subcategories:
   - renewables-energysaving-products
   - lighting
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Mains gas 2023
   slug: mains-gas-espo
   category_slugs:
@@ -888,7 +966,7 @@ solutions:
   - energy-utilities
   subcategories:
   - gas
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Multifunctional devices and associated products and services (including print
     and design)
   slug: mfd-and-associated-products-and-services-including-print-and-design
@@ -903,7 +981,7 @@ solutions:
   subcategories:
   - cloud-services-ai-data-storage
   - laptops-printers-ict-hardware
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Minor works DPS 2
   slug: minor-works-dps-2
   category_slugs:
@@ -915,12 +993,23 @@ solutions:
   - buildings-maintenance
   subcategories:
   - buildings
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Multifunctional Devices, GovPrint Hardware, Managed Print Provision and Digital
     Workflow Software Services
   slug: multifunctional-devices-govprint-hardware-managed-print-provision-digital-workflow-software-services
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - laptops-printers-ict-hardware
 - title: Musical instruments, equipment and technology
   slug: musical-instruments-equipment-and-technology
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  subcategories:
+  - arts-crafts-music
+  - laptops-av-classroom-tech
 - title: Network connectivity and telecommunication solutions
   slug: network-connectivity-and-telecommunication-solutions
   category_slugs:
@@ -932,9 +1021,14 @@ solutions:
   - ict-business-systems
   subcategories:
   - broadband-wifi-telecomms
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: National professional qualification (NPQ) courses
   slug: npq
+  primary_category: hr-people-professional-services
+  categories:
+  - hr-people-professional-services
+  subcategories:
+  - training-development
 - title: Occupational health services
   slug: occupational-health-services
   category_slugs:
@@ -946,9 +1040,18 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - hr-recruitment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Outdoor playground equipment, fitness and sport facilities and equipment
   slug: outdoor-playground-equipment-fitness-and-sport-facilities-and-equipment
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  - buildings-maintenance
+  subcategories:
+  - sports-equipment
+  - sports-grounds-facilities-equipment
+  - facilities-management
+  ways_to_buy: framework
 - title: Outdoor sports surfaces and activity equipment
   slug: outdoor-sports-surfaces-and-activity-equipment
   category_slugs:
@@ -966,7 +1069,7 @@ solutions:
   - sports-equipment
   - send-products
   - sports-grounds-facilities-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Catering services
   slug: outsourced-catering
   category_slugs:
@@ -980,7 +1083,7 @@ solutions:
   subcategories:
   - catering-services-staff
   - breakfast-club
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Outsourced catering services
   slug: outsourced-catering-cpc
   category_slugs:
@@ -992,9 +1095,15 @@ solutions:
   - catering
   subcategories:
   - catering-services-staff
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Pest control products & services
   slug: pest-control-products-and-services
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - health-safety-security
+  ways_to_buy: framework
 - title: Photographic equipment and consumables
   slug: photographic-equipment-and-consumables
   category_slugs:
@@ -1010,9 +1119,17 @@ solutions:
   subcategories:
   - laptops-av-classroom-tech
   - cameras-av-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Playground, fitness and sports facilities and leisure facilities
   slug: playground-fitness-and-sports-facilities-and-leisure-facilities
+  primary_category: classroom-curriculum-office-supplies
+  categories:
+  - classroom-curriculum-office-supplies
+  - buildings-maintenance
+  subcategories:
+  - sports-equipment
+  - sports-grounds-facilities-equipment
+  ways_to_buy: framework
 - title: Print books
   slug: print-books
   category_slugs:
@@ -1024,7 +1141,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - books
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Print Marketplace 2
   slug: print-marketplace-2
   category_slugs:
@@ -1036,7 +1153,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - printed-materials
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Promotional merchandise
   slug: promotional-merchandise
   category_slugs:
@@ -1048,7 +1165,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - printed-materials
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Property refurbishment, maintenance and management
   slug: property-refurbishment-maintenance-and-management
   category_slugs:
@@ -1056,7 +1173,7 @@ solutions:
   primary_category: buildings-maintenance
   categories:
   - buildings-maintenance
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Public sector legal services
   slug: public-sector-legal-services
   category_slugs:
@@ -1068,11 +1185,23 @@ solutions:
   - finance-legal-insurance
   subcategories:
   - legal-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Records information management
   slug: records-information-management
+  primary_category: ict-business-systems
+  categories:
+  - ict-business-systems
+  subcategories:
+  - ict-software-systems
+  - cyber-security
 - title: Risk protection arrangement – alternative to commercial insurance
   slug: rpa
+  primary_category: finance-legal-insurance
+  categories:
+  - finance-legal-insurance
+  subcategories:
+  - insurance
+  ways_to_buy: dfe_deal
 - title: Sandwiches and food to go
   slug: sandwiches-and-food-to-go
   category_slugs:
@@ -1084,7 +1213,7 @@ solutions:
   - catering
   subcategories:
   - food
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Sandwiches, ready meals, meal concepts and food to go
   slug: sandwiches-ready-meals-meal-concepts-and-food-to-go
   category_slugs:
@@ -1096,7 +1225,7 @@ solutions:
   - catering
   subcategories:
   - food
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Sensory equipment and associated services
   slug: sensory-equipment-and-associated-services
   category_slugs:
@@ -1108,7 +1237,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - send-products
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Signs and associated services
   slug: signs-and-associated-services
   category_slugs:
@@ -1124,7 +1253,7 @@ solutions:
   - buildings
   - health-safety-security
   - grounds-estates-maintenance
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Software application solutions - dynamic purchasing system (DPS)
   slug: software-application-solutions-dps
   category_slugs:
@@ -1136,7 +1265,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - ict-software-systems
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Software licenses and associated services for academies and schools
   slug: software-licenses
   category_slugs:
@@ -1150,7 +1279,7 @@ solutions:
   subcategories:
   - ict-software-systems
   - cyber-security
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Software products & associated services
   slug: software-products-and-associated-services
   category_slugs:
@@ -1162,7 +1291,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - ict-software-systems
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Solar photovoltaic
   slug: solar-photovoltaic
 - title: Specialist professional services
@@ -1176,7 +1305,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - professional-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Sports facilities installation, refurbishment and maintenance
   slug: sports-facilities-installation-refurbishment-and-maintenance
   category_slugs:
@@ -1190,7 +1319,7 @@ solutions:
   subcategories:
   - sports-grounds-facilities-equipment
   - buildings
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Staff absence protection and reimbursement services 2025
   slug: staff-absence-protection-and-reimbursement-services
   category_slugs:
@@ -1206,7 +1335,7 @@ solutions:
   subcategories:
   - hr-recruitment
   - insurance
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Stationery, paper and education supplies
   slug: stationery-paper-and-education-supplies
   category_slugs:
@@ -1218,7 +1347,7 @@ solutions:
   - classroom-curriculum-office-supplies
   subcategories:
   - classroom-office-supplies
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Supply and installation of Solar PV
   slug: supply-and-installation-of-solar-pv
 - title: Supply of mains gas
@@ -1232,7 +1361,7 @@ solutions:
   - energy-utilities
   subcategories:
   - gas
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Supply Teachers and Education Recruitment
   slug: supply-teachers
   category_slugs:
@@ -1244,7 +1373,7 @@ solutions:
   - hr-people-professional-services
   subcategories:
   - hr-recruitment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Sustainable hardware, asset recycling and data destruction
   slug: sustainable-hardware-asset-recycling-and-data-destruction
   category_slugs:
@@ -1256,7 +1385,7 @@ solutions:
   - ict-business-systems
   subcategories:
   - laptops-printers-ict-hardware
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Technology products and associated services 2
   slug: technology-products-and-associated-services-2
   category_slugs:
@@ -1272,7 +1401,7 @@ solutions:
   - ict-software-systems
   - laptops-printers-ict-hardware
   - cloud-services-ai-data-storage
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Temporary and semi-permanent buildings
   slug: temporary-and-semi-permanent-buildings
   category_slugs:
@@ -1284,7 +1413,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - buildings
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Total cleaning service solutions
   slug: total-cleaning-service-solutions
   category_slugs:
@@ -1296,7 +1425,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - cleaning-services-equipment
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Total facilities management
   slug: total-facilities-management
   category_slugs:
@@ -1308,7 +1437,7 @@ solutions:
   - buildings-maintenance
   subcategories:
   - facilities-management
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Training, learning and development managed services
   slug: training-learning-and-development-managed-services
 - title: Student transport DPS
@@ -1318,7 +1447,7 @@ solutions:
   primary_category: transport
   categories:
   - transport
-  ways_to_buy: DPS
+  ways_to_buy: dps
 - title: Utilities supplies and services
   slug: utilities-supply-services
   category_slugs:
@@ -1336,9 +1465,12 @@ solutions:
   - energy-audits-savings-debt-resolution
   - renewables-energysaving-products
   - professional-services
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Vehicle daily rental
   slug: vehicle-daily-rental
+  primary_category: transport
+  categories:
+  - transport
 - title: Vehicle purchase
   slug: vehicle-purchase
   category_slugs:
@@ -1346,7 +1478,7 @@ solutions:
   primary_category: transport
   categories:
   - transport
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Waste management services
   slug: waste-management-services
   category_slugs:
@@ -1358,11 +1490,26 @@ solutions:
   - buildings-maintenance
   subcategories:
   - buildings
-  ways_to_buy: Framework
+  ways_to_buy: framework
 - title: Water, wastewater and ancillary services
   slug: water-wastewater-and-ancillary-services
+  primary_category: energy-utilities
+  categories:
+  - energy-utilities
+  - buildings-maintenance
+  subcategories:
+  - water
+  - buildings
+  ways_to_buy: framework
 - title: Wheelie bin containers and kerbside recycling containers
   slug: wheelie-bin-containers-and-kerbside-recycling-containers
+  primary_category: buildings-maintenance
+  categories:
+  - buildings-maintenance
+  subcategories:
+  - cleaning-services-equipment
+  - grounds-estates-maintenance
+  ways_to_buy: framework
 - title: YPO procurement product catalogue
   slug: ypo-procurement
   category_slugs:
@@ -1386,4 +1533,4 @@ solutions:
   - sports-equipment
   - send-products
   - laptops-av-classroom-tech
-  ways_to_buy: Catalogue
+  ways_to_buy: catalogue

--- a/doc/contentful-updates.md
+++ b/doc/contentful-updates.md
@@ -26,3 +26,19 @@ Both tasks require:
 - `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`
 
 Note that `CONTENTFUL_CMA_TOKEN` is intentionally not available during deployment to Azure so will have to be manually defined within a terminal session after connecting to Azure environment before running these rake tasks.
+
+### Exporting solutions to `config/solutions.yml`
+
+You can export the currently published solutions from Contentful into `config/solutions.yml` with:
+
+```sh
+bundle exec rake contentful:export_solutions
+```
+
+The exported file contains the `title` and `slug` for each published solution, ordered by slug for stable output.
+
+This task also requires:
+
+- `CONTENTFUL_CMA_TOKEN`
+- `CONTENTFUL_SPACE_ID`
+- `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`

--- a/doc/contentful-updates.md
+++ b/doc/contentful-updates.md
@@ -73,3 +73,41 @@ The intended workflow is:
 Matching is done by `Framework slug` when present. If that column is blank, the task falls back to matching by solution title. If `Framework slug` contains `ignore`, that spreadsheet row is skipped.
 
 The task prints a summary showing unmatched rows, unresolved category or subcategory values, ignored rows, and any solutions still missing mapped data.
+
+### Updating existing Contentful solutions from `config/solutions.yml`
+
+Once `config/solutions.yml` has been annotated with the correct category, subcategory and buying option slugs, you can apply that data back to existing Contentful solution entries with:
+
+```sh
+bundle exec rake contentful:update_solutions
+```
+
+This task:
+
+- reads the annotated `config/solutions.yml`
+- looks up existing published Contentful entries by slug for:
+  - solutions
+  - categories
+  - subcategories
+  - ways to buy
+- updates existing solution entries with:
+  - `primary_category`
+  - `categories`
+  - `subcategories`
+  - `ways_to_buy`
+
+The task does not create new solutions. If a solution slug from `config/solutions.yml` cannot be matched in Contentful, it is reported in the summary and skipped.
+
+If any referenced category, subcategory or ways to buy slug cannot be resolved in Contentful for a given solution, that solution is skipped rather than being partially updated. The task summary reports any unmatched:
+
+- solutions
+- categories
+- subcategories
+- ways to buy
+- solutions skipped because of unresolved references
+
+This task also requires:
+
+- `CONTENTFUL_CMA_TOKEN`
+- `CONTENTFUL_SPACE_ID`
+- `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`

--- a/doc/contentful-updates.md
+++ b/doc/contentful-updates.md
@@ -49,6 +49,36 @@ This task also requires:
 - `CONTENTFUL_SPACE_ID`
 - `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`
 
+### Creating redirects from `config/redirects.yml`
+
+Redirect entries can be created or updated in Contentful with:
+
+```sh
+bundle exec rake contentful:create_redirects
+```
+
+This task reads `config/redirects.yml` and upserts Redirect entries by `source_path`.
+
+Each redirect entry in the YAML file must define:
+
+- `title`
+- `source_path`
+- `destination_path`
+- `redirect_type`
+
+`redirect_type` must be either:
+
+- `permanent`
+- `temporary`
+
+The initial `config/redirects.yml` file includes the about-page redirect and the current legacy category redirects.
+
+This task also requires:
+
+- `CONTENTFUL_CMA_TOKEN`
+- `CONTENTFUL_SPACE_ID`
+- `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`
+
 ### Exporting solutions to `config/solutions.yml`
 
 You can export the currently published solutions from Contentful into `config/solutions.yml` with:

--- a/doc/contentful-updates.md
+++ b/doc/contentful-updates.md
@@ -8,12 +8,21 @@ New fields should be added with input from a developer. Significant changes shou
 
 ## Categories
 
-A webhook has been added to Contentful to keep track of changes to the `Category` content as it is **published**.
+### Creating categories from `config/categories.yml`
 
-The following fields may be updated with each published change:
-- `title`
-- `description`
-- `liquid_template`
-- `slug`
+The categories used by the public FABS pages can be created or updated in Contentful with the following rake tasks:
 
-As `liquid_template` determines the content of a user specification, any existing user specification may be affected by changes made to this field. Work to handle this has not yet started.
+```sh
+bundle exec rake contentful:create_subcategories
+bundle exec rake contentful:create_categories
+```
+
+Run `contentful:create_subcategories` first when you need to create or refresh the subcategory entries. After that, `contentful:create_categories` can be rerun on its own to map categories to the correct subcategories.
+
+Both tasks require:
+
+- `CONTENTFUL_CMA_TOKEN` this is a temporary admin token that lasts for 30 days
+- `CONTENTFUL_SPACE_ID`
+- `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`
+
+Note that `CONTENTFUL_CMA_TOKEN` is intentionally not available during deployment to Azure so will have to be manually defined within a terminal session after connecting to Azure environment before running these rake tasks.

--- a/doc/contentful-updates.md
+++ b/doc/contentful-updates.md
@@ -13,11 +13,12 @@ New fields should be added with input from a developer. Significant changes shou
 The categories used by the public FABS pages can be created or updated in Contentful with the following rake tasks:
 
 ```sh
+bundle exec rake contentful:create_ways_to_buy
 bundle exec rake contentful:create_subcategories
 bundle exec rake contentful:create_categories
 ```
 
-Run `contentful:create_subcategories` first when you need to create or refresh the subcategory entries. After that, `contentful:create_categories` can be rerun on its own to map categories to the correct subcategories.
+Run `contentful:create_ways_to_buy` when you need to create or refresh the fixed ways to buy entries used by solutions. Run `contentful:create_subcategories` first when you need to create or refresh the subcategory entries. After that, `contentful:create_categories` can be rerun on its own to map categories to the correct subcategories.
 
 Both tasks require:
 
@@ -26,6 +27,27 @@ Both tasks require:
 - `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`
 
 Note that `CONTENTFUL_CMA_TOKEN` is intentionally not available during deployment to Azure so will have to be manually defined within a terminal session after connecting to Azure environment before running these rake tasks.
+
+### Creating ways to buy entries
+
+The fixed ways to buy entries can be created or updated in Contentful with:
+
+```sh
+bundle exec rake contentful:create_ways_to_buy
+```
+
+This task creates or updates the following title and slug pairs:
+
+- `Catalogue` → `catalogue`
+- `DfE deal` → `dfe_deal`
+- `DPS` → `dps`
+- `Framework` → `framework`
+
+This task also requires:
+
+- `CONTENTFUL_CMA_TOKEN`
+- `CONTENTFUL_SPACE_ID`
+- `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`
 
 ### Exporting solutions to `config/solutions.yml`
 

--- a/doc/contentful-updates.md
+++ b/doc/contentful-updates.md
@@ -42,3 +42,34 @@ This task also requires:
 - `CONTENTFUL_CMA_TOKEN`
 - `CONTENTFUL_SPACE_ID`
 - `CONTENTFUL_ENVIRONMENT` if you are not using the default `master`
+
+### Annotating `config/solutions.yml` from the recategorisation spreadsheet
+
+After exporting the initial `config/solutions.yml`, you can enrich it with category, subcategory and buying option data from the recategorisation spreadsheet with:
+
+```sh
+bundle exec rake solutions:update_category_mapping
+```
+
+This task reads:
+
+- `config/solutions.yml` as the base list of published solutions exported from Contentful
+- `config/categories.yml` to translate category and subcategory names to slugs
+- `DO NOT EDIT - Categories_BuyingOptions(Recategorising frameworks).csv` as the source spreadsheet data
+
+The spreadsheet must be exported from Excel as `CSV UTF-8 (Comma delimited) (*.csv)`. Other CSV encodings may cause the rake task to misread headers or cell values.
+
+The intended workflow is:
+
+1. Export the current published solutions from Contentful into `config/solutions.yml`
+2. Maintain the recategorisation spreadsheet with category, subcategory, buying option and optional slug data
+3. Export that spreadsheet from Excel as UTF-8 CSV, replacing `DO NOT EDIT - Categories_BuyingOptions(Recategorising frameworks).csv`
+4. Run `bundle exec rake solutions:update_category_mapping` to annotate the exported solutions with:
+   - `primary_category`
+   - `categories`
+   - `subcategories`
+   - `ways_to_buy`
+
+Matching is done by `Framework slug` when present. If that column is blank, the task falls back to matching by solution title. If `Framework slug` contains `ignore`, that spreadsheet row is skipped.
+
+The task prints a summary showing unmatched rows, unresolved category or subcategory values, ignored rows, and any solutions still missing mapped data.

--- a/lib/tasks/contentful.rake
+++ b/lib/tasks/contentful.rake
@@ -20,6 +20,120 @@ namespace :contentful do
     puts "Wrote #{solutions.count} published solutions to #{file}"
   end
 
+  desc "Update existing Contentful solutions from config/solutions.yml"
+  task update_solutions: :environment do
+    puts "Updating Contentful solutions from config/solutions.yml..."
+
+    environment = contentful_environment
+    solutions_data = YAML.load_file(Rails.root.join("config/solutions.yml")).fetch("solutions", [])
+
+    solutions_by_slug = published_entries_by_slug(environment, "solution")
+    categories_by_slug = published_entries_by_slug(environment, "category")
+    subcategories_by_slug = published_entries_by_slug(environment, "subcategory")
+    ways_to_buy_by_slug = published_entries_by_slug(environment, "ways_to_buy")
+
+    updated = 0
+    unmatched_solutions = []
+    unmatched_categories = []
+    unmatched_subcategories = []
+    unmatched_ways_to_buy = []
+    skipped_solutions = []
+
+    solutions_data.each do |solution_data|
+      solution_slug = solution_data["slug"].to_s
+      solution_entry = solutions_by_slug[solution_slug]
+
+      if solution_entry.nil?
+        unmatched_solutions << solution_slug
+        next
+      end
+
+      primary_category_slug = solution_data["primary_category"].presence
+      category_slugs = Array(solution_data["categories"]).presence || []
+      subcategory_slugs = Array(solution_data["subcategories"]).presence || []
+      ways_to_buy_slug = solution_data["ways_to_buy"].presence
+
+      primary_category_entry = primary_category_slug && categories_by_slug[primary_category_slug]
+      category_entries = category_slugs.filter_map { |slug| categories_by_slug[slug] }
+      subcategory_entries = subcategory_slugs.filter_map { |slug| subcategories_by_slug[slug] }
+      ways_to_buy_entry = ways_to_buy_slug && ways_to_buy_by_slug[ways_to_buy_slug]
+
+      if primary_category_slug.present? && primary_category_entry.nil?
+        unmatched_categories << { solution: solution_slug, slug: primary_category_slug }
+      end
+
+      (category_slugs - category_entries.map { |entry| entry.fields[:slug] }).each do |slug|
+        unmatched_categories << { solution: solution_slug, slug: }
+      end
+
+      (subcategory_slugs - subcategory_entries.map { |entry| entry.fields[:slug] }).each do |slug|
+        unmatched_subcategories << { solution: solution_slug, slug: }
+      end
+
+      if ways_to_buy_slug.present? && ways_to_buy_entry.nil?
+        unmatched_ways_to_buy << { solution: solution_slug, slug: ways_to_buy_slug }
+      end
+
+      if primary_category_slug.present? && primary_category_entry.nil? ||
+          category_entries.size != category_slugs.size ||
+          subcategory_entries.size != subcategory_slugs.size ||
+          ways_to_buy_slug.present? && ways_to_buy_entry.nil?
+        skipped_solutions << solution_slug
+        next
+      end
+
+      update_attributes = {}
+      update_attributes[:primary_category] = primary_category_entry if primary_category_slug.present?
+      update_attributes[:categories] = category_entries if solution_data.key?("categories")
+      update_attributes[:subcategories] = subcategory_entries if solution_data.key?("subcategories")
+
+      if ways_to_buy_slug.present?
+        ways_to_buy_field = solution_buying_option_field(solution_entry)
+        update_attributes[ways_to_buy_field] = ways_to_buy_entry if ways_to_buy_field
+      end
+
+      next if update_attributes.empty?
+
+      puts "Updating #{solution_entry.title} (#{solution_slug})"
+      solution_entry.update(**update_attributes)
+      solution_entry.publish
+      updated += 1
+    end
+
+    puts "Updated #{updated} solutions"
+
+    if unmatched_solutions.any?
+      puts "Solutions not found: #{unmatched_solutions.uniq.count}"
+      unmatched_solutions.uniq.sort.each { |slug| puts "  - #{slug}" }
+    end
+
+    if unmatched_categories.any?
+      puts "Categories not found: #{unmatched_categories.uniq.count}"
+      unmatched_categories.uniq.sort_by { |item| [item[:slug], item[:solution]] }.each do |item|
+        puts "  - #{item[:slug]} (solution: #{item[:solution]})"
+      end
+    end
+
+    if unmatched_subcategories.any?
+      puts "Subcategories not found: #{unmatched_subcategories.uniq.count}"
+      unmatched_subcategories.uniq.sort_by { |item| [item[:slug], item[:solution]] }.each do |item|
+        puts "  - #{item[:slug]} (solution: #{item[:solution]})"
+      end
+    end
+
+    if unmatched_ways_to_buy.any?
+      puts "Ways to buy not found: #{unmatched_ways_to_buy.uniq.count}"
+      unmatched_ways_to_buy.uniq.sort_by { |item| [item[:slug], item[:solution]] }.each do |item|
+        puts "  - #{item[:slug]} (solution: #{item[:solution]})"
+      end
+    end
+
+    if skipped_solutions.any?
+      puts "Solutions skipped due to unresolved references: #{skipped_solutions.uniq.count}"
+      skipped_solutions.uniq.sort.each { |slug| puts "  - #{slug}" }
+    end
+  end
+
   desc "Create or update subcategories from config/categories.yml in Contentful"
   task create_subcategories: :environment do
     data = categories_config
@@ -280,6 +394,23 @@ def contentful_environment
   client = Contentful::Management::Client.new(ENV["CONTENTFUL_CMA_TOKEN"])
   space = client.spaces.find(ENV["CONTENTFUL_SPACE_ID"])
   space.environments.find(ENV.fetch("CONTENTFUL_ENVIRONMENT", "master"))
+end
+
+def published_entries_by_slug(environment, content_type)
+  environment.entries.all(content_type:, limit: 1000)
+    .select(&:published?)
+    .each_with_object({}) do |entry, entries_by_slug|
+      slug = entry.fields[:slug]
+      entries_by_slug[slug] = entry if slug.present?
+    end
+end
+
+def solution_buying_option_field(solution_entry)
+  fields = solution_entry.fields
+  return :ways_to_buy if fields.key?(:ways_to_buy)
+  return :buying_option_type if fields.key?(:buying_option_type)
+
+  :ways_to_buy
 end
 
 def each_subcategory(json_data)

--- a/lib/tasks/contentful.rake
+++ b/lib/tasks/contentful.rake
@@ -11,7 +11,7 @@ namespace :contentful do
     environment = contentful_environment
     solutions = environment.entries.all(content_type: "solution", limit: 1000)
       .select(&:published?)
-      .map { |entry| { "title" => entry.title, "slug" => entry.fields[:slug] } }
+      .map { |entry| { "title" => entry.title.strip, "slug" => entry.fields[:slug] } }
       .sort_by { |solution| solution["slug"] }
 
     file = Rails.root.join("config/solutions.yml")

--- a/lib/tasks/contentful.rake
+++ b/lib/tasks/contentful.rake
@@ -3,48 +3,51 @@ require "contentful/management"
 
 # rubocop:disable Rails/SaveBang
 namespace :contentful do
-  desc "Create categories and subcategories from config/categories.yml in Contentful"
-  task create_categories: :environment do
-    data = YAML.load_file(Rails.root.join("config/categories.yml"))
-    client = Contentful::Management::Client.new(ENV["CONTENTFUL_CMA_TOKEN"])
-    space = client.spaces.find(ENV["CONTENTFUL_SPACE_ID"])
-    environment = space.environments.find(ENV.fetch("CONTENTFUL_ENVIRONMENT", "master"))
-
+  desc "Create or update subcategories from config/categories.yml in Contentful"
+  task create_subcategories: :environment do
+    data = categories_config
+    environment = contentful_environment
     subcategory_type = environment.content_types.find("subcategory")
-    category_type = environment.content_types.find("category")
 
-    subcategories_by_slug = {}
+    each_subcategory(data) do |sub_category|
+      slug = sub_category["slug"]
+      entry = find_entry_by_slug(environment, "subcategory", slug)
 
-    data.fetch("categories", []).each do |category|
-      Array(category["subcategories"]).each do |sub_category|
-        slug = sub_category["slug"]
-        next if subcategories_by_slug.key?(slug)
-
-        entry = find_entry_by_slug(environment, "subcategory", slug)
-
-        if entry
-          puts "Updating subcategory #{sub_category['name']} (#{slug})"
-          entry.update(
-            title: sub_category["name"],
-            slug:,
-          )
-        else
-          puts "Creating subcategory #{sub_category['name']} (#{slug})"
-          entry = subcategory_type.entries.create(
-            id: slug,
-            title: sub_category["name"],
-            slug:,
-          )
-        end
-
-        entry.publish
-        subcategories_by_slug[slug] = entry
+      if entry
+        puts "Updating subcategory #{sub_category['name']} (#{slug})"
+        entry.update(
+          title: sub_category["name"],
+          slug:,
+        )
+      else
+        puts "Creating subcategory #{sub_category['name']} (#{slug})"
+        entry = subcategory_type.entries.create(
+          id: slug,
+          title: sub_category["name"],
+          slug:,
+        )
       end
+
+      entry.publish
     end
+
+    puts "Subcategory creation complete."
+  end
+
+  desc "Create or update categories from config/categories.yml in Contentful"
+  task create_categories: :environment do
+    data = categories_config
+    environment = contentful_environment
+    category_type = environment.content_types.find("category")
 
     data.fetch("categories", []).each do |category|
       slug = category["slug"]
-      subcategory_entries = Array(category["subcategories"]).map { |sub_category| subcategories_by_slug.fetch(sub_category["slug"]) }
+      subcategory_entries = Array(category["subcategories"]).map do |sub_category|
+        entry = find_entry_by_slug(environment, "subcategory", sub_category["slug"])
+        raise "Missing subcategory #{sub_category['name']} (#{sub_category['slug']}). Run contentful:create_subcategories first." unless entry
+
+        entry
+      end
       entry = find_entry_by_slug(environment, "category", slug)
 
       if entry
@@ -252,11 +255,27 @@ namespace :contentful do
   end
 end
 
+def categories_config
+  YAML.load_file(Rails.root.join("config/categories.yml"))
+end
+
+def contentful_environment
+  client = Contentful::Management::Client.new(ENV["CONTENTFUL_CMA_TOKEN"])
+  space = client.spaces.find(ENV["CONTENTFUL_SPACE_ID"])
+  space.environments.find(ENV.fetch("CONTENTFUL_ENVIRONMENT", "master"))
+end
+
+def each_subcategory(json_data)
+  json_data.fetch("categories", []).each do |category|
+    Array(category["subcategories"]).each { |sub_category| yield sub_category }
+  end
+end
+
 def unique_categories(json_data)
   json_data.map { |item| item["cat"] }.uniq
 end
 
-def create_categories(environment, json_data)
+def build_categories(environment, json_data)
   categories = {}
   unique_categories(json_data).each { |item| categories[item["ref"]] = create_category(environment, item) }
   categories

--- a/lib/tasks/contentful.rake
+++ b/lib/tasks/contentful.rake
@@ -165,6 +165,42 @@ namespace :contentful do
     puts "Subcategory creation complete."
   end
 
+  desc "Create or update ways to buy entries in Contentful"
+  task create_ways_to_buy: :environment do
+    environment = contentful_environment
+    ways_to_buy_type = environment.content_types.find("ways_to_buy")
+
+    buying_options = {
+      "Catalogue" => "catalogue",
+      "DfE deal" => "dfe_deal",
+      "DPS" => "dps",
+      "Framework" => "framework",
+    }
+
+    buying_options.each do |title, slug|
+      entry = find_entry_by_slug(environment, "ways_to_buy", slug)
+
+      if entry
+        puts "Updating ways to buy #{title} (#{slug})"
+        entry.update(
+          title:,
+          slug:,
+        )
+      else
+        puts "Creating ways to buy #{title} (#{slug})"
+        entry = ways_to_buy_type.entries.create(
+          id: slug,
+          title:,
+          slug:,
+        )
+      end
+
+      entry.publish
+    end
+
+    puts "Ways to buy creation complete."
+  end
+
   desc "Create or update categories from config/categories.yml in Contentful"
   task create_categories: :environment do
     data = categories_config

--- a/lib/tasks/contentful.rake
+++ b/lib/tasks/contentful.rake
@@ -1,8 +1,25 @@
 require "json"
 require "contentful/management"
+require "yaml"
 
 # rubocop:disable Rails/SaveBang
 namespace :contentful do
+  desc "Download published solutions to config/solutions.yml"
+  task export_solutions: :environment do
+    puts "Exporting published solutions to config/solutions.yml..."
+
+    environment = contentful_environment
+    solutions = environment.entries.all(content_type: "solution", limit: 1000)
+      .select(&:published?)
+      .map { |entry| { "title" => entry.title, "slug" => entry.fields[:slug] } }
+      .sort_by { |solution| solution["slug"] }
+
+    file = Rails.root.join("config/solutions.yml")
+    File.write(file, { "solutions" => solutions }.to_yaml)
+
+    puts "Wrote #{solutions.count} published solutions to #{file}"
+  end
+
   desc "Create or update subcategories from config/categories.yml in Contentful"
   task create_subcategories: :environment do
     data = categories_config

--- a/lib/tasks/contentful.rake
+++ b/lib/tasks/contentful.rake
@@ -3,6 +3,75 @@ require "contentful/management"
 
 # rubocop:disable Rails/SaveBang
 namespace :contentful do
+  desc "Create categories and subcategories from config/categories.yml in Contentful"
+  task create_categories: :environment do
+    data = YAML.load_file(Rails.root.join("config/categories.yml"))
+    client = Contentful::Management::Client.new(ENV["CONTENTFUL_CMA_TOKEN"])
+    space = client.spaces.find(ENV["CONTENTFUL_SPACE_ID"])
+    environment = space.environments.find(ENV.fetch("CONTENTFUL_ENVIRONMENT", "master"))
+
+    subcategory_type = environment.content_types.find("subcategory")
+    category_type = environment.content_types.find("category")
+
+    subcategories_by_slug = {}
+
+    data.fetch("categories", []).each do |category|
+      Array(category["subcategories"]).each do |sub_category|
+        slug = sub_category["slug"]
+        next if subcategories_by_slug.key?(slug)
+
+        entry = find_entry_by_slug(environment, "subcategory", slug)
+
+        if entry
+          puts "Updating subcategory #{sub_category['name']} (#{slug})"
+          entry.update(
+            title: sub_category["name"],
+            slug:,
+          )
+        else
+          puts "Creating subcategory #{sub_category['name']} (#{slug})"
+          entry = subcategory_type.entries.create(
+            id: slug,
+            title: sub_category["name"],
+            slug:,
+          )
+        end
+
+        entry.publish
+        subcategories_by_slug[slug] = entry
+      end
+    end
+
+    data.fetch("categories", []).each do |category|
+      slug = category["slug"]
+      subcategory_entries = Array(category["subcategories"]).map { |sub_category| subcategories_by_slug.fetch(sub_category["slug"]) }
+      entry = find_entry_by_slug(environment, "category", slug)
+
+      if entry
+        puts "Updating category #{category['category']} (#{slug})"
+        entry.update(
+          title: category["category"],
+          description: category["description"],
+          slug:,
+          subcategories: subcategory_entries,
+        )
+      else
+        puts "Creating category #{category['category']} (#{slug})"
+        entry = category_type.entries.create(
+          id: slug,
+          title: category["category"],
+          description: category["description"],
+          slug:,
+          subcategories: subcategory_entries,
+        )
+      end
+
+      entry.publish
+    end
+
+    puts "Category creation complete."
+  end
+
   desc "Fetches all solutions and checks if their URLs are working"
   task check_solution_urls: :environment do
     puts "Fetching all solutions and checking URLs..."
@@ -267,5 +336,9 @@ end
 def skip_entry(msg)
   puts msg
   puts "------------------"
+end
+
+def find_entry_by_slug(environment, content_type, slug)
+  environment.entries.all(content_type:, "fields.slug" => slug).first
 end
 # rubocop:enable Rails/SaveBang

--- a/lib/tasks/contentful.rake
+++ b/lib/tasks/contentful.rake
@@ -201,6 +201,53 @@ namespace :contentful do
     puts "Ways to buy creation complete."
   end
 
+  desc "Create or update redirects from config/redirects.yml in Contentful"
+  task create_redirects: :environment do
+    data = redirects_config
+    environment = contentful_environment
+    redirect_type = environment.content_types.find("redirect")
+
+    created = 0
+    updated = 0
+
+    data.fetch("redirects", []).each do |redirect|
+      title = redirect.fetch("title")
+      source_path = redirect.fetch("source_path")
+      destination_path = redirect.fetch("destination_path")
+      redirect_kind = redirect.fetch("redirect_type")
+
+      unless %w[permanent temporary].include?(redirect_kind)
+        raise "Invalid redirect_type #{redirect_kind.inspect} for #{title}. Expected 'permanent' or 'temporary'."
+      end
+
+      entry = find_entry_by_field(environment, "redirect", :source_path, source_path)
+
+      if entry
+        puts "Updating redirect #{title} (#{source_path})"
+        entry.update(
+          title:,
+          source_path:,
+          destination_path:,
+          redirect_type: redirect_kind,
+        )
+        updated += 1
+      else
+        puts "Creating redirect #{title} (#{source_path})"
+        entry = redirect_type.entries.create(
+          title:,
+          source_path:,
+          destination_path:,
+          redirect_type: redirect_kind,
+        )
+        created += 1
+      end
+
+      entry.publish
+    end
+
+    puts "Redirect creation complete. Created #{created}, updated #{updated}."
+  end
+
   desc "Create or update categories from config/categories.yml in Contentful"
   task create_categories: :environment do
     data = categories_config
@@ -426,6 +473,10 @@ def categories_config
   YAML.load_file(Rails.root.join("config/categories.yml"))
 end
 
+def redirects_config
+  YAML.load_file(Rails.root.join("config/redirects.yml"))
+end
+
 def contentful_environment
   client = Contentful::Management::Client.new(ENV["CONTENTFUL_CMA_TOKEN"])
   space = client.spaces.find(ENV["CONTENTFUL_SPACE_ID"])
@@ -543,5 +594,9 @@ end
 
 def find_entry_by_slug(environment, content_type, slug)
   environment.entries.all(content_type:, "fields.slug" => slug).first
+end
+
+def find_entry_by_field(environment, content_type, field, value)
+  environment.entries.all(content_type:, "fields.#{field}" => value).first
 end
 # rubocop:enable Rails/SaveBang

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -72,10 +72,12 @@ namespace :solutions do
 
     puts "Updated #{updated} solutions in #{solutions_path}"
     puts "Ignored rows: #{ignored}"
-    puts "Unmatched solution rows: #{unmatched_rows.size}"
-    unmatched_rows.each do |row|
-      identifier = row[:slug].present? ? "#{row[:title]} (slug: #{row[:slug]})" : row[:title]
-      puts "  - line #{row[:row]}: #{identifier}"
+    if unmatched_rows.any?
+      puts "Unmatched solution rows: #{unmatched_rows.size}"
+      unmatched_rows.each do |row|
+        identifier = row[:slug].present? ? "#{row[:title]} (slug: #{row[:slug]})" : row[:title]
+        puts "  - line #{row[:row]}: #{identifier}"
+      end
     end
 
     if unresolved_categories.any?
@@ -94,27 +96,33 @@ namespace :solutions do
     end
 
     unmapped_buying_options = solutions.select { |solution| solution["ways_to_buy"].blank? }
-    puts "Solutions with no mapped ways_to_buy: #{unmapped_buying_options.count}"
-    unmapped_buying_options.each do |solution|
-      puts "  - #{solution['title']} (#{solution['slug']})"
+    if unmapped_buying_options.any?
+      puts "Solutions with no mapped ways_to_buy: #{unmapped_buying_options.count}"
+      unmapped_buying_options.each do |solution|
+        puts "  - #{solution['title']} (#{solution['slug']})"
+      end
     end
 
     solutions_with_no_mapped_categories = solutions.select do |solution|
       solution["primary_category"].blank? || Array(solution["categories"]).blank?
     end
 
-    puts "Solutions with no mapped categories: #{solutions_with_no_mapped_categories.count}"
-    solutions_with_no_mapped_categories.each do |solution|
-      puts "  - #{solution['title']} (#{solution['slug']})"
+    if solutions_with_no_mapped_categories.any?
+      puts "Solutions with no mapped categories: #{solutions_with_no_mapped_categories.count}"
+      solutions_with_no_mapped_categories.each do |solution|
+        puts "  - #{solution['title']} (#{solution['slug']})"
+      end
     end
 
     solutions_with_no_mapped_subcategories = solutions.select do |solution|
       Array(solution["subcategories"]).blank?
     end
 
-    puts "Solutions with no mapped subcategories: #{solutions_with_no_mapped_subcategories.count}"
-    solutions_with_no_mapped_subcategories.each do |solution|
-      puts "  - #{solution['title']} (#{solution['slug']})"
+    if solutions_with_no_mapped_subcategories.any?
+      puts "Solutions with no mapped subcategories: #{solutions_with_no_mapped_subcategories.count}"
+      solutions_with_no_mapped_subcategories.each do |solution|
+        puts "  - #{solution['title']} (#{solution['slug']})"
+      end
     end
   end
 end

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -176,11 +176,14 @@ def lookup_buying_option(value, unresolved, row_number)
   raw_value = value.to_s.strip
   return nil if raw_value.blank?
 
-  buying_options = ["Catalogue", "DfE deal", "DPS", "Framework"]
-  buying_option = buying_options.find { |option| option == raw_value }
+  buying_options = {
+    "Catalogue" => 'catalogue',
+    "DfE deal" => 'dfe_deal',
+    "DPS" => 'dps',
+    "Framework" => 'framework'
+  }
 
-  unresolved << { row: row_number, value: raw_value } if buying_option.nil?
-  buying_option
+  buying_options[raw_value]
 end
 
 def normalise_title(value)

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -79,8 +79,10 @@ namespace :solutions do
       unresolved_subcategories.uniq.each { |row| puts "  - line #{row[:row]}: #{row[:value]}" }
     end
 
-    puts "Unresolved ways to buy: #{invalid_buying_option_rows.count}"
-    invalid_buying_option_rows.each { |row| puts "  - line #{row[:row]}: #{row[:value]}" }
+    if invalid_buying_option_rows.any?
+      puts "Unresolved ways to buy: #{invalid_buying_option_rows.count}"
+      invalid_buying_option_rows.each { |row| puts "  - line #{row[:row]}: #{row[:value]}" }
+    end
 
     unmapped_buying_options = solutions.select { |solution| solution["ways_to_buy"].blank? }
     puts "Solutions with no mapped ways_to_buy: #{unmapped_buying_options.count}"

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -1,0 +1,146 @@
+require "csv"
+require "yaml"
+
+namespace :solutions do
+  DESC = "Update config/solutions.yml with category and subcategory slugs from the recategorisation spreadsheet".freeze
+
+  desc DESC
+  task update_category_mapping: :environment do
+    spreadsheet_path = Rails.root.join("DO NOT EDIT - Categories_BuyingOptions(Recategorising frameworks).csv")
+    solutions_path = Rails.root.join("config/solutions.yml")
+    categories_path = Rails.root.join("config/categories.yml")
+
+    spreadsheet_rows = CSV.read(spreadsheet_path, headers: true, encoding: "bom|utf-8")
+    solutions_file = YAML.load_file(solutions_path)
+    solutions = Array(solutions_file["solutions"])
+    category_lookup, subcategory_lookup = build_title_lookups(categories_path)
+
+    solutions_by_normalised_title = solutions.index_by { |solution| normalise_title(solution["title"]) }
+    solutions_by_slug = solutions.index_by { |solution| solution["slug"] }
+
+    updated = 0
+    unmatched_rows = []
+    unresolved_categories = []
+    unresolved_subcategories = []
+
+    spreadsheet_rows.each_with_index do |row, index|
+      row_number = index + 2
+      title = row["Framework name or content name"].to_s.strip
+      break if title.blank? && row.to_h.values.compact.map(&:to_s).all?(&:blank?)
+
+      solution = solutions_by_slug[title.parameterize] || solutions_by_normalised_title[normalise_title(title)]
+
+      if solution.nil?
+        unmatched_rows << { row: row_number, title: }
+        next
+      end
+
+      primary_category = lookup_slug(row["To-be primary category"], category_lookup, unresolved_categories, row_number)
+      secondary_category = lookup_slug(row["To-be 2nd category (if applicable)"], category_lookup, unresolved_categories, row_number)
+      categories = [primary_category, secondary_category].compact.uniq
+
+      subcategory_slugs = (
+        parse_values(row["Primary sub-categories"]).flat_map { |value| lookup_subcategory_slugs(value, subcategory_lookup, unresolved_subcategories, row_number) } +
+          parse_values(row["Secondary sub-categories (if applicable)"]).flat_map { |value| lookup_subcategory_slugs(value, subcategory_lookup, unresolved_subcategories, row_number) }
+      ).compact.uniq
+
+      solution["primary_category"] = primary_category if primary_category.present?
+      solution["categories"] = categories if categories.any?
+      solution["subcategories"] = subcategory_slugs if subcategory_slugs.any?
+      updated += 1
+    end
+
+    File.write(solutions_path, solutions_file.to_yaml)
+
+    puts "Updated #{updated} solutions in #{solutions_path}"
+    puts "Unmatched solution rows: #{unmatched_rows.size}"
+    unmatched_rows.each { |row| puts "  - line #{row[:row]}: #{row[:title]}" }
+
+    if unresolved_categories.any?
+      puts "Unresolved category titles:"
+      unresolved_categories.uniq.each { |row| puts "  - line #{row[:row]}: #{row[:value]}" }
+    end
+
+    if unresolved_subcategories.any?
+      puts "Unresolved subcategory titles:"
+      unresolved_subcategories.uniq.each { |row| puts "  - line #{row[:row]}: #{row[:value]}" }
+    end
+  end
+end
+
+def build_title_lookups(categories_path)
+  categories = YAML.load_file(categories_path).fetch("categories", [])
+
+  category_lookup = {}
+  subcategory_lookup = {}
+
+  categories.each do |category|
+    category_lookup[normalise_title(category["category"])] = category["slug"]
+
+    Array(category["subcategories"]).each do |subcategory|
+      subcategory_lookup[normalise_title(subcategory["name"])] = subcategory["slug"]
+    end
+  end
+
+  category_lookup.merge!(category_aliases)
+  subcategory_lookup.merge!(subcategory_aliases)
+
+  [category_lookup, subcategory_lookup]
+end
+
+def category_aliases
+  {
+    normalise_title("Catering ") => "catering",
+  }
+end
+
+def subcategory_aliases
+  {
+    normalise_title("Hardware") => "laptops-printers-ict-hardware",
+    normalise_title("IT software and systems") => "ict-software-systems",
+    normalise_title("N/A til there are more transport options") => [],
+    normalise_title("Renewables and energy saving products") => "renewables-energysaving-products",
+    normalise_title("Sports equipment, SEND") => ["sports-equipment", "send-products"],
+    normalise_title("Catering services") => "catering-services-staff",
+    normalise_title("[B&M]Health, safety and security") => "health-safety-security",
+  }.compact
+end
+
+def parse_values(value)
+  value.to_s.split(";").map(&:strip).reject(&:blank?)
+end
+
+def lookup_slug(value, lookup, unresolved, row_number)
+  normalised = normalise_title(value)
+  return nil if normalised.blank?
+
+  slug = lookup[normalised]
+  unresolved << { row: row_number, value: } if slug.nil?
+  slug
+end
+
+def lookup_subcategory_slugs(value, lookup, unresolved, row_number)
+  normalised = normalise_title(value)
+  return [] if normalised.blank?
+
+  slug = lookup[normalised]
+  if slug.nil?
+    unresolved << { row: row_number, value: }
+    []
+  else
+    Array(slug)
+  end
+end
+
+def normalise_title(value)
+  value.to_s
+    .strip
+    .gsub(/^\[[^\]]+\]\s*/, "")
+    .gsub(/\bfor schools?\b/i, "")
+    .gsub(/dynamic purchasing system \(dps\)/i, "")
+    .gsub(/\b(dps|catalogue|catalogues)\b/i, "")
+    .gsub(/&/, "and")
+    .gsub(/[^a-z0-9]+/i, " ")
+    .squish
+    .downcase
+end

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -65,6 +65,17 @@ namespace :solutions do
       puts "Unresolved subcategory titles:"
       unresolved_subcategories.uniq.each { |row| puts "  - line #{row[:row]}: #{row[:value]}" }
     end
+
+    unmapped_solutions = solutions.select do |solution|
+      solution["primary_category"].blank? ||
+        Array(solution["categories"]).blank? ||
+        Array(solution["subcategories"]).blank?
+    end
+
+    puts "Solutions with no mapped categories or subcategories: #{unmapped_solutions.count}"
+    unmapped_solutions.each do |solution|
+      puts "  - #{solution['title']} (#{solution['slug']})"
+    end
   end
 end
 

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -28,14 +28,19 @@ namespace :solutions do
       row = row.to_h.transform_values { |value| value.is_a?(String) ? value.strip : value }
       row_number = index + 2
       title = row["Framework name or content name"].to_s
+      slug = row["Framework slug"].to_s
       break if title.blank? && row.to_h.values.compact.map(&:to_s).all?(&:blank?)
 
       buying_option = lookup_buying_option(row["Type of buying option"], invalid_buying_option_rows, row_number)
 
-      solution = solutions_by_slug[title.parameterize] || solutions_by_normalised_title[normalise_title(title)]
+      solution = if slug.present?
+                   solutions_by_slug[slug]
+                 else
+                   solutions_by_slug[title.parameterize] || solutions_by_normalised_title[normalise_title(title)]
+                 end
 
       if solution.nil?
-        unmatched_rows << { row: row_number, title: }
+        unmatched_rows << { row: row_number, title:, slug: }
         next
       end
 
@@ -59,7 +64,10 @@ namespace :solutions do
 
     puts "Updated #{updated} solutions in #{solutions_path}"
     puts "Unmatched solution rows: #{unmatched_rows.size}"
-    unmatched_rows.each { |row| puts "  - line #{row[:row]}: #{row[:title]}" }
+    unmatched_rows.each do |row|
+      identifier = row[:slug].present? ? "#{row[:title]} (slug: #{row[:slug]})" : row[:title]
+      puts "  - line #{row[:row]}: #{identifier}"
+    end
 
     if unresolved_categories.any?
       puts "Unresolved category titles:"

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -22,11 +22,15 @@ namespace :solutions do
     unmatched_rows = []
     unresolved_categories = []
     unresolved_subcategories = []
+    invalid_buying_option_rows = []
 
     spreadsheet_rows.each_with_index do |row, index|
+      row = row.to_h.transform_values { |value| value.is_a?(String) ? value.strip : value }
       row_number = index + 2
-      title = row["Framework name or content name"].to_s.strip
+      title = row["Framework name or content name"].to_s
       break if title.blank? && row.to_h.values.compact.map(&:to_s).all?(&:blank?)
+
+      buying_option = lookup_buying_option(row["Type of buying option"], invalid_buying_option_rows, row_number)
 
       solution = solutions_by_slug[title.parameterize] || solutions_by_normalised_title[normalise_title(title)]
 
@@ -47,6 +51,7 @@ namespace :solutions do
       solution["primary_category"] = primary_category if primary_category.present?
       solution["categories"] = categories if categories.any?
       solution["subcategories"] = subcategory_slugs if subcategory_slugs.any?
+      solution["ways_to_buy"] = buying_option if buying_option.present?
       updated += 1
     end
 
@@ -64,6 +69,15 @@ namespace :solutions do
     if unresolved_subcategories.any?
       puts "Unresolved subcategory titles:"
       unresolved_subcategories.uniq.each { |row| puts "  - line #{row[:row]}: #{row[:value]}" }
+    end
+
+    puts "Unresolved ways to buy: #{invalid_buying_option_rows.count}"
+    invalid_buying_option_rows.each { |row| puts "  - line #{row[:row]}: #{row[:value]}" }
+
+    unmapped_buying_options = solutions.select { |solution| solution["ways_to_buy"].blank? }
+    puts "Solutions with no mapped ways_to_buy: #{unmapped_buying_options.count}"
+    unmapped_buying_options.each do |solution|
+      puts "  - #{solution['title']} (#{solution['slug']})"
     end
 
     unmapped_solutions = solutions.select do |solution|
@@ -141,6 +155,17 @@ def lookup_subcategory_slugs(value, lookup, unresolved, row_number)
   else
     Array(slug)
   end
+end
+
+def lookup_buying_option(value, unresolved, row_number)
+  raw_value = value.to_s.strip
+  return nil if raw_value.blank?
+
+  buying_options = ["Catalogue", "DfE deal", "DPS", "Framework"]
+  buying_option = buying_options.find { |option| option == raw_value }
+
+  unresolved << { row: row_number, value: raw_value } if buying_option.nil?
+  buying_option
 end
 
 def normalise_title(value)

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -88,14 +88,21 @@ namespace :solutions do
       puts "  - #{solution['title']} (#{solution['slug']})"
     end
 
-    unmapped_solutions = solutions.select do |solution|
-      solution["primary_category"].blank? ||
-        Array(solution["categories"]).blank? ||
-        Array(solution["subcategories"]).blank?
+    solutions_with_no_mapped_categories = solutions.select do |solution|
+      solution["primary_category"].blank? || Array(solution["categories"]).blank?
     end
 
-    puts "Solutions with no mapped categories or subcategories: #{unmapped_solutions.count}"
-    unmapped_solutions.each do |solution|
+    puts "Solutions with no mapped categories: #{solutions_with_no_mapped_categories.count}"
+    solutions_with_no_mapped_categories.each do |solution|
+      puts "  - #{solution['title']} (#{solution['slug']})"
+    end
+
+    solutions_with_no_mapped_subcategories = solutions.select do |solution|
+      Array(solution["subcategories"]).blank?
+    end
+
+    puts "Solutions with no mapped subcategories: #{solutions_with_no_mapped_subcategories.count}"
+    solutions_with_no_mapped_subcategories.each do |solution|
       puts "  - #{solution['title']} (#{solution['slug']})"
     end
   end

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -19,6 +19,7 @@ namespace :solutions do
     solutions_by_slug = solutions.index_by { |solution| solution["slug"] }
 
     updated = 0
+    ignored = 0
     unmatched_rows = []
     unresolved_categories = []
     unresolved_subcategories = []
@@ -30,6 +31,11 @@ namespace :solutions do
       title = row["Framework name or content name"].to_s
       slug = row["Framework slug"].to_s
       break if title.blank? && row.to_h.values.compact.map(&:to_s).all?(&:blank?)
+
+      if slug.casecmp("ignore").zero?
+        ignored += 1
+        next
+      end
 
       buying_option = lookup_buying_option(row["Type of buying option"], invalid_buying_option_rows, row_number)
 
@@ -65,6 +71,7 @@ namespace :solutions do
     File.write(solutions_path, solutions_file.to_yaml)
 
     puts "Updated #{updated} solutions in #{solutions_path}"
+    puts "Ignored rows: #{ignored}"
     puts "Unmatched solution rows: #{unmatched_rows.size}"
     unmatched_rows.each do |row|
       identifier = row[:slug].present? ? "#{row[:title]} (slug: #{row[:slug]})" : row[:title]

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -45,8 +45,10 @@ namespace :solutions do
       end
 
       primary_category = lookup_slug(row["To-be primary category"], category_lookup, unresolved_categories, row_number)
-      secondary_category = lookup_slug(row["To-be 2nd category (if applicable)"], category_lookup, unresolved_categories, row_number)
-      categories = [primary_category, secondary_category].compact.uniq
+      secondary_categories = parse_values(row["To-be 2nd category (if applicable)"]).filter_map do |value|
+        lookup_slug(value, category_lookup, unresolved_categories, row_number)
+      end
+      categories = ([primary_category] + secondary_categories).compact.uniq
 
       subcategory_slugs = (
         parse_values(row["Primary sub-categories"]).flat_map { |value| lookup_subcategory_slugs(value, subcategory_lookup, unresolved_subcategories, row_number) } +

--- a/lib/tasks/solutions.rake
+++ b/lib/tasks/solutions.rake
@@ -188,13 +188,15 @@ def lookup_buying_option(value, unresolved, row_number)
   return nil if raw_value.blank?
 
   buying_options = {
-    "Catalogue" => 'catalogue',
-    "DfE deal" => 'dfe_deal',
-    "DPS" => 'dps',
-    "Framework" => 'framework'
+    "Catalogue" => "catalogue",
+    "DfE deal" => "dfe_deal",
+    "DPS" => "dps",
+    "Framework" => "framework",
   }
 
-  buying_options[raw_value]
+  buying_option = buying_options[raw_value]
+  unresolved << { row: row_number, value: raw_value } if buying_option.nil?
+  buying_option
 end
 
 def normalise_title(value)


### PR DESCRIPTION
This temporary PR (not intended to be merged) processes the IA spreadsheet to generate structured data for category/subcategory mapping and for existing solution mapping to categories/subcategories and buying type. It also adds new rake tasks for populating ways to buy and redirects.

The scripts should be run in the following order:

1. `bundle exec rails contentful:create_redirects` - this populates redirect models for legacy categories and the about page change.
2. `bundle exec rails contentful:create_ways_to_buy` - this populates the 4 ways to buy which are now referenced from solutions.
3. `bundle exec rails contentful:export_solutions` - this overwrites the file `config/solutions.yml` with titles and slugs for all current published solutions.
4. `bundle exec rails contentful:create_subcategories` - this uses the file `config/categories.yml` to populate subcategories which will be referenced from categories.
5. `bundle exec rails contentful:create_categories` - this uses the file `config/categories.yml` to populate categories which will be referenced from solutions.
6. `bundle exec rails solutions:update_category_mapping` - this is the big / messy one that reads the Excel spreadsheet and `config/categories.yml` and updates `config/solutions.yml` to enrich each solution with the relevant categories, subcategories and ways to buy details (No changes in Contentful)
7. `bundle exec rails contentful:update_solutions` - this uses the enriched `config/solutions.yml` file to update each solution primary category, categories, subcategories and ways to buy fields in Contentful.

When this goes live on Monday, steps 3 and 6 can be skipped as `config/solutions.yml` is already up to date within this branch. If any changes are made in the meantime to the spreadsheet then those steps will need to be included.


**N.B.** The `transport` category does not have any real subcategories, but in order for the category landing page filter to work correctly, it has a dummy `N/A` subcategory. This has a slug `not-applicable` which is not displayed in the sub category filter.


Example output from `bundle exec rails solutions:update_category_mapping`:

```
rails solutions:update_category_mapping
Updated 124 solutions in config/solutions.yml
Ignored rows: 13
Solutions with no mapped subcategories: 4
  - Property refurbishment, maintenance and management (property-refurbishment-maintenance-and-management)
  - Student transport DPS (transport)
  - Vehicle daily rental (vehicle-daily-rental)
  - Vehicle purchase (vehicle-purchase)
 ```
