### PR TITLE
Exclude some Cron jobs from running in local development

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,16 @@
+EXCLUDED_DEV_JOBS = %w[synchronize_shared_inbox resync_email_ids].freeze
+
 Sidekiq.configure_server do |config|
   config.redis = { url: "#{ENV['REDIS_URL']}/0" }
 
   # Sidekiq Cron
   schedule_file = "config/schedule.yml"
   if File.exist?(schedule_file)
+    schedule = YAML.load_file(schedule_file)
+    schedule.except!(*EXCLUDED_DEV_JOBS) if Rails.env.development?
+
     Sidekiq::Cron::Job.destroy_all!
-    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash(schedule)
   end
 end
 


### PR DESCRIPTION
These jobs run every minute which means that Sidekiq queues quickly get filled with repeated noise of jobs failing that were not designed to run in local development environment. The simplest fix is to exclude those just for local development; we can then still use Sidekiq for development as needed but without all the noise.