### PR TITLE
Add support for redirect rules defined within Contentful CMS

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,8 @@
 class CategoriesController < Fabs::ApplicationController
   before_action :disable_search_in_header, only: :index
+  include Redirectable
+
+  before_action :redirect_legacy_slugs, only: :show
 
   DUMMY_SUBCATEGORY_SLUG = "not-applicable".freeze
 

--- a/app/controllers/concerns/redirectable.rb
+++ b/app/controllers/concerns/redirectable.rb
@@ -1,0 +1,12 @@
+module Redirectable
+  extend ActiveSupport::Concern
+
+private
+
+  def redirect_legacy_slugs
+    match = RedirectMatcher.call(request.path)
+    return unless match
+
+    redirect_to match.destination_path, status: match.status
+  end
+end

--- a/app/controllers/contentful_webhooks_controller.rb
+++ b/app/controllers/contentful_webhooks_controller.rb
@@ -1,42 +1,90 @@
 class ContentfulWebhooksController < Fabs::ApplicationController
   skip_before_action :verify_authenticity_token
 
+  UPSERT_TOPICS = [
+    "ContentManagement.Entry.publish",
+  ].freeze
+
+  DELETE_TOPICS = [
+    "ContentManagement.Entry.unpublish",
+    "ContentManagement.Entry.archive",
+    "ContentManagement.Entry.delete",
+  ].freeze
+
   def create
     return head :unauthorized unless valid_signature?
 
-    if id.present?
-      result = SolutionIndexer.new(id:).index_document
+    return render json: { error: "The entry id is missing from the request." }, status: :bad_request if id.blank?
 
-      if result
-        render json: { message: "Webhook for entry #{id} processed successfully." }, status: :ok
-      else
-        render json: { error: "Failed to index the document for id #{id}." }, status: :unprocessable_content
-      end
+    case topic
+    when *UPSERT_TOPICS
+      process_upsert
+    when *DELETE_TOPICS
+      process_delete
     else
-      render json: { error: "The 'entityId' is missing from the request." }, status: :bad_request
-    end
-  end
-
-  def destroy
-    return head :unauthorized unless valid_signature?
-
-    if id.present?
-      result = SolutionIndexer.new(id:).delete_document
-
-      if result
-        render json: { message: "Webhook for entry #{id} deletion processed successfully." }, status: :ok
-      else
-        render json: { error: "Failed to delete the document for id #{id}." }, status: :unprocessable_content
-      end
-    else
-      render json: { error: "The 'entityId' is missing from the request." }, status: :bad_request
+      render json: { message: "Ignoring unsupported webhook topic #{topic} for entry #{id}." }, status: :ok
     end
   end
 
 private
 
   def id
-    params["entityId"]
+    params.dig("sys", "id")
+  end
+
+  def content_type
+    params.dig("sys", "contentType", "sys", "id")
+  end
+
+  def topic
+    request.headers["X-Contentful-Topic"]
+  end
+
+  def process_upsert
+    case content_type
+    when "solution"
+      process_solution_index_upsert
+    when "redirect"
+      invalidate_redirect_cache("processed")
+    else
+      render json: { message: "Ignoring unsupported content type #{content_type} for entry #{id}." }, status: :ok
+    end
+  end
+
+  def process_delete
+    case content_type
+    when "solution"
+      process_solution_index_delete
+    when "redirect"
+      invalidate_redirect_cache("deletion processed")
+    else
+      render json: { message: "Ignoring unsupported content type #{content_type} for entry #{id}." }, status: :ok
+    end
+  end
+
+  def process_solution_index_upsert
+    result = SolutionIndexer.new(id:).index_document
+
+    if result
+      render json: { message: "Webhook for entry #{id} processed successfully." }, status: :ok
+    else
+      render json: { error: "Failed to index the document for id #{id}." }, status: :unprocessable_content
+    end
+  end
+
+  def process_solution_index_delete
+    result = SolutionIndexer.new(id:).delete_document
+
+    if result
+      render json: { message: "Webhook for entry #{id} deletion processed successfully." }, status: :ok
+    else
+      render json: { error: "Failed to delete the document for id #{id}." }, status: :unprocessable_content
+    end
+  end
+
+  def invalidate_redirect_cache(message_suffix)
+    RedirectMatcher.invalidate_cache!
+    render json: { message: "Webhook for redirect entry #{id} #{message_suffix} successfully." }, status: :ok
   end
 
   def valid_signature?

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,9 @@ class PagesController < ApplicationController
   skip_before_action :authenticate_user!
 
   include Breadcrumbs
+  include Redirectable
+
+  before_action :redirect_legacy_slugs
 
   def show
     if page.present?
@@ -10,10 +13,10 @@ class PagesController < ApplicationController
       build_page_breadcrumbs(@page)
       render "fabs/pages/show", layout: "pages"
     else
-      redirect_to "/404"
+      render "errors/not_found", status: :not_found
     end
   rescue ContentfulRecordNotFoundError
-    redirect_to "/404"
+    render "errors/not_found", status: :not_found
   end
 
   # TODO: remove this once pages are dynamic

--- a/app/controllers/solutions_controller.rb
+++ b/app/controllers/solutions_controller.rb
@@ -1,4 +1,8 @@
 class SolutionsController < Fabs::ApplicationController
+  include Redirectable
+
+  before_action :redirect_legacy_slugs, only: :show
+
   def index
     @solutions = Solution.all
     @sorted_categories = @solutions.each_with_object({}) { |solution, hash|

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -1,0 +1,43 @@
+class Redirect
+  include ActiveModel::Model
+
+  CONTENT_TYPE = "redirect".freeze
+  SELECT_FIELDS = [
+    "sys.id",
+    "fields.title",
+    "fields.source_path",
+    "fields.destination_path",
+    "fields.redirect_type",
+  ].join(",").freeze
+
+  attr_reader :id, :title, :source_path, :destination_path, :redirect_type
+
+  def initialize(entry)
+    @id = entry.id
+    @title = entry.fields[:title]
+    @source_path = entry.fields[:source_path]
+    @destination_path = entry.fields[:destination_path]
+    @redirect_type = entry.fields[:redirect_type]
+    super()
+  end
+
+  def self.all
+    ContentfulClient.entries(
+      content_type: CONTENT_TYPE,
+      select: SELECT_FIELDS,
+      order: "fields.title",
+    ).map { |entry| new(entry) }
+  end
+
+  def permanent?
+    redirect_type == "permanent"
+  end
+
+  def temporary?
+    redirect_type == "temporary"
+  end
+
+  def ==(other)
+    super || other.instance_of?(self.class) && other.id == id
+  end
+end

--- a/app/services/redirect_matcher.rb
+++ b/app/services/redirect_matcher.rb
@@ -14,6 +14,10 @@ class RedirectMatcher
     end
   end
 
+  def self.invalidate_cache!
+    Rails.cache.delete(CACHE_KEY)
+  end
+
   def initialize(path, redirects: self.class.cached_redirects)
     @path = path
     @redirects = redirects

--- a/app/services/redirect_matcher.rb
+++ b/app/services/redirect_matcher.rb
@@ -1,0 +1,77 @@
+class RedirectMatcher
+  CACHE_KEY = "contentful/redirects".freeze
+  CACHE_EXPIRY = 1.day
+
+  Result = Data.define(:redirect, :destination_path, :status)
+
+  def self.call(path, redirects: cached_redirects)
+    new(path, redirects:).call
+  end
+
+  def self.cached_redirects
+    Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_EXPIRY) do
+      Redirect.all
+    end
+  end
+
+  def initialize(path, redirects: self.class.cached_redirects)
+    @path = path
+    @redirects = redirects
+  end
+
+  def call
+    redirect = redirects.find { |rule| matches?(rule) }
+    return nil unless redirect
+
+    Result.new(
+      redirect:,
+      destination_path: resolve_destination_path(redirect),
+      status: redirect.permanent? ? :moved_permanently : :found,
+    )
+  end
+
+private
+
+  attr_reader :path, :redirects
+
+  def matches?(redirect)
+    if wildcard_rule?(redirect.source_path)
+      wildcard_match?(redirect.source_path)
+    else
+      redirect.source_path == path
+    end
+  end
+
+  def resolve_destination_path(redirect)
+    return redirect.destination_path unless wildcard_rule?(redirect.source_path)
+
+    wildcard_destination(redirect.destination_path, wildcard_remainder(redirect.source_path))
+  end
+
+  def wildcard_rule?(pattern)
+    pattern.end_with?("/*")
+  end
+
+  def wildcard_match?(source_path)
+    prefix = wildcard_prefix(source_path)
+    path == prefix || path.start_with?("#{prefix}/")
+  end
+
+  def wildcard_remainder(source_path)
+    prefix = wildcard_prefix(source_path)
+    return "" if path == prefix
+
+    path.delete_prefix("#{prefix}/")
+  end
+
+  def wildcard_destination(destination_path, remainder)
+    return destination_path unless wildcard_rule?(destination_path)
+
+    destination_prefix = wildcard_prefix(destination_path)
+    remainder.present? ? "#{destination_prefix}/#{remainder}" : destination_prefix
+  end
+
+  def wildcard_prefix(pattern)
+    pattern.delete_suffix("/*")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -640,7 +640,6 @@ Rails.application.routes.draw do
   resources :offers, only: %i[index show], param: :slug
 
   resources :contentful_webhooks, only: %i[create]
-  post "delete_contentful_entry", to: "contentful_webhooks#destroy"
 
   get "/search", to: "search#index"
   post "/events", to: "events#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -644,6 +644,5 @@ Rails.application.routes.draw do
   get "/search", to: "search#index"
   post "/events", to: "events#create"
 
-  # DB-backed pages (BFYS) and Contentful-backed pages (FABS)
-  get ":slug", to: "pages#show", as: :page, format: false, constraints: { slug: /[^.]+/ }
+  get ":slug", to: "pages#show", as: :page, format: false, constraints: { slug: /[^\/.]+/ }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -645,9 +645,6 @@ Rails.application.routes.draw do
   get "/search", to: "search#index"
   post "/events", to: "events#create"
 
-  # Exempt browser request for favicon from being treated as a page by catch-all route below
-  get "/favicon.ico", to: ->(_env) { [404, { "Content-Type" => "text/plain", "Content-Length" => "0" }, []] }
-
   # DB-backed pages (BFYS) and Contentful-backed pages (FABS)
-  get ":slug", to: "pages#show", as: :page
+  get ":slug", to: "pages#show", as: :page, format: false, constraints: { slug: /[^.]+/ }
 end

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -1,86 +1,123 @@
 # Webhooks
 
-We use Contentful webhooks to notify our application of new and updated content.
+We use Contentful webhooks to notify the application when published content changes.
 
-## Settings
+The application currently exposes a single webhook endpoint:
 
-The following are the minimal required settings for two types of webhook. Both are needed for each application environment to ensure the content there is up-to-date.
+- `POST /contentful_webhooks`
 
-### Cache busting webhook
+This endpoint handles multiple Contentful entry types and actions by inspecting the standard Contentful webhook payload and the `X-Contentful-Topic` header.
 
-This webhook is triggered when any action is performed on a Contentufl entry, e.g. create, save, delete, etc.
-This lets our application know that there has been a content change and the old version of the entry is deleted from the cache.
+## Supported Contentful content types
 
-|              |                                     |
-| ------------ | ----------------------------------- |
-| **Env**:     | `CONTENTFUL_ENVIRONMENT=staging`    |
-| **Filter**:  | `sys.environment.sys.id == staging` |
-| **Headers**: | `Authorization Token xxxxxx`        |
-|              | `Content-Type application/json`     |
+The webhook currently handles these Contentful content types:
 
-**Payload**:
+- `solution`
+- `redirect`
 
-```json
-{
-  "entityId": "{ /payload/sys/id }",
-  "spaceId": "{ /payload/sys/space/sys/id }",
-  "parameters": {
-    "text": "Entity version: { /payload/sys/version }"
-  }
-}
-```
+Any other content type is accepted but ignored.
 
-### Published category webhook
+## Supported Contentful topics
 
-This webhook is triggered when a `Category` entry has been (re)published.
+The webhook currently processes these topics:
 
-|              |                                      |
-| ------------ | ------------------------------------ |
-| **Env**:     | `CONTENTFUL_ENVIRONMENT=staging`     |
-| **Filters**: | `sys.environment.sys.id == staging`  |
-|              | `sys.contentType.sys.id == category` |
-| **Headers**: | `Authorization Token xxxxxx`         |
-|              | `Content-Type application/json`      |
-| **Payload**: | default                              |
+- `ContentManagement.Entry.publish`
+- `ContentManagement.Entry.unpublish`
+- `ContentManagement.Entry.archive`
+- `ContentManagement.Entry.delete`
 
-### Published page webhook
+Any other topic is accepted but ignored.
 
-This webhook is triggered when a `Page` entry has been (re)published.
+## Behaviour
 
-|              |                                     |
-| ------------ | ----------------------------------- |
-| **Env**:     | `CONTENTFUL_ENVIRONMENT=staging`    |
-| **Filters**: | `sys.environment.sys.id == staging` |
-|              | `sys.contentType.sys.id == page`    |
-| **Headers**: | `Authorization Token xxxxxx`        |
-|              | `Content-Type application/json`     |
-| **Payload**: | default                             |
+### Solution entries
 
-### Deleted page webhook
+For `solution` entries:
 
-This webhook is triggered when a `Page` entry has been deleted or unpublished.
+- `ContentManagement.Entry.publish` updates the search index entry for the solution
+- `ContentManagement.Entry.unpublish` removes the solution from the search index
+- `ContentManagement.Entry.archive` removes the solution from the search index
+- `ContentManagement.Entry.delete` removes the solution from the search index
+
+### Redirect entries
+
+For `redirect` entries:
+
+- `ContentManagement.Entry.publish` invalidates the cached redirect list
+- `ContentManagement.Entry.unpublish` invalidates the cached redirect list
+- `ContentManagement.Entry.archive` invalidates the cached redirect list
+- `ContentManagement.Entry.delete` invalidates the cached redirect list
+
+## Contentful webhook configuration
+
+Create one webhook per application environment.
+
+Recommended minimal settings:
 
 |              |                                     |
 | ------------ | ----------------------------------- |
 | **Env**:     | `CONTENTFUL_ENVIRONMENT=staging`    |
 | **Filters**: | `sys.environment.sys.id == staging` |
-|              | `sys.contentType.sys.id == page`    |
-| **Headers**: | `Authorization Token xxxxxx`        |
-|              | `Content-Type application/json`     |
+|              | `sys.type == Entry`                 |
+| **Headers**: | `X-Contentful-Webhook-Signature: xxxxxx` |
+|              | `Content-Type: application/json`    |
 | **Payload**: | default                             |
 
-## Open Tunnel via Ngrok
+Notes:
 
-Working with incoming webhooks (i.e. contentful) can be made easier by using [ngrok](https://ngrok.com/). The easiest way to install ngrok is probably through brew (`$ brew install ngrok`), otherwise docs can be found [here](https://dashboard.ngrok.com/get-started/setup) upon setting up a free account.
+- Use the default Contentful payload. The application reads `sys.id` and `sys.contentType.sys.id` from the request body.
+- The custom header X-Contentful-Webhook-Signature must be added with a secure secret value.
+- The webhook secret must match `CONTENTFUL_WEBHOOK_SECRET` in the Rails application.
+- The `Content-Type` header must be set to `application/json` so Rails parses the webhook body into `params`.
+- Set the environment filter to the correct Contentful environment for the target app, for example:
+  - `sys.environment.sys.id == development`
+  - `sys.environment.sys.id == master`
+  - `sys.environment.sys.id == staging`
+- Filtering to `sys.type == Entry` helps avoid irrelevant non-entry webhook traffic.
+- Additional filters can be added if needed, but are not required by the application.
 
-Upon starting the local server (`$ script/server`), you can then run ngrok:
+## Testing webhooks locally with ngrok
 
+ngrok is a simple way to expose your local Rails application to Contentful.
+
+Install ngrok on macOS with Homebrew:
+
+```sh
+brew install ngrok
 ```
-$ ngrok http https://localhost:3000
+
+Connect ngrok to your account:
+
+```sh
+ngrok config add-authtoken <your-authtoken>
 ```
 
-Once connected, you use the forwarding address which appears in the terminal for the incoming webhooks and route to the respective controller. With a free ngrok account, the forwarding address for each developer is different every time, so the webhooks in Contentful will need to be updated regularly.
+Start the local Rails server first. If you are running Rails over HTTPS on port 3000:
 
-To avoid any confusion, and adopt a common convention, the name of the developer can be used when naming the webhook in Contentful.
+```sh
+script/server
+```
 
-- Web interface will be available on http://localhost:4040 - allowing you view the raw payload of incoming requests.
+Then start ngrok and point it at the local HTTPS app:
+
+```sh
+ngrok http https://localhost:3000
+```
+
+Use the HTTPS forwarding URL shown by ngrok as the base URL for the Contentful webhook, for example:
+
+```text
+https://<random-subdomain>.ngrok-free.app/contentful_webhooks
+```
+
+Notes:
+
+- With a free ngrok account, the public URL usually changes when ngrok restarts.
+- If the URL changes, update the webhook URL in Contentful.
+- The local ngrok inspection UI is available at `http://localhost:4040`.
+- The inspection UI is useful for checking headers, payload shape and delivery attempts.
+
+## References
+
+- [Ngrok quickstart](https://ngrok.com/docs/guides/share-localhost/quickstart)
+- [Ngrok CLI reference](https://ngrok.com/docs/agent/cli)

--- a/spec/features/specify/errors/custom_errors_spec.rb
+++ b/spec/features/specify/errors/custom_errors_spec.rb
@@ -1,16 +1,24 @@
 RSpec.feature "Custom Errors" do
   context "when the page does not exist (404)" do
-    before do
+    around do |example|
+      original_show_exceptions = Rails.application.env_config["action_dispatch.show_exceptions"]
+      original_show_detailed_exceptions = Rails.application.env_config["action_dispatch.show_detailed_exceptions"]
+      original_consider_all_requests_local = Rails.application.env_config["consider_all_requests_local"]
+
       Rails.application.env_config["action_dispatch.show_exceptions"] = true
       Rails.application.env_config["action_dispatch.show_detailed_exceptions"] = false
       Rails.application.env_config["consider_all_requests_local"] = false
-      allow(FABS::Page).to receive(:find_by_slug!).with("foo")
-        .and_raise(ContentfulRecordNotFoundError.new("Page not found", slug: "foo"))
+
+      example.run
+    ensure
+      Rails.application.env_config["action_dispatch.show_exceptions"] = original_show_exceptions
+      Rails.application.env_config["action_dispatch.show_detailed_exceptions"] = original_show_detailed_exceptions
+      Rails.application.env_config["consider_all_requests_local"] = original_consider_all_requests_local
     end
 
-    after do
-      Rails.application.env_config["action_dispatch.show_exceptions"] = false
-      Rails.application.env_config["consider_all_requests_local"] = true
+    before do
+      allow(FABS::Page).to receive(:find_by_slug!).with("foo")
+        .and_raise(ContentfulRecordNotFoundError.new("Page not found", slug: "foo"))
     end
 
     it "shows the expected error message" do

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe Redirect, type: :model do
+  describe "#initialize" do
+    subject(:redirect) { described_class.new(entry) }
+
+    let(:entry) do
+      OpenStruct.new(
+        id: "redirect-id",
+        fields: {
+          title: "Legacy category IT",
+          source_path: "/categories/it/*",
+          destination_path: "/categories/ict-business-systems/*",
+          redirect_type: "permanent",
+        },
+      )
+    end
+
+    it "sets the attributes" do
+      expect(redirect).to have_attributes(
+        id: "redirect-id",
+        title: "Legacy category IT",
+        source_path: "/categories/it/*",
+        destination_path: "/categories/ict-business-systems/*",
+        redirect_type: "permanent",
+      )
+    end
+  end
+
+  describe ".all" do
+    subject(:redirects) { described_class.all }
+
+    let(:entry_a) do
+      OpenStruct.new(
+        id: "redirect-a",
+        fields: {
+          title: "About this service",
+          source_path: "/about-this-service",
+          destination_path: "/about-our-service",
+          redirect_type: "permanent",
+        },
+      )
+    end
+
+    let(:entry_b) do
+      OpenStruct.new(
+        id: "redirect-b",
+        fields: {
+          title: "Legacy category IT",
+          source_path: "/categories/it/*",
+          destination_path: "/categories/ict-business-systems/*",
+          redirect_type: "permanent",
+        },
+      )
+    end
+
+    before do
+      allow(ContentfulClient).to receive(:entries).with(
+        content_type: "redirect",
+        select: described_class::SELECT_FIELDS,
+        order: "fields.title",
+      ).and_return([entry_a, entry_b])
+    end
+
+    it "fetches redirects from Contentful" do
+      expect(redirects).to all(be_a(described_class))
+    end
+  end
+
+  describe "#permanent?" do
+    it "returns true for permanent redirects" do
+      redirect = described_class.new(
+        OpenStruct.new(id: "1", fields: { title: "Test", source_path: "/a", destination_path: "/b", redirect_type: "permanent" }),
+      )
+
+      expect(redirect).to be_permanent
+      expect(redirect).not_to be_temporary
+    end
+  end
+
+  describe "#temporary?" do
+    it "returns true for temporary redirects" do
+      redirect = described_class.new(
+        OpenStruct.new(id: "1", fields: { title: "Test", source_path: "/a", destination_path: "/b", redirect_type: "temporary" }),
+      )
+
+      expect(redirect).to be_temporary
+      expect(redirect).not_to be_permanent
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,11 +75,16 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
   config.before do
+    # Enable feature flags that are common across all tests
     Flipper.enable(:customer_satisfaction_survey)
     Flipper.enable(:sc_tasklist_case)
     Flipper.enable(:usability_surveys)
     Flipper.enable(:auto_email_vat_dd)
+
+    # Avoid making Contentful API call to fetch redirects
+    allow(RedirectMatcher).to receive(:cached_redirects).and_return([])
   end
 
   config.before(:each, type: :feature) do

--- a/spec/requests/contentful_webhooks_spec.rb
+++ b/spec/requests/contentful_webhooks_spec.rb
@@ -3,96 +3,142 @@ require "rails_helper"
 RSpec.describe "Contentful webhooks", type: :request do
   let(:entity_id) { "contentful-entry-123" }
   let(:secret) { "valid-signature" }
-  let(:headers) { { "X-Contentful-Webhook-Signature" => secret } }
+  let(:topic) { "ContentManagement.Entry.publish" }
+  let(:headers) do
+    {
+      "X-Contentful-Webhook-Signature" => secret,
+      "X-Contentful-Topic" => topic,
+    }
+  end
   let(:indexer) { instance_double(SolutionIndexer) }
+  let(:payload) do
+    {
+      sys: {
+        id: entity_id,
+        contentType: {
+          sys: {
+            id: content_type,
+          },
+        },
+      },
+    }
+  end
+  let(:content_type) { "solution" }
 
   before do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with("CONTENTFUL_WEBHOOK_SECRET").and_return(secret)
     allow(SolutionIndexer).to receive(:new).with(id: entity_id).and_return(indexer)
+    allow(RedirectMatcher).to receive(:invalidate_cache!)
   end
 
   describe "POST /contentful_webhooks" do
-    it "returns success when indexing succeeds" do
-      allow(indexer).to receive(:index_document).and_return(true)
+    context "when publishing a solution" do
+      it "returns success when indexing succeeds" do
+        allow(indexer).to receive(:index_document).and_return(true)
 
-      post(contentful_webhooks_path, params: { entityId: entity_id }, headers:)
+        post(contentful_webhooks_path, params: payload, headers:)
 
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq("message" => "Webhook for entry #{entity_id} processed successfully.")
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq("message" => "Webhook for entry #{entity_id} processed successfully.")
+      end
+
+      it "returns unprocessable_content when indexing fails" do
+        allow(indexer).to receive(:index_document).and_return(false)
+
+        post(contentful_webhooks_path, params: payload, headers:)
+
+        expect(response.status).to eq(422)
+        expect(JSON.parse(response.body)).to eq("error" => "Failed to index the document for id #{entity_id}.")
+      end
     end
 
-    it "returns unprocessable_content when indexing fails" do
-      allow(indexer).to receive(:index_document).and_return(false)
+    context "when deleting a solution" do
+      let(:topic) { "ContentManagement.Entry.delete" }
 
-      post(contentful_webhooks_path, params: { entityId: entity_id }, headers:)
+      it "returns success when deletion succeeds" do
+        allow(indexer).to receive(:delete_document).and_return(true)
 
-      expect(response.status).to eq(422)
-      expect(JSON.parse(response.body)).to eq("error" => "Failed to index the document for id #{entity_id}.")
+        post(contentful_webhooks_path, params: payload, headers:)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq("message" => "Webhook for entry #{entity_id} deletion processed successfully.")
+      end
+
+      it "returns unprocessable_content when deletion fails" do
+        allow(indexer).to receive(:delete_document).and_return(false)
+
+        post(contentful_webhooks_path, params: payload, headers:)
+
+        expect(response.status).to eq(422)
+        expect(JSON.parse(response.body)).to eq("error" => "Failed to delete the document for id #{entity_id}.")
+      end
     end
 
-    it "returns bad_request when entityId is missing" do
-      post(contentful_webhooks_path, params: {}, headers:)
+    context "when publishing a redirect" do
+      let(:content_type) { "redirect" }
 
-      expect(response).to have_http_status(:bad_request)
-      expect(JSON.parse(response.body)).to eq("error" => "The 'entityId' is missing from the request.")
+      it "invalidates the redirect cache" do
+        post(contentful_webhooks_path, params: payload, headers:)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq("message" => "Webhook for redirect entry #{entity_id} processed successfully.")
+        expect(RedirectMatcher).to have_received(:invalidate_cache!)
+      end
     end
 
-    it "returns bad_request when only sys.id is provided" do
-      allow(indexer).to receive(:index_document)
+    context "when unpublishing a redirect" do
+      let(:content_type) { "redirect" }
+      let(:topic) { "ContentManagement.Entry.unpublish" }
 
-      post(contentful_webhooks_path, params: { sys: { id: entity_id } }, headers:)
+      it "invalidates the redirect cache" do
+        post(contentful_webhooks_path, params: payload, headers:)
 
-      expect(response).to have_http_status(:bad_request)
-      expect(indexer).not_to have_received(:index_document)
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq("message" => "Webhook for redirect entry #{entity_id} deletion processed successfully.")
+        expect(RedirectMatcher).to have_received(:invalidate_cache!)
+      end
     end
 
-    it "returns unauthorized when the signature is invalid" do
-      post contentful_webhooks_path, params: { entityId: entity_id }, headers: { "X-Contentful-Webhook-Signature" => "wrong" }
+    context "when the entry id is missing" do
+      let(:payload) { { sys: { contentType: { sys: { id: content_type } } } } }
 
-      expect(response).to have_http_status(:unauthorized)
-    end
-  end
+      it "returns bad_request" do
+        post(contentful_webhooks_path, params: payload, headers:)
 
-  describe "POST /delete_contentful_entry" do
-    it "returns success when deletion succeeds" do
-      allow(indexer).to receive(:delete_document).and_return(true)
-
-      post(delete_contentful_entry_path, params: { entityId: entity_id }, headers:)
-
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq("message" => "Webhook for entry #{entity_id} deletion processed successfully.")
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body)).to eq("error" => "The entry id is missing from the request.")
+      end
     end
 
-    it "returns unprocessable_content when deletion fails" do
-      allow(indexer).to receive(:delete_document).and_return(false)
+    context "when the topic is unsupported" do
+      let(:topic) { "ContentManagement.Entry.auto_save" }
 
-      post(delete_contentful_entry_path, params: { entityId: entity_id }, headers:)
+      it "returns success and ignores the webhook" do
+        post(contentful_webhooks_path, params: payload, headers:)
 
-      expect(response.status).to eq(422)
-      expect(JSON.parse(response.body)).to eq("error" => "Failed to delete the document for id #{entity_id}.")
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq("message" => "Ignoring unsupported webhook topic #{topic} for entry #{entity_id}.")
+      end
     end
 
-    it "returns bad_request when entityId is missing" do
-      post(delete_contentful_entry_path, params: {}, headers:)
+    context "when the content type is unsupported" do
+      let(:content_type) { "category" }
 
-      expect(response).to have_http_status(:bad_request)
-      expect(JSON.parse(response.body)).to eq("error" => "The 'entityId' is missing from the request.")
+      it "returns success and ignores the webhook" do
+        post(contentful_webhooks_path, params: payload, headers:)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq("message" => "Ignoring unsupported content type #{content_type} for entry #{entity_id}.")
+      end
     end
 
-    it "returns bad_request when only sys.id is provided" do
-      allow(indexer).to receive(:delete_document)
+    context "when the signature is invalid" do
+      it "returns unauthorized" do
+        post contentful_webhooks_path, params: payload, headers: headers.merge("X-Contentful-Webhook-Signature" => "wrong")
 
-      post(delete_contentful_entry_path, params: { sys: { id: entity_id } }, headers:)
-
-      expect(response).to have_http_status(:bad_request)
-      expect(indexer).not_to have_received(:delete_document)
-    end
-
-    it "returns unauthorized when the signature is missing" do
-      post delete_contentful_entry_path, params: { entityId: entity_id }
-
-      expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end

--- a/spec/requests/fabs/categories_spec.rb
+++ b/spec/requests/fabs/categories_spec.rb
@@ -58,15 +58,20 @@ RSpec.describe "Categories pages", type: :request do
   end
 
   describe "GET /categories/:slug" do
+    let(:get_expert_help) { instance_double(GetExpertHelp, title: "Get expert help", description: "Helpful content") }
+
     let(:category) do
       instance_double(
         FABS::Category,
         title: "ICT business systems",
         description: "Buy ICT services",
         slug: "ict-business-systems",
+        body_title: nil,
+        body_description: nil,
         banner: nil,
         related_content: [],
         subcategories: [],
+        solutions: [],
         filtered_solutions: [],
       )
     end
@@ -90,6 +95,7 @@ RSpec.describe "Categories pages", type: :request do
     it "renders the category when no legacy redirect matches" do
       allow(RedirectMatcher).to receive(:call).with("/categories/ict-business-systems").and_return(nil)
       allow(FABS::Category).to receive(:find_by_slug!).with("ict-business-systems").and_return(category)
+      allow(GetExpertHelp).to receive(:content).and_return(get_expert_help)
 
       get category_path("ict-business-systems")
 

--- a/spec/requests/fabs/categories_spec.rb
+++ b/spec/requests/fabs/categories_spec.rb
@@ -56,4 +56,44 @@ RSpec.describe "Categories pages", type: :request do
       expect(response.body).to include('href="/procurement-support">Get expert buying help')
     end
   end
+
+  describe "GET /categories/:slug" do
+    let(:category) do
+      instance_double(
+        FABS::Category,
+        title: "ICT business systems",
+        description: "Buy ICT services",
+        slug: "ict-business-systems",
+        banner: nil,
+        related_content: [],
+        subcategories: [],
+        filtered_solutions: [],
+      )
+    end
+
+    it "redirects legacy category slugs before category lookup" do
+      match = RedirectMatcher::Result.new(
+        redirect: instance_double(Redirect),
+        destination_path: "/categories/ict-business-systems",
+        status: :moved_permanently,
+      )
+
+      allow(RedirectMatcher).to receive(:call).with("/categories/it").and_return(match)
+      expect(FABS::Category).not_to receive(:find_by_slug!)
+
+      get category_path("it")
+
+      expect(response).to redirect_to("/categories/ict-business-systems")
+      expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "renders the category when no legacy redirect matches" do
+      allow(RedirectMatcher).to receive(:call).with("/categories/ict-business-systems").and_return(nil)
+      allow(FABS::Category).to receive(:find_by_slug!).with("ict-business-systems").and_return(category)
+
+      get category_path("ict-business-systems")
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/fabs/pages_spec.rb
+++ b/spec/requests/fabs/pages_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "FABS pages", type: :request do
   end
 
   it "renders a FABS page with title, related content, and nested breadcrumbs" do
+    allow(RedirectMatcher).to receive(:call).with("/unit-trust-bank").and_return(nil)
     allow(FABS::Page).to receive(:find_by_slug!).with("unit-trust-bank").and_return(FABS::Page.new(page_entry))
 
     get page_path("unit-trust-bank")
@@ -85,6 +86,7 @@ RSpec.describe "FABS pages", type: :request do
         related_content: [],
       },
     )
+    allow(RedirectMatcher).to receive(:call).with("/dynamic-purchasing-systems").and_return(nil)
     allow(FABS::Page).to receive(:find_by_slug!).with("dynamic-purchasing-systems").and_return(FABS::Page.new(no_related_content_entry))
 
     get page_path("dynamic-purchasing-systems")
@@ -93,12 +95,29 @@ RSpec.describe "FABS pages", type: :request do
     expect(response.body).not_to include("Related reading")
   end
 
-  it "redirects to /404 when the FABS page does not exist" do
+  it "returns not found when the FABS page does not exist" do
+    allow(RedirectMatcher).to receive(:call).with("/missing-page").and_return(nil)
     allow(FABS::Page).to receive(:find_by_slug!).with("missing-page")
       .and_raise(ContentfulRecordNotFoundError.new("Page not found", slug: "missing-page"))
 
     get page_path("missing-page")
 
-    expect(response).to redirect_to("/404")
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "redirects legacy page slugs before Contentful page lookup" do
+    match = RedirectMatcher::Result.new(
+      redirect: instance_double(Redirect),
+      destination_path: "/about-our-service",
+      status: :moved_permanently,
+    )
+
+    allow(RedirectMatcher).to receive(:call).with("/about-this-service").and_return(match)
+    expect(FABS::Page).not_to receive(:find_by_slug!)
+
+    get page_path("about-this-service")
+
+    expect(response).to redirect_to("/about-our-service")
+    expect(response).to have_http_status(:moved_permanently)
   end
 end

--- a/spec/requests/fabs/solutions_spec.rb
+++ b/spec/requests/fabs/solutions_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "FABS solutions", type: :request do
 
   describe "GET /categories/:category_slug/:slug" do
     before do
+      allow(RedirectMatcher).to receive(:call).with("/categories/banking-finance/audit-and-financial-services").and_return(nil)
       allow(Solution).to receive(:find_by_slug!).with("audit-and-financial-services").and_return(solution)
       allow(FABS::Category).to receive(:find_by_slug!).with("banking-finance").and_return(primary_category)
     end
@@ -78,6 +79,23 @@ RSpec.describe "FABS solutions", type: :request do
       expect(response.body).not_to include("31 December 2026")
       expect(response.body).not_to include("RM1234")
       expect(document).to have_link("Apply now", href: "https://example.com/apply")
+    end
+
+    it "redirects legacy category solution slugs before solution lookup" do
+      match = RedirectMatcher::Result.new(
+        redirect: instance_double(Redirect),
+        destination_path: "/categories/ict-business-systems/communications-solutions",
+        status: :moved_permanently,
+      )
+
+      allow(RedirectMatcher).to receive(:call).with("/categories/it/communications-solutions").and_return(match)
+      expect(Solution).not_to receive(:find_by_slug!)
+      expect(FABS::Category).not_to receive(:find_by_slug!)
+
+      get category_solution_path("it", "communications-solutions")
+
+      expect(response).to redirect_to("/categories/ict-business-systems/communications-solutions")
+      expect(response).to have_http_status(:moved_permanently)
     end
   end
 end

--- a/spec/requests/favicon_spec.rb
+++ b/spec/requests/favicon_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Favicon", type: :request do
-  it "returns a not found response without hitting Contentful page lookups" do
+  it "does not hit Contentful page lookups" do
     expect(FABS::Page).not_to receive(:find_by_slug!)
+    expect(RedirectMatcher).not_to receive(:call)
 
-    get "/favicon.ico"
-
-    expect(response).to have_http_status(:not_found)
+    expect { get "/favicon.ico" }.to raise_error(ActionController::RoutingError)
   end
 end

--- a/spec/services/redirect_matcher_spec.rb
+++ b/spec/services/redirect_matcher_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 RSpec.describe RedirectMatcher do
   describe ".cached_redirects" do
+    before do
+      allow(described_class).to receive(:cached_redirects).and_call_original
+    end
+
     it "loads redirects through Rails cache" do
       redirects = [instance_double(Redirect)]
 

--- a/spec/services/redirect_matcher_spec.rb
+++ b/spec/services/redirect_matcher_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe RedirectMatcher do
+  describe ".cached_redirects" do
+    it "loads redirects through Rails cache" do
+      redirects = [instance_double(Redirect)]
+
+      allow(Rails.cache).to receive(:fetch).with(
+        described_class::CACHE_KEY,
+        expires_in: described_class::CACHE_EXPIRY,
+      ).and_yield
+      allow(Redirect).to receive(:all).and_return(redirects)
+
+      expect(described_class.cached_redirects).to eq(redirects)
+    end
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(path, redirects:) }
+
+    let(:redirects) { [redirect] }
+
+    context "when an exact permanent redirect matches" do
+      let(:path) { "/about-this-service" }
+      let(:redirect) do
+        instance_double(
+          Redirect,
+          source_path: "/about-this-service",
+          destination_path: "/about-our-service",
+          permanent?: true,
+        )
+      end
+
+      it "returns the matched redirect result" do
+        expect(result.redirect).to eq(redirect)
+        expect(result.destination_path).to eq("/about-our-service")
+        expect(result.status).to eq(:moved_permanently)
+      end
+    end
+
+    context "when a wildcard permanent redirect matches a category page" do
+      let(:path) { "/categories/it" }
+      let(:redirect) do
+        instance_double(
+          Redirect,
+          source_path: "/categories/it/*",
+          destination_path: "/categories/ict-business-systems/*",
+          permanent?: true,
+        )
+      end
+
+      it "maps to the destination prefix" do
+        expect(result.destination_path).to eq("/categories/ict-business-systems")
+        expect(result.status).to eq(:moved_permanently)
+      end
+    end
+
+    context "when a wildcard temporary redirect matches a solution page" do
+      let(:path) { "/categories/it/communications-solutions" }
+      let(:redirect) do
+        instance_double(
+          Redirect,
+          source_path: "/categories/it/*",
+          destination_path: "/categories/ict-business-systems/*",
+          permanent?: false,
+        )
+      end
+
+      it "preserves the wildcard remainder in the destination path" do
+        expect(result.destination_path).to eq("/categories/ict-business-systems/communications-solutions")
+        expect(result.status).to eq(:found)
+      end
+    end
+
+    context "when multiple redirects match" do
+      let(:path) { "/categories/it/communications-solutions" }
+      let(:first_redirect) do
+        instance_double(
+          Redirect,
+          source_path: "/categories/it/*",
+          destination_path: "/categories/ict-business-systems/*",
+          permanent?: true,
+        )
+      end
+      let(:second_redirect) do
+        instance_double(
+          Redirect,
+          source_path: "/categories/it/*",
+          destination_path: "/categories/other/*",
+          permanent?: true,
+        )
+      end
+      let(:redirects) { [first_redirect, second_redirect] }
+
+      it "returns the first matching redirect" do
+        expect(result.redirect).to eq(first_redirect)
+        expect(result.destination_path).to eq("/categories/ict-business-systems/communications-solutions")
+      end
+    end
+
+    context "when no redirect matches" do
+      let(:path) { "/no-match" }
+      let(:redirect) do
+        instance_double(
+          Redirect,
+          source_path: "/about-this-service",
+          destination_path: "/about-our-service",
+          permanent?: true,
+        )
+      end
+
+      it "returns nil" do
+        expect(result).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new model for Redirect - with attributes for title (info only), source_path, destination_path and redirect_type (permanent or temporary). These redirect rules are read on first request and cached for 24 hours (they change rarely and performance is important so a long cache time is appropriate).

Currently the following redirect patterns are supported:

- `/old-page-slug` => `/new-page-slug`
- `/categories/old-name` => `/categories/new-name`
- `/categories/old-name/solution-slug` => `/categories/new-name/solution-slug`

The two category redirects are handled by a single redirect model in Contentful using `source_path` set to `/categories/old-name/*` and `destination_path` set to `/categories/new-name/*`; the `*` acts as an optional placeholder for solution slug. It will be easy to add support for other patterns in future (just needs the concern and before filter adding to relevant controller) but I've kept this scoped to our current use cases.

Also cleaned up pages route/controller slightly; this route no longer accepts anything with a file extension so the custom `favicon.ico` route is no longer required (this will now fall through the pages route and be handled by standard 404 path). The pages controller also redirects directly to the error page rather than via `/404` which causes an unnecessary redirect step.

The existing Contentful webhooks controller has been updated/fixed to also support invalidating the cached Redirect routes when any redirects are added/deleted/updated within Contentful. The cache is then rebuilt on the next request.