### PR TITLE
CORE-606 | bug fix, hide ways to buy filter, when there is only single ways to buy option

### DIFF
--- a/app/views/shared/_right_filters.html.erb
+++ b/app/views/shared/_right_filters.html.erb
@@ -86,7 +86,7 @@
             <hr />
           <% end %>
 
-          <% if ways_to_buy.present? %>
+          <% if ways_to_buy.present? && ways_to_buy.count > 1 %>
             <div class="govuk-form-group govuk-!-margin-bottom-0">
               <fieldset class="govuk-fieldset">
                 <details <%= "open" if selected_ways_to_buy_slugs.present? %> class="govuk-details govuk-!-margin-bottom-4">

--- a/spec/requests/fabs/categories_show_spec.rb
+++ b/spec/requests/fabs/categories_show_spec.rb
@@ -223,4 +223,26 @@ RSpec.describe "FABS category pages", type: :request do
       expect(response.body).to include("Software")
     end
   end
+
+  describe "with single ways to buy type" do
+    let(:solutions) { [dfe_solution] }
+
+    it "does not display the ways to buy filter section when there is only one way to buy" do
+      get category_path("it")
+
+      expect(response).to be_successful
+      expect(response.body).not_to include("Ways to buy")
+    end
+  end
+
+  describe "with multiple ways to buy type" do
+    let(:solutions) { [dfe_solution, other_solution] }
+
+    it "displays the ways to buy filter section when there are multiple ways to buy" do
+      get category_path("it")
+
+      expect(response).to be_successful
+      expect(response.body).to include("Ways to buy")
+    end
+  end
 end


### PR DESCRIPTION
<!--
  1. New dependency? Is there an accompanying ADR?
  2. New route? Is the code covered by functional (unit) and feature (browser) tests?
  3. New method/class? Have you documented your code using valid Yard syntax?
  4. Do you need to update the CHANGELOG and add a PR ref?
-->

## Changes in this PR
Ticket: https://dfedigital.atlassian.net/browse/CORE-606

This bug fix ensures the Ways to buy filter is only displayed when there are multiple options available. If there is only one Ways to buy option, the filter is hidden.

<!--
  Succinct list of changes explaining what has changed and why.
-->

## Screen-shots or screen-capture of UI changes

<!--
  # Screen-shots
  - Include full page from header to footer, cropping the sides to fit.

  # Screen-captures
  - Record only the browser window
  - Don't full screen the browser window (to avoid large files)
  - Break into separate videos if there are several journeys being presented
  - Mac guide: https://support.apple.com/en-gb/HT208721
  - Windows guide: https://support.microsoft.com/en-us/windows/5328cd25-9046-4472-8a14-c485f138802c
-->
