### PR TITLE
CORE-797 Energy start page copy changes

### DIFF
--- a/app/controllers/energy/application_controller.rb
+++ b/app/controllers/energy/application_controller.rb
@@ -1,6 +1,6 @@
 module Energy
   class ApplicationController < ::ApplicationController
-    before_action :check_flag, :check_if_submitted, :set_routing_flags
+    before_action :check_if_submitted, :set_routing_flags
 
     ALLOWED_CLASSES = [
       "Support::Organisation",
@@ -10,10 +10,6 @@ module Energy
     MAX_METER_COUNT = 5
 
   private
-
-    def check_flag
-      render "errors/not_found", status: :not_found unless Flipper.enabled?(:energy)
-    end
 
     def check_if_submitted
       redirect_to energy_case_confirmation_path(onboarding_case) if onboarding_case.submitted?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -384,6 +384,7 @@ en:
     join:
       title: Join Energy for Schools
       explanations:
+      - <strong>This is a DfE energy deal.</strong> All schools can use this deal to procure gas and electricity, including academy trusts. See the <a href="/dfe-energy-approved-deals" class="govuk-link">guidance on DfE energy approved deals</a>.
       - Energy for Schools helps state-funded schools and trusts switch to the same energy contract used by the Department for Education.
       - Schools that join Energy for Schools are added to DfE’s V30 energy contract with Government Commercial Agency (GCA), formerly Crown Commercial Service. GCA buys energy for this particular contract over a long period of time, reducing the risk to customers of substantial fluctuations in price.
       benefits:

--- a/doc/feature-flags.md
+++ b/doc/feature-flags.md
@@ -35,7 +35,6 @@ Click on `add feature` and enter the name you have used for your feature flag. Y
 |auto_send_siteAdditions_power|Site addition and portal access forms email goes to electric supplier (EDF)|DISABLED|DO NOT ENABLE
 |auto_email_vat_dd|when enabled, auto email sending of emails regarding DD/VAT|
 |customer_satisfaction_survey|Replace the exit survey with the new customer satisfaction survey.|ENABLED|Feature now live, flag to be removed|
-|energy|Energy for Schools|ENABLED|Feature now live, flag to be removed|
 |maintenance_mode|Prevent user access to the application. Intended for infrastructure or data maintenance.|DISABLED|To be enabled when required|
 |rfh_usability_survey|Embed the RfH usability survey in the RfH submission confirmation page.|ENABLED|Feature now live, flag to be removed|
 |sc_tasklist_case|The task list tab for a case at level 4 or 5 will be visible, and the 'case action_required' flag will be updated based on the evaluation document upload status and the evaluation approval status. |ENABLED in development, DISABLED in production|To be enabled when all components of the task list are ready|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,7 +79,6 @@ RSpec.configure do |config|
     Flipper.enable(:customer_satisfaction_survey)
     Flipper.enable(:sc_tasklist_case)
     Flipper.enable(:usability_surveys)
-    Flipper.enable(:energy)
     Flipper.enable(:auto_email_vat_dd)
   end
 


### PR DESCRIPTION
- Remove :energy feature flag - this feature is fully live now, so no need to retain the feature flag.
- Add new intro paragraph to energy start page