### PR TITLE
CORE-808 Remove "Buying options for" title prefix

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_header do %>
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-4">
-    <h1 class="govuk-heading-l"><%= t("layouts.fabs_application.page_title") %> <%= @page_title %></h1>
+    <h1 class="govuk-heading-l"><%= @page_title %></h1>
   </div>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,9 +81,6 @@ en:
       visitor: You must sign in.
   breadcrumbs:
     offers: Offers
-  layouts:
-    fabs_application:
-      page_title: "Buying options for"
   categories:
     filter_labels:
       active_filters: Active filters


### PR DESCRIPTION
Remove "Buying options for" prefix on Category landing page title.

This now just shows the Category title instead. Removed the now redundant locale entry too.